### PR TITLE
refactor(hero): remove dead obstacle subsystem + drop scrim

### DIFF
--- a/app/(marketing)/_sections/hero/hero.module.css
+++ b/app/(marketing)/_sections/hero/hero.module.css
@@ -49,25 +49,6 @@
   pointer-events: none;
 }
 
-/* Subtle radial scrim to keep text readable over the gradient */
-.scrim {
-  /* Full-bleed (the section is inset by the layout gutter): break out to 100vw
-     so the readability vignette reaches the edges. */
-  position: absolute;
-  top: 0;
-  left: 50%;
-  width: 100vw;
-  height: 100%;
-  margin-left: -50vw;
-  z-index: 1;
-  background: radial-gradient(
-    ellipse 80% 60% at 50% 50%,
-    transparent 30%,
-    color-mix(in srgb, var(--color-primary) 60%, transparent) 100%
-  );
-  pointer-events: none;
-}
-
 .content {
   position: relative;
   z-index: 2;

--- a/app/(marketing)/_sections/hero/index.tsx
+++ b/app/(marketing)/_sections/hero/index.tsx
@@ -115,8 +115,6 @@ export function Hero() {
         />
       )}
 
-      <div className={s.scrim} aria-hidden="true" />
-
       <div
         className={cn(s.content, 'col-span-full dt:col-start-3 dt:col-end-11')}
       >

--- a/components/effects/liquid-drip/index.tsx
+++ b/components/effects/liquid-drip/index.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import dynamic from 'next/dynamic'
-import type { ComponentProps, CSSProperties } from 'react'
+import type { CSSProperties } from 'react'
 import { WebGLTunnel } from '@/webgl/components/tunnel'
 import { useWebGLElement } from '@/webgl/hooks/use-webgl-element'
+import type { WebGLLiquidDripProps } from './webgl'
 
 const WebGLLiquidDrip = dynamic(
   () => import('./webgl').then(({ WebGLLiquidDrip }) => WebGLLiquidDrip),
@@ -15,7 +16,7 @@ const WebGLLiquidDrip = dynamic(
 type LiquidDripProps = {
   className?: string
   style?: CSSProperties
-} & Omit<ComponentProps<typeof WebGLLiquidDrip>, 'visible'>
+} & Omit<WebGLLiquidDripProps, 'visible'>
 
 /**
  * Darkroom-developer drip hero effect.

--- a/components/effects/liquid-drip/material.ts
+++ b/components/effects/liquid-drip/material.ts
@@ -7,14 +7,11 @@
  * normals, shaded as a translucent/glassy fluid (near-transparent body read via
  * a bright wet meniscus + sharp glints, faint safelight-red tint). NOT chrome.
  *
- * Physics / interactivity:
+ * Motion / interactivity:
  *  - Rivulets grow down out of the curtain; a bead swells at the tip, pinches
  *    off and falls away off-screen while the thread drains back up, then loops.
  *  - `spawnDrop(uvx)` releases a fresh drop at a clicked column (8 slots, so
  *    rapid clicks never cancel a still-falling drop).
- *  - `setObstacles(rects)` registers UI boxes the liquid flows AROUND: the drip
- *    field is x-warped to bend around them and the boxes are carved out so no
- *    liquid renders over the content.
  *
  * Pinned to the viewport (static fullscreen quad — see webgl.tsx).
  *
@@ -26,9 +23,8 @@
  * breaks. The Fn() body holds only the march loop + final color assembly.
  */
 
-import { Vector2, Vector4 } from 'three'
+import { Vector2 } from 'three'
 import {
-  abs,
   Break,
   clamp,
   dot,
@@ -38,13 +34,11 @@ import {
   If,
   Loop,
   length,
-  max,
   min,
   mix,
   normalize,
   pow,
   screenUV,
-  sign,
   sin,
   smoothstep,
   uniform,
@@ -59,8 +53,6 @@ const _v3sample = vec3(0, 0, 0)
 type Vec3Node = typeof _v3sample
 const _v2u = uniform(new Vector2())
 type Vec2Uniform = typeof _v2u
-const _v4u = uniform(new Vector4())
-type Vec4Uniform = typeof _v4u
 
 // World half-height the view maps to (worldY ∈ [-SCALE/2, +SCALE/2]).
 const VIEW_SCALE = 2.0
@@ -72,9 +64,6 @@ const CURTAIN_LEN = 6.0
 // Concurrent click-drop slots: enough that rapid clicking never recycles a
 // still-falling user drop (round-robin only reuses after this many).
 const CLICK_SLOTS = 8
-const OBSTACLE_SLOTS = 4
-// Inactive obstacle: far below the view, zero size.
-const OBSTACLE_OFF = new Vector4(0, -100, 0, 0)
 
 export class LiquidDripMaterial extends MeshBasicNodeMaterial {
   private readonly _uTime = uniform(0)
@@ -87,17 +76,10 @@ export class LiquidDripMaterial extends MeshBasicNodeMaterial {
   )
   private _clickIndex = 0
 
-  // UI obstacles in world coords: (centerX, centerY, halfW, halfH).
-  private readonly _uObstacles: Vec4Uniform[] = Array.from(
-    { length: OBSTACLE_SLOTS },
-    () => uniform(OBSTACLE_OFF.clone())
-  )
-
   readonly resolution = this._uResolution.value as Vector2
 
-  constructor({ amplitude = 1.0 }: { amplitude?: number } = {}) {
+  constructor() {
     super({ transparent: true })
-    this._uAmplitude.value = amplitude
     this._buildNodes()
   }
 
@@ -106,7 +88,6 @@ export class LiquidDripMaterial extends MeshBasicNodeMaterial {
     const uAmp = this._uAmplitude
     const uRes = this._uResolution
     const clicks = this._uClicks
-    const obstacles = this._uObstacles
 
     const sdSphere = (p: Vec3Node, c: Vec3Node, r: FloatNode): FloatNode =>
       length(p.sub(c)).sub(r) as unknown as FloatNode
@@ -123,18 +104,8 @@ export class LiquidDripMaterial extends MeshBasicNodeMaterial {
       return length(p.sub(near)).sub(r) as unknown as FloatNode
     }
 
-    // 2D rounded-box distance (extruded in z) for a UI obstacle.
-    const sdObstacle = (p: Vec3Node, o: Vec4Uniform): FloatNode => {
-      const qx = abs(p.x.sub(o.x)).sub(o.z) as unknown as FloatNode
-      const qy = abs(p.y.sub(o.y)).sub(o.w) as unknown as FloatNode
-      const ax = max(qx, float(0.0)) as unknown as FloatNode
-      const ay = max(qy, float(0.0)) as unknown as FloatNode
-      const outside = length(vec3(ax, ay, float(0.0))) as unknown as FloatNode
-      const inside = min(max(qx, qy), float(0.0)) as unknown as FloatNode
-      return outside.add(inside).sub(0.04) as unknown as FloatNode
-    }
-
     const smin = (a: FloatNode, b: FloatNode, k: number): FloatNode => {
+      if (k === 0) return a
       const h = clamp(
         float(0.5).add(b.sub(a).mul(0.5 / k)),
         float(0.0),
@@ -143,29 +114,6 @@ export class LiquidDripMaterial extends MeshBasicNodeMaterial {
       return mix(b, a, h).sub(
         float(k).mul(h).mul(float(1.0).sub(h))
       ) as unknown as FloatNode
-    }
-
-    // Smooth subtract surface `b` from `a` (carve): smax(a, -b).
-    const ssub = (a: FloatNode, b: FloatNode, k: number): FloatNode =>
-      smin(a.mul(-1.0), b, k).mul(-1.0) as unknown as FloatNode
-
-    // X-domain warp: repel the sample x away from each obstacle within its
-    // vertical band so straight rivulets bend AROUND the UI boxes.
-    const warpX = (p: Vec3Node): FloatNode => {
-      let wx = p.x as unknown as FloatNode
-      for (const o of obstacles) {
-        const dx = p.x.sub(o.x) as unknown as FloatNode
-        const yInfl = float(1.0).sub(
-          smoothstep(o.w, o.w.add(0.3), abs(p.y.sub(o.y)))
-        ) as unknown as FloatNode
-        const pushMag = max(
-          float(0.0),
-          o.z.add(0.13).sub(abs(dx))
-        ) as unknown as FloatNode
-        const push = sign(dx).mul(pushMag).mul(yInfl) as unknown as FloatNode
-        wx = wx.add(push) as unknown as FloatNode
-      }
-      return wx
     }
 
     const addRivulet = (
@@ -277,26 +225,18 @@ export class LiquidDripMaterial extends MeshBasicNodeMaterial {
       return length(vec3(dxv, dy, p.z)).sub(CURTAIN_R) as unknown as FloatNode
     }
 
-    // Scene SDF: sheet (real p) + rivulets/drops (warped p, bending around UI) −
-    // carved UI boxes.
+    // Scene SDF: the curtain band, the ambient rivulets, and the click drops.
     const map = (p: Vec3Node): FloatNode => {
       let d = sdCurtainBand(p)
 
-      // Drips bend around the UI via the x-warp.
-      const pw = vec3(warpX(p), p.y, p.z) as unknown as Vec3Node
-      d = addRivulet(pw, d, -1.7, 0.2, 0.0, 1.15, 0.034)
-      d = addRivulet(pw, d, -0.85, 0.26, 1.6, 1.35, 0.03)
-      d = addRivulet(pw, d, -0.1, 0.22, 3.0, 1.0, 0.042)
-      d = addRivulet(pw, d, 0.8, 0.3, 0.8, 1.25, 0.031)
-      d = addRivulet(pw, d, 1.6, 0.24, 2.3, 1.4, 0.036)
+      d = addRivulet(p, d, -1.7, 0.2, 0.0, 1.15, 0.034)
+      d = addRivulet(p, d, -0.85, 0.26, 1.6, 1.35, 0.03)
+      d = addRivulet(p, d, -0.1, 0.22, 3.0, 1.0, 0.042)
+      d = addRivulet(p, d, 0.8, 0.3, 0.8, 1.25, 0.031)
+      d = addRivulet(p, d, 1.6, 0.24, 2.3, 1.4, 0.036)
 
       for (const c of clicks) {
-        d = addClickDrop(pw, d, c as Vec2Uniform)
-      }
-
-      // Carve the UI boxes so liquid never renders over the content.
-      for (const o of obstacles) {
-        d = ssub(d, sdObstacle(p, o), 0.05)
+        d = addClickDrop(p, d, c as Vec2Uniform)
       }
       return d
     }
@@ -386,7 +326,10 @@ export class LiquidDripMaterial extends MeshBasicNodeMaterial {
           Break()
         })
         t.addAssign(d.mul(0.9))
-        If(t.greaterThan(4.0), () => {
+        // All geometry sits within z ∈ [−CURTAIN_R, +CURTAIN_R] around z = 0, so
+        // a ray from z = 2 confirms a miss by ~t = 2.4; 2.8 leaves margin while
+        // sparing the empty lower screen the full march depth.
+        If(t.greaterThan(2.8), () => {
           Break()
         })
       })
@@ -414,40 +357,6 @@ export class LiquidDripMaterial extends MeshBasicNodeMaterial {
     if (slot) {
       ;(slot.value as Vector2).set(cx, this._uTime.value as number)
       this._clickIndex = (this._clickIndex + 1) % this._uClicks.length
-    }
-  }
-
-  /**
-   * Register UI boxes (in CSS px, viewport-relative) that the liquid flows
-   * around. Converted to the shader's world space using the current resolution.
-   */
-  setObstacles(
-    rects: ReadonlyArray<{
-      left: number
-      top: number
-      width: number
-      height: number
-    }>
-  ): void {
-    const res = this._uResolution.value as Vector2
-    const vw = res.x || 1
-    const vh = res.y || 1
-    const aspect = vw / vh
-    for (let i = 0; i < this._uObstacles.length; i++) {
-      const slot = this._uObstacles[i]
-      if (!slot) continue
-      const rect = rects[i]
-      if (!rect) {
-        ;(slot.value as Vector4).copy(OBSTACLE_OFF)
-        continue
-      }
-      const cxPx = rect.left + rect.width / 2
-      const cyPx = rect.top + rect.height / 2
-      const cx = (cxPx / vw - 0.5) * aspect * VIEW_SCALE
-      const cy = (0.5 - cyPx / vh) * VIEW_SCALE
-      const hw = ((rect.width / vw) * aspect * VIEW_SCALE) / 2
-      const hh = ((rect.height / vh) * VIEW_SCALE) / 2
-      ;(slot.value as Vector4).set(cx, cy, hw, hh)
     }
   }
 

--- a/components/effects/liquid-drip/webgl.tsx
+++ b/components/effects/liquid-drip/webgl.tsx
@@ -1,11 +1,11 @@
 import { type ThreeEvent, useFrame, useThree } from '@react-three/fiber'
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef } from 'react'
 import type { Mesh } from 'three'
 import { LiquidDripMaterial } from './material'
 
 // @refresh reset
 
-type WebGLLiquidDripProps = {
+export type WebGLLiquidDripProps = {
   /** Whether the source element is in the viewport (gates animation). */
   visible?: boolean
   amplitude?: number
@@ -16,16 +16,23 @@ type WebGLLiquidDripProps = {
 /**
  * WebGL darkroom-developer drip mesh.
  *
- * A screen-space shader (screenUV-based) pinned to the viewport: the quad is
- * sized to the canvas and positioned statically, so the effect does NOT follow
- * page scroll. Clicking releases a fresh drop at the clicked column.
+ * A screen-space shader pinned to the viewport (static fullscreen quad — does
+ * NOT follow page scroll): a clear developer-chemical sheet at the top that
+ * bleeds downward in rivulets. Clicking releases a fresh drop at that column.
  */
 export function WebGLLiquidDrip({
   visible = true,
   amplitude = 1.0,
   speed = 1.0,
 }: WebGLLiquidDripProps) {
-  const [material] = useState(() => new LiquidDripMaterial({ amplitude }))
+  // useRef (not useState) for the imperative material instance — the project's
+  // canonical pattern for class instantiation. Created once; `amplitude` flows
+  // in via the effect below, which is the single source of truth for it.
+  const materialRef = useRef<LiquidDripMaterial | null>(null)
+  if (!materialRef.current) {
+    materialRef.current = new LiquidDripMaterial()
+  }
+  const material = materialRef.current
 
   useEffect(() => {
     return () => {
@@ -43,7 +50,7 @@ export function WebGLLiquidDrip({
     material.resolution.set(size.width, size.height)
   }, [material, size])
 
-  const meshRef = useRef<Mesh>(null!)
+  const meshRef = useRef<Mesh | null>(null)
 
   // Pin the quad to the full viewport (static — does not scroll with the page).
   useLayoutEffect(() => {
@@ -64,7 +71,7 @@ export function WebGLLiquidDrip({
   }
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: <mesh> is an R3F WebGL object, not a DOM element
+    // biome-ignore lint/a11y/noStaticElementInteractions: <mesh> is an R3F WebGL object, not a DOM element; the click is a decorative easter-egg with no keyboard path required
     <mesh matrixAutoUpdate={false} ref={meshRef} onClick={handleClick}>
       <planeGeometry />
       <primitive object={material} />


### PR DESCRIPTION
## Summary

Nuclear-review cleanup of the liquid-drip hero (merged in #150). **No visual change** — confirmed against a runtime screenshot; the only intended visual difference is the removed scrim vignette.

### Structural (the headline)
- **Deleted the entire obstacle subsystem** from `material.ts`: `_uObstacles`, `OBSTACLE_SLOTS`/`OBSTACLE_OFF`, `sdObstacle`, `warpX`, the `ssub` carve loop, and `setObstacles`. It had **zero callers** anywhere in the repo, yet baked a 4-slot warp loop + 4 smooth-subtract carves into every per-pixel `map()` evaluation — and again ×4 inside `calcNormal`. Removing it also drops the now-unused `abs`/`max`/`sign`/`Vector4` imports.

### Perf / correctness
- Tightened the raymarch escape from `t > 4.0` → `t > 2.8`. All geometry sits within `z ≈ ±0.4`, so a miss is confirmed by ~`t = 2.4`; this spares the large empty lower screen the full march depth. (Note: the reviewer suggested `1.8`, which would have **clipped the drips** at `z ≈ 0` — rejected.)
- Guarded `smin` against `k = 0`; dropped the dead constructor `amplitude` arg (the effect is the sole writer).

### Conformance / types
- `webgl.tsx`: instantiate the material via `useRef` (the repo's canonical class-instantiation idiom, matching `lib/webgl/utils/fluid`) instead of `useState`; export `WebGLLiquidDripProps`; type `meshRef` as `Mesh | null` (removed the `null!` lie); document the decorative click easter-egg on the `biome-ignore`.
- `index.tsx`: derive `LiquidDripProps` from the directly-imported `WebGLLiquidDripProps` instead of the fragile `ComponentProps<typeof dynamicImport>`.

### UX
- Removed the readability scrim (DOM element + CSS) — the wordmark reads cleanly on the black background without it.

### a11y note
The `<mesh onClick>` click-to-drop is a **decorative easter-egg** (canvas at `z-index:-1`, unreachable by AT; the hero's links/button are fully keyboard-navigable). No keyboard path needed; the `biome-ignore` is correctly scoped and now documents this.

### Deferred (low-priority, optional)
- Per-slot early-out for the 8 click-drop spheres (risky to express cleanly in the functional TSL builder; `AdaptiveDpr` already caps cost).

## Test Plan
- [x] `bun run check` — 424 pass, 0 fail (biome + tsgo)
- [x] `bun run build` — green
- [x] Runtime (Chrome DevTools): curtain + drips render identically, scrim gone, console clean