### PR TITLE
fix(sanity): generate query-result types and drop unsafe casts

### DIFF
--- a/app/(examples)/sanity/[slug]/_components/article/index.tsx
+++ b/app/(examples)/sanity/[slug]/_components/article/index.tsx
@@ -1,9 +1,9 @@
 import type { PortableTextBlock } from 'next-sanity'
 import { SanityImage } from '@/components/ui/sanity-image'
 import { RichText } from '@/integrations/sanity/components/rich-text'
-import type { Article } from '@/integrations/sanity/sanity.types'
+import type { ArticleQueryResult } from '@/integrations/sanity/sanity.types'
 
-type SanityArticleProps = NonNullable<Article>
+type SanityArticleProps = NonNullable<ArticleQueryResult>
 
 export function SanityArticle({ data }: { data: SanityArticleProps }) {
   if (!data) return null

--- a/app/(examples)/sanity/[slug]/page.tsx
+++ b/app/(examples)/sanity/[slug]/page.tsx
@@ -3,7 +3,6 @@ import { Wrapper } from '@/components/layout/wrapper'
 import { client } from '@/integrations/sanity/client'
 import { sanityFetch } from '@/integrations/sanity/live'
 import { allArticlesQuery, articleQuery } from '@/integrations/sanity/queries'
-import type { Article } from '@/integrations/sanity/sanity.types'
 import { generateSanityMetadata } from '@/utils/metadata'
 import { SanityArticle } from './_components/article'
 
@@ -44,8 +43,7 @@ export default async function SanityArticlePage({
   return (
     <Wrapper theme="light" className="font-mono uppercase">
       <div className="max-dt:dr-px-16 flex grow items-center justify-center">
-        {/* TODO: remove cast after running `bun run sanity:typegen` to regenerate ArticleQueryResult */}
-        <SanityArticle data={data as Article} />
+        <SanityArticle data={data} />
       </div>
     </Wrapper>
   )

--- a/app/(examples)/sanity/_components/tutorial/index.tsx
+++ b/app/(examples)/sanity/_components/tutorial/index.tsx
@@ -1,20 +1,15 @@
 import type { PortableTextBlock } from 'next-sanity'
 import { Link } from '@/components/ui/link'
 import { RichText } from '@/integrations/sanity/components/rich-text'
-import type {
-  Page,
-  Link as SanityLink,
-} from '@/integrations/sanity/sanity.types'
+import type { PageQueryResult } from '@/integrations/sanity/sanity.types'
 import { getLinkAttributes } from '@/integrations/sanity/utils/link'
 
-type SanityTutorialProps = NonNullable<Page>
+type SanityTutorialProps = NonNullable<PageQueryResult>
 
 export function SanityTutorial({ data }: { data: SanityTutorialProps }) {
   if (!data) return null
 
-  const linkAttrs = data?.link
-    ? getLinkAttributes(data.link as SanityLink)
-    : null
+  const linkAttrs = data.link ? getLinkAttributes(data.link) : null
 
   return (
     <div className="flex flex-col items-center gap-gap" data-sanity={data._id}>

--- a/app/(examples)/sanity/page.tsx
+++ b/app/(examples)/sanity/page.tsx
@@ -4,7 +4,6 @@ import { NotConfigured } from '@/components/ui/not-configured'
 import { isConfigured } from '@/integrations/registry'
 import { sanityFetch } from '@/integrations/sanity/live'
 import { pageQuery } from '@/integrations/sanity/queries'
-import type { Page } from '@/integrations/sanity/sanity.types'
 import { generateSanityMetadata } from '@/utils/metadata'
 import { SanityTutorial } from './_components/tutorial'
 
@@ -30,8 +29,7 @@ export default async function SanityPage() {
   return (
     <Wrapper theme="light" className="font-mono uppercase">
       <div className="max-dt:dr-px-16 flex grow items-center justify-center">
-        {/* TODO: remove cast after running `bun run sanity:typegen` to regenerate PageQueryResult */}
-        <SanityTutorial data={data as Page} />
+        <SanityTutorial data={data} />
       </div>
     </Wrapper>
   )

--- a/biome.json
+++ b/biome.json
@@ -185,6 +185,16 @@
 
   "overrides": [
     {
+      "includes": ["lib/integrations/sanity/sanity.types.ts"],
+      "linter": {
+        "rules": {
+          "nursery": {
+            "useImportsFirst": "off"
+          }
+        }
+      }
+    },
+    {
       "includes": ["**/*.css"],
       "linter": {
         "rules": {

--- a/lib/integrations/sanity/sanity-typegen.json
+++ b/lib/integrations/sanity/sanity-typegen.json
@@ -1,0 +1,5 @@
+{
+  "path": "./**/*.{ts,tsx}",
+  "schema": "./schema.json",
+  "generates": "./sanity.types.ts"
+}

--- a/lib/integrations/sanity/sanity.types.ts
+++ b/lib/integrations/sanity/sanity.types.ts
@@ -12,6 +12,8 @@
  * ---------------------------------------------------------------------------------
  */
 
+export declare const internalGroqTypeReferenceTo: unique symbol
+
 // Source: schema.json
 export type SanityImageAssetReference = {
   _ref: string
@@ -334,4 +336,195 @@ export type AllSanitySchemaTypes =
   | SanityImageAsset
   | Geopoint
 
-export declare const internalGroqTypeReferenceTo: unique symbol
+// Source: queries.ts
+// Variable: pageQuery
+// Query: *[_type == "page" && slug.current == $slug][0] {    _id,    title,    slug,      content[]{    ...,    markDefs[]{      ...,      _type == "link" => {        ...,        internalLink->{_type, slug, title}      }    }  },      link {    ...,    internalLink->{_type, slug, title}  },    metadata,    publishedAt,    _updatedAt  }
+export type PageQueryResult = {
+  _id: string
+  title: string | null
+  slug: Slug | null
+  content: Array<
+    | {
+        children?: Array<{
+          marks?: string[]
+          text?: string
+          _type: 'span'
+          _key: string
+        }>
+        style?:
+          | 'blockquote'
+          | 'h1'
+          | 'h2'
+          | 'h3'
+          | 'h4'
+          | 'h5'
+          | 'h6'
+          | 'normal'
+        listItem?: 'bullet' | 'number'
+        markDefs: Array<{
+          _key: string
+          _type: 'link'
+          linkType?: 'external' | 'internal'
+          internalLink:
+            | {
+                _type: 'article'
+                slug: Slug | null
+                title: string | null
+              }
+            | {
+                _type: 'page'
+                slug: Slug | null
+                title: string | null
+              }
+            | null
+          externalUrl?: string
+          text?: string
+          openInNewTab?: boolean
+        }> | null
+        level?: number
+        _type: 'block'
+        _key: string
+      }
+    | {
+        asset?: SanityImageAssetReference
+        media?: unknown
+        hotspot?: SanityImageHotspot
+        crop?: SanityImageCrop
+        alt?: string
+        caption?: string
+        _type: 'image'
+        _key: string
+        markDefs: null
+      }
+  > | null
+  link: {
+    _type: 'link'
+    linkType?: 'external' | 'internal'
+    internalLink:
+      | {
+          _type: 'article'
+          slug: Slug | null
+          title: string | null
+        }
+      | {
+          _type: 'page'
+          slug: Slug | null
+          title: string | null
+        }
+      | null
+    externalUrl?: string
+    text?: string
+    openInNewTab?: boolean
+  } | null
+  metadata: Metadata | null
+  publishedAt: string | null
+  _updatedAt: string
+} | null
+
+// Source: queries.ts
+// Variable: articleQuery
+// Query: *[_type == "article" && slug.current == $slug][0] {    _id,    title,    slug,    excerpt,    featuredImage,      content[]{    ...,    markDefs[]{      ...,      _type == "link" => {        ...,        internalLink->{_type, slug, title}      }    }  },    categories,    tags,    author,    publishedAt,    metadata,    _updatedAt  }
+export type ArticleQueryResult = {
+  _id: string
+  title: string | null
+  slug: Slug | null
+  excerpt: string | null
+  featuredImage: {
+    asset?: SanityImageAssetReference
+    media?: unknown
+    hotspot?: SanityImageHotspot
+    crop?: SanityImageCrop
+    alt?: string
+    _type: 'image'
+  } | null
+  content: Array<
+    | {
+        children?: Array<{
+          marks?: string[]
+          text?: string
+          _type: 'span'
+          _key: string
+        }>
+        style?:
+          | 'blockquote'
+          | 'h1'
+          | 'h2'
+          | 'h3'
+          | 'h4'
+          | 'h5'
+          | 'h6'
+          | 'normal'
+        listItem?: 'bullet' | 'number'
+        markDefs: Array<{
+          _key: string
+          _type: 'link'
+          linkType?: 'external' | 'internal'
+          internalLink:
+            | {
+                _type: 'article'
+                slug: Slug | null
+                title: string | null
+              }
+            | {
+                _type: 'page'
+                slug: Slug | null
+                title: string | null
+              }
+            | null
+          externalUrl?: string
+          text?: string
+          openInNewTab?: boolean
+        }> | null
+        level?: number
+        _type: 'block'
+        _key: string
+      }
+    | {
+        asset?: SanityImageAssetReference
+        media?: unknown
+        hotspot?: SanityImageHotspot
+        crop?: SanityImageCrop
+        alt?: string
+        caption?: string
+        _type: 'image'
+        _key: string
+        markDefs: null
+      }
+  > | null
+  categories: string[] | null
+  tags: string[] | null
+  author: string | null
+  publishedAt: string | null
+  metadata: Metadata | null
+  _updatedAt: string
+} | null
+
+// Source: queries.ts
+// Variable: allArticlesQuery
+// Query: *[_type == "article"] | order(publishedAt desc) {    _id,    title,    slug,    excerpt,    featuredImage,    categories,    publishedAt  }
+export type AllArticlesQueryResult = Array<{
+  _id: string
+  title: string | null
+  slug: Slug | null
+  excerpt: string | null
+  featuredImage: {
+    asset?: SanityImageAssetReference
+    media?: unknown
+    hotspot?: SanityImageHotspot
+    crop?: SanityImageCrop
+    alt?: string
+    _type: 'image'
+  } | null
+  categories: string[] | null
+  publishedAt: string | null
+}>
+
+// Query TypeMap
+import '@sanity/client'
+declare module '@sanity/client' {
+  interface SanityQueries {
+    '\n  *[_type == "page" && slug.current == $slug][0] {\n    _id,\n    title,\n    slug,\n    \n  content[]{\n    ...,\n    markDefs[]{\n      ...,\n      _type == "link" => {\n        ...,\n        internalLink->{_type, slug, title}\n      }\n    }\n  }\n,\n    \n  link {\n    ...,\n    internalLink->{_type, slug, title}\n  }\n,\n    metadata,\n    publishedAt,\n    _updatedAt\n  }\n': PageQueryResult
+    '\n  *[_type == "article" && slug.current == $slug][0] {\n    _id,\n    title,\n    slug,\n    excerpt,\n    featuredImage,\n    \n  content[]{\n    ...,\n    markDefs[]{\n      ...,\n      _type == "link" => {\n        ...,\n        internalLink->{_type, slug, title}\n      }\n    }\n  }\n,\n    categories,\n    tags,\n    author,\n    publishedAt,\n    metadata,\n    _updatedAt\n  }\n': ArticleQueryResult
+    '\n  *[_type == "article"] | order(publishedAt desc) {\n    _id,\n    title,\n    slug,\n    excerpt,\n    featuredImage,\n    categories,\n    publishedAt\n  }\n': AllArticlesQueryResult
+  }
+}

--- a/lib/integrations/sanity/utils/link.ts
+++ b/lib/integrations/sanity/utils/link.ts
@@ -1,12 +1,19 @@
-import type { Link } from '../sanity.types'
+/**
+ * Structural link shape shared by the raw schema `Link` object and the
+ * dereferenced link projection emitted by TypeGen (`internalLink->{...}`).
+ * Kept permissive so both satisfy it without coupling this util to either type.
+ */
+type LinkLike = {
+  linkType?: string | null
+  externalUrl?: string | null
+  openInNewTab?: boolean | null
+  internalLink?: {
+    _type?: string | null
+    slug?: { current?: string | null } | null
+  } | null
+} | null
 
-type InternalReference = {
-  _type: string
-  slug?: { current: string }
-  title?: string
-}
-
-export const urlForReference = (link: Link): string => {
+export const urlForReference = (link: LinkLike): string => {
   if (!link) return '#'
 
   // External URL
@@ -15,20 +22,17 @@ export const urlForReference = (link: Link): string => {
   }
 
   // Internal reference (dereferenced document with slug)
-  if (
-    link.linkType === 'internal' &&
-    link.internalLink &&
-    typeof link.internalLink === 'object' &&
-    'slug' in link.internalLink
-  ) {
-    const ref = link.internalLink as InternalReference
-    return resolveDocumentUrl(ref._type, ref.slug?.current)
+  if (link.linkType === 'internal' && link.internalLink) {
+    return resolveDocumentUrl(
+      link.internalLink._type ?? undefined,
+      link.internalLink.slug?.current ?? undefined
+    )
   }
 
   return '#'
 }
 
-function resolveDocumentUrl(documentType: string, slug?: string): string {
+function resolveDocumentUrl(documentType?: string, slug?: string): string {
   if (!slug) return '#'
 
   switch (documentType) {
@@ -43,13 +47,13 @@ function resolveDocumentUrl(documentType: string, slug?: string): string {
 }
 
 // Helper to get link attributes
-export const getLinkAttributes = (link: Link | null) => {
+export const getLinkAttributes = (link: LinkLike) => {
   if (!link) return { href: '#', target: undefined, rel: undefined }
 
   const href = urlForReference(link)
   const isExternal =
     link.linkType === 'external' ||
-    (link.externalUrl && !link.externalUrl.startsWith('/'))
+    (link.externalUrl != null && !link.externalUrl.startsWith('/'))
 
   return {
     href,

--- a/lib/utils/metadata.ts
+++ b/lib/utils/metadata.ts
@@ -143,17 +143,18 @@ export function generatePageMetadata(
  * ```
  */
 export function generateSanityMetadata(options: {
+  // Fields are nullable to accept TypeGen query-result types directly
+  // (projections type optional fields as `T | null`).
   document: {
-    title?: string
+    title?: string | null
     metadata?: {
-      title?: string
-      description?: string
-      keywords?: string[]
-      image?: { asset?: { url?: string } }
-      noIndex?: boolean
-    }
-    _updatedAt?: string
-    publishedAt?: string
+      title?: string | null
+      description?: string | null
+      keywords?: string[] | null
+      noIndex?: boolean | null
+    } | null
+    _updatedAt?: string | null
+    publishedAt?: string | null
   }
   url?: string
   type?: 'website' | 'article'
@@ -164,27 +165,29 @@ export function generateSanityMetadata(options: {
   if (!metadata) {
     // Fallback to basic metadata if none provided
     return generatePageMetadata({
-      ...(document.title && { title: document.title }),
+      ...(document.title ? { title: document.title } : {}),
       ...(url && { url }),
       type,
     })
   }
 
+  // Bind to locals so control-flow narrowing strips the `null` before the
+  // values reach generatePageMetadata (which expects `string`, not `string | null`).
+  // Note: OG image is not derived from `metadata.image` — the queries don't
+  // dereference the asset (`asset->{url}`), so generatePageMetadata's default
+  // image is used. Add a resolved url to the query to wire a per-page OG image.
+  const title = metadata.title ?? document.title
+  const { description, keywords, noIndex } = metadata
+  const { publishedAt, _updatedAt } = document
+
   return generatePageMetadata({
-    ...((metadata.title ?? document.title)
-      ? { title: metadata.title ?? document.title }
-      : {}),
-    ...(metadata.description && { description: metadata.description }),
-    ...(metadata.keywords && { keywords: metadata.keywords }),
-    ...(metadata.image?.asset?.url && {
-      image: {
-        url: metadata.image.asset.url,
-      },
-    }),
+    ...(title ? { title } : {}),
+    ...(description ? { description } : {}),
+    ...(keywords ? { keywords } : {}),
     ...(url && { url }),
-    ...(metadata.noIndex !== undefined && { noIndex: metadata.noIndex }),
+    ...(noIndex != null && { noIndex }),
     type,
-    ...(document.publishedAt && { publishedTime: document.publishedAt }),
-    ...(document._updatedAt && { modifiedTime: document._updatedAt }),
+    ...(publishedAt ? { publishedTime: publishedAt } : {}),
+    ...(_updatedAt ? { modifiedTime: _updatedAt } : {}),
   })
 }


### PR DESCRIPTION
Follow-up #1 from the dependency leverage audit. Deferred from #147 because it turned out to be a typed refactor, not a quick fix.

## Root cause
The starter had **no `sanity-typegen.json`**, so `sanity typegen generate` used its default query path (`./src`, which doesn't exist here) and only ever emitted **schema** types — never the `*QueryResult` types. That's why the example pages carried `data as Page` / `data as Article` casts (with TODOs).

## Changes
- **`sanity-typegen.json`** (new): points typegen at the real query location → it now emits `PageQueryResult`/`ArticleQueryResult`/`AllArticlesQueryResult` **and** the `@sanity/client` module augmentation that makes `sanityFetch({ query })` precisely typed.
- **`biome.json`**: disable `nursery/useImportsFirst` for the generated `sanity.types.ts` (codegen emits a trailing `import '@sanity/client'` for the augmentation; not auto-fixable).
- **Pages**: removed the `as Page` / `as Article` casts — `sanityFetch` is now auto-typed.
- **Components**: `SanityTutorial`/`SanityArticle` props → `NonNullable<*QueryResult>`.
- **Link util**: widened `getLinkAttributes`/`urlForReference` to a structural `LinkLike` that both the schema `Link` and the dereferenced link projection satisfy (schema `Link` still fits → other callers like rich-text unaffected), removing the call-site cast — no logic duplication.
- **`generateSanityMetadata`**: accepts nullable projection fields; **dropped a dead branch** — `metadata.image.asset.url` was always `undefined` (the queries don't dereference the asset), so it never set an OG image. Inline note on how to wire a real one.

## Test Plan
- [x] `bun run sanity:typegen` exits 0 (was exit 1 / 0 query types)
- [x] `bun run check` (biome + tsgo + 424 tests)
- [x] `next build`