### PR TITLE
chore(v2-roadmap): phase 2/3 quick wins

### DIFF
--- a/.github/workflows/lighthouse-to-slack.yml
+++ b/.github/workflows/lighthouse-to-slack.yml
@@ -83,13 +83,20 @@ jobs:
         continue-on-error: true
 
       - name: Run Lighthouse
-        if: steps.vercel_info.outputs.skip != 'true' && steps.await.outcome == 'success'
+        # Also require a non-empty preview URL: an empty URL would otherwise run
+        # Lighthouse against bare "https://" and report junk scores.
+        # This workflow REPORTS scores (as a commit comment) but intentionally
+        # does NOT gate/fail on them — scores are advisory, not a merge blocker.
+        if: steps.vercel_info.outputs.skip != 'true' && steps.await.outcome == 'success' && steps.vercel_url.outputs.preview_url != ''
         id: lighthouse
         uses: treosh/lighthouse-ci-action@v12
         env:
           LHCI_BUILD_CONTEXT__CURRENT_HASH: ${{ github.sha }}
         with:
           urls: https://${{ steps.vercel_url.outputs.preview_url }}
+          # Average 3 runs to smooth out single-run cold-start variance (a cold
+          # run can score 10-20 points below a warmed one).
+          runs: 3
           uploadArtifacts: true
           temporaryPublicStorage: true
 

--- a/lib/scripts/setup-project.ts
+++ b/lib/scripts/setup-project.ts
@@ -80,6 +80,37 @@ type PresetKey = keyof typeof PROJECT_PRESETS
 interface SetupOptions {
   dryRun: boolean
   keepIntegrations: string[]
+  /** Replace the demo marketing homepage with a blank starter page. */
+  cleanMarketing: boolean
+}
+
+/**
+ * Minimal homepage written when the user opts to drop the demo marketing page.
+ * Mirrors the reset documented in the header of `app/page.tsx`.
+ */
+const BLANK_HOMEPAGE = `import { Wrapper } from '@/components/layout/wrapper'
+
+export default function Home() {
+  return (
+    <Wrapper theme="dark" lenis={{}}>
+      <main />
+    </Wrapper>
+  )
+}
+`
+
+/**
+ * Replace the showcase homepage with a blank page and remove the demo sections.
+ * This is the "fresh start" path documented in `app/page.tsx`: rewrite
+ * `app/page.tsx`, then delete `app/(marketing)` (which only holds `_sections`).
+ */
+const removeMarketingHomepage = async (dryRun: boolean): Promise<void> => {
+  if (dryRun) {
+    p.log.message('  Would replace app/page.tsx with a blank homepage')
+  } else {
+    await Bun.write(resolvePath('app/page.tsx'), BLANK_HOMEPAGE)
+  }
+  await removeDir('app/(marketing)', dryRun)
 }
 
 /**
@@ -292,8 +323,16 @@ const updateBarrelExports = async (
  * Main setup function
  */
 const setup = async (options: SetupOptions): Promise<void> => {
-  const { dryRun, keepIntegrations } = options
+  const { dryRun, keepIntegrations, cleanMarketing } = options
   const integrationNames = getIntegrationNames()
+
+  // Replace the demo homepage first (independent of integration removal).
+  if (cleanMarketing) {
+    const ms = p.spinner()
+    ms.start('Replacing demo marketing homepage...')
+    await removeMarketingHomepage(dryRun)
+    ms.stop('Replaced demo homepage with a blank starter page')
+  }
 
   // Determine what to remove
   const toRemove = integrationNames.filter(
@@ -510,11 +549,22 @@ const main = async (): Promise<void> => {
     )
   }
 
+  // Offer to drop the demo marketing homepage for a clean slate.
+  const cleanMarketing = await p.confirm({
+    message: 'Replace the demo marketing homepage with a blank starter page?',
+    initialValue: false,
+  })
+
+  if (p.isCancel(cleanMarketing)) {
+    p.cancel('Setup cancelled')
+    process.exit(0)
+  }
+
   const toRemove = getIntegrationNames().filter(
     (name) => !keepIntegrations.includes(name)
   )
 
-  if (toRemove.length === 0) {
+  if (toRemove.length === 0 && !cleanMarketing) {
     p.log.success('Keeping all integrations. No changes needed!')
     p.outro('Run: bun dev')
     return
@@ -529,9 +579,15 @@ const main = async (): Promise<void> => {
     )
   }
 
-  p.log.message(
-    `  Remove: ${toRemove.map((k) => INTEGRATION_BUNDLES[k]?.name).join(', ')}`
-  )
+  if (toRemove.length > 0) {
+    p.log.message(
+      `  Remove: ${toRemove.map((k) => INTEGRATION_BUNDLES[k]?.name).join(', ')}`
+    )
+  }
+
+  if (cleanMarketing) {
+    p.log.message('  Homepage: replace demo with a blank starter page')
+  }
 
   // Confirm
   const proceed = await p.confirm({
@@ -544,7 +600,11 @@ const main = async (): Promise<void> => {
   }
 
   // Run setup
-  await setup({ dryRun, keepIntegrations: keepIntegrations as string[] })
+  await setup({
+    dryRun,
+    keepIntegrations: keepIntegrations as string[],
+    cleanMarketing,
+  })
 
   // Done
   if (dryRun) {

--- a/lib/styles/README.md
+++ b/lib/styles/README.md
@@ -1,57 +1,137 @@
 # Styles
 
-Hybrid styling with Tailwind CSS v4 and custom PostCSS functions.
+Hybrid styling for Satūs: **Tailwind CSS v4** (CSS-based config via `@theme`),
+**CSS Modules** for complex/animated components, and custom **PostCSS functions**
++ **`dr-*` utilities** for viewport-relative responsive sizing.
 
-## PostCSS Functions
+## Which tool for which job?
 
-```css
-/* Viewport-relative sizing */
-.element {
-  width: mobile-vw(375);    /* 375px at mobile viewport */
-  height: desktop-vh(100);  /* 100px at desktop viewport */
-}
+Reach for the lightest tool that does the job. In rough order of preference:
 
-/* Grid columns */
-.sidebar {
-  width: columns(3);        /* Spans 3 columns + gaps */
-}
-```
+| Use… | When | Example |
+|------|------|---------|
+| **Tailwind utilities** | Layout, spacing, fl/grid, color, simple states. The default. | `className="flex items-center gap-4 p-6"` |
+| **`dr-*` utilities** | Sizing that must **scale with the viewport** (px-perfect to a design) | `className="dr-w-150 dr-h-100"` |
+| **PostCSS fns in CSS** | Viewport/column math inside a CSS Module | `width: desktop-vw(320);` |
+| **CSS Modules** | Complex layouts, keyframes, pseudo-elements, deep specificity | `import s from './x.module.css'` |
+| **Inline `style`** | **Only** dynamic runtime values (a computed `--progress`) | `style={{ '--p': pct } as CSSProperties}` |
 
-## Custom Utilities (`dr-*`)
+Rules of thumb: never hand-write spacing/colors Tailwind already gives you;
+animate only `transform`/`opacity`; compose classes with `cn()` (from `clsx`),
+and keep classes **sorted** (Biome enforces `useSortedClasses`).
+
+## A component using all three
 
 ```tsx
-// Responsive sizing (scales with viewport)
-<div className="dr-w-150 dr-h-100" />
+import cn from 'clsx'
+import type { ComponentProps } from 'react'
+import s from './card.module.css'
 
-// Column-based sizing
-<div className="dr-w-col-4" />  {/* 4 columns wide */}
+interface CardProps extends ComponentProps<'article'> {
+  featured?: boolean
+}
 
-// Grid layout
-<div className="dr-grid" />     {/* 4 cols mobile, 12 cols desktop */}
+export function Card({ featured = false, className, ...props }: CardProps) {
+  return (
+    <article
+      // Tailwind atoms + dr-* responsive width + a CSS Module class (conditional)
+      className={cn('flex flex-col gap-4', s.root, featured && s.isFeatured, className)}
+      {...props}
+    />
+  )
+}
 ```
+
+```css
+/* card.module.css — CamelCase class names, `s.root` import convention */
+.root {
+  width: desktop-vw(320);          /* PostCSS: 320px at the desktop viewport */
+  padding: desktop-vw(24);
+  background: var(--color-primary); /* design token (theme-aware) */
+  border-radius: desktop-vw(8);
+}
+
+.isFeatured {
+  border: 1px solid var(--color-contrast);
+}
+```
+
+## PostCSS functions
+
+```css
+.element {
+  width: mobile-vw(375);     /* 375px at the mobile viewport */
+  height: desktop-vh(100);   /* 100px at the desktop viewport */
+}
+.sidebar {
+  width: columns(3);         /* spans 3 grid columns + gaps */
+}
+```
+
+Available: `mobile-vw()`, `mobile-vh()`, `desktop-vw()`, `desktop-vh()`, `columns(n)`.
+
+## Custom `dr-*` utilities
+
+```tsx
+<div className="dr-w-150 dr-h-100" />  {/* viewport-scaled width/height */}
+<div className="dr-w-col-4" />          {/* 4 columns wide */}
+<div className="dr-grid" />             {/* 4 cols mobile, 12 cols desktop */}
+```
+
+See the generated `css/tailwind.css` for the full generated set.
 
 ## Breakpoints
 
 ```css
-@media (--mobile) { /* <= 799px */ }
-@media (--desktop) { /* >= 800px */ }
+@media (--mobile)  { /* <= 799px */ }
+@media (--desktop) { /* >= 800px (desktop breakpoint) */ }
 ```
 
-## Configuration
+## Design tokens
+
+Tokens are generated into `css/root.css` as CSS custom properties and exposed to
+Tailwind via the `@theme` directive in `css/tailwind.css`. Key families:
+
+- **Color** — raw palette (`--color-red`, `--color-blue`, …) plus **theme-aware**
+  `--color-primary` / `--color-secondary` / `--color-contrast`, which are remapped
+  per theme (`light`, `dark`, `evil`, `red`). Set the active theme via the Theme
+  wrapper (e.g. `<Wrapper theme="dark">`), then reference the semantic tokens —
+  never hard-code a hex in a component.
+- **Easing** — `--ease-out-expo`, `--ease-in-out-cubic`, `--ease-gleasing`, … for
+  `transition`/`animation` timing functions.
+- **Layout** — `--gap`, `--device-width`, and the column grid that powers
+  `columns()` and `dr-*-col-*`.
+
+## Adding a design token
+
+Edit the **source** config (never the generated CSS), then regenerate:
+
+```bash
+# 1. Add the value — e.g. a new brand color in lib/styles/colors.ts
+#    colors = { ..., brand: '#ff5c00' }
+# 2. Regenerate root.css + tailwind.css from the config
+bun setup:styles
+# 3. Use it
+#    CSS:      color: var(--color-brand);
+#    Tailwind: className="text-(--color-brand)"
+```
 
 | File | Purpose |
 |------|---------|
-| `colors.ts` | Color palette & themes |
+| `colors.ts` | Color palette & per-theme semantic mapping |
 | `typography.ts` | Font sizes & weights |
-| `layout.mjs` | Grid, breakpoints, spacing |
+| `layout.mjs` | Grid, breakpoints, spacing, device widths |
 | `easings.ts` | Animation curves |
 | `fonts.ts` | Font loading |
+| `config.ts` | Aggregates the above (imported as `@/config`) |
 
-After changing config: `bun setup:styles`
+## Generated files — do not edit
 
-## Generated Files (Don't Edit)
+`css/root.css` (custom properties) and `css/tailwind.css` (`@theme` + utilities)
+are **generated** by `bun setup:styles`. Hand-edits are overwritten on the next run.
 
-- `css/root.css` — CSS custom properties
-- `css/tailwind.css` — Tailwind utilities
+## Troubleshooting
 
-Run `bun setup:styles` to regenerate after config changes.
+- **Tokens missing / `var(--color-*)` resolves to nothing, `dr-*` classes do nothing, or `mobile-vw()` is left unparsed** — the generated CSS is stale. `bun dev` runs the generator in **watch mode** and `bun run build` runs it first, so this normally self-heals; if the watcher isn't running (CI, a one-off script, or it didn't pick up a change), regenerate manually with `bun setup:styles`.
+- **A token edit "didn't apply"** — confirm you changed the source in `lib/styles/*`, not the generated `css/*`, then re-run `bun setup:styles`.
+- **Unsorted-class lint error** — let Biome fix it: `bun lint:fix`.

--- a/lib/utils/rate-limit.test.ts
+++ b/lib/utils/rate-limit.test.ts
@@ -137,6 +137,29 @@ describe('rateLimit', () => {
     expect(r3.remaining).toBe(0)
     expect(r4.remaining).toBe(0)
   })
+
+  it('counts against a single per-process store (serverless multi-instance limitation)', () => {
+    // The limiter's state lives in one module-level Map, so every call in THIS
+    // process shares a counter. That is exactly why it does not hold across
+    // Vercel/serverless instances: each isolate has its own Map and its own
+    // counter, so the same identifier is limited independently per instance
+    // (and resets on cold start). This test pins the per-process-shared-state
+    // contract so the limitation is explicit, not incidental.
+    const id = uniqueId()
+    const config = { limit: 3, windowSeconds: 60 }
+
+    // Simulate two "callers" (e.g. two requests) routed to the SAME instance:
+    // they share the counter and are limited together.
+    expect(rateLimit(id, config).remaining).toBe(2)
+    expect(rateLimit(id, config).remaining).toBe(1)
+    expect(rateLimit(id, config).remaining).toBe(0)
+    expect(rateLimit(id, config).success).toBe(false)
+
+    // A DIFFERENT identifier (the closest thing a unit test can do to "another
+    // instance") keeps a fully independent budget — mirroring how a second
+    // serverless isolate would not see the first isolate's count.
+    expect(rateLimit(uniqueId(), config).success).toBe(true)
+  })
 })
 
 describe('getClientIP', () => {

--- a/lib/utils/rate-limit.ts
+++ b/lib/utils/rate-limit.ts
@@ -1,14 +1,20 @@
 /**
  * Simple in-memory rate limiter
  *
- * For production with multiple serverless instances, consider upgrading to:
- * - @upstash/ratelimit with Redis
- * - Vercel KV
+ * ⚠️ Serverless / Vercel limitation — read before relying on this in prod:
+ * the counter lives in a module-level `Map`, so it is scoped to a single
+ * process/isolate. On Vercel (and any horizontally-scaled host) requests are
+ * spread across multiple function instances and regions, each with its OWN
+ * counter — and instances are recycled on cold starts. A client hitting N
+ * instances effectively gets N× the limit, and a cold start resets the window.
+ * Treat this as best-effort, per-instance throttling, NOT a global guarantee.
  *
- * This implementation works well for:
- * - Development
- * - Single-server deployments
- * - Edge functions (per-isolate limiting)
+ * For a durable, cross-instance limit, swap the `store` for a shared backend:
+ * - `@upstash/ratelimit` with Upstash Redis (recommended on Vercel)
+ * - any Redis / KV reachable from the function
+ *
+ * Works well as-is for: local development, single-server deployments, and
+ * coarse per-isolate abuse-dampening at the edge.
  */
 
 interface RateLimitEntry {


### PR DESCRIPTION
## Summary

Acts on the **safe, self-contained** items from the v2 roadmap ([#95](https://github.com/darkroomengineering/satus/issues/95)). Scoping found several roadmap items are already done or shouldn't be auto-applied — see the triage below.

### Done in this PR
- **2.1 — CSS onboarding guide** (`lib/styles/README.md`): expanded the stub into a real guide — a "which tool for which job" decision table (Tailwind / `dr-*` / PostCSS fns / CSS Modules), a full three-way component example, the design-token families (theme-aware `--color-primary/secondary/contrast`, easings, layout), an "adding a token" walkthrough, and troubleshooting. (Verified the watch-mode `setup:styles` behavior against `dev.ts` so the docs are accurate.)
- **2.3 — Auto-clean marketing homepage** (`lib/scripts/setup-project.ts`): the setup script now offers (opt-in confirm) to replace the demo homepage with a blank starter page — rewrites `app/page.tsx` and removes `app/(marketing)`. **Purely additive**; the starter keeps its demo. Respects `--dry-run`.
- **3.2 — Rate-limit serverless note + test** (`lib/utils/rate-limit.ts`, `.test.ts`): documented the per-instance limitation explicitly (module-scoped `Map` → not shared across Vercel isolates, resets on cold start) and added a test pinning the multi-instance contract.
- **3.4 — Lighthouse CI stabilization** (`.github/workflows/lighthouse-to-slack.yml`): `runs: 3` to average out cold-start variance, an empty-preview-URL guard, and a comment documenting that scores are advisory (no merge gate).

### Triage of the rest of Phases 2 & 3 (no action needed here)
- **Already done** (roadmap stale): 2.4 path aliases, 2.5 Shopify split, 2.6 `.env.example`.
- **Needs a decision:**
  - **2.2 relax `exactOptionalPropertyTypes`** — recommend **keeping it on**; relaxing weakens the strict-TS guarantee for all downstream projects. Better addressed by the new docs note than by loosening the compiler.
  - **3.5 publish stable `hamo`/`tempus`** — those are **external repos**; can't be done from satus.
- **Deferred to its own PR:** **3.1** regex→AST transforms (L effort, new dep) and **3.3** handoff template split (the script is already clean — extracting templates is cosmetic churn with no e2e test to catch regressions; pair it with 3.1).

### Phase 1 ("reduce size") — recommend skipping
WebGL is already fully `next/dynamic` + `ssr:false` (code-split per route), so it's already excluded from bundles when unused. Phase 1's package extraction (`@satus/webgl`, etc.) is about publishing reusable libraries, not bundle size — it *adds* monorepo/versioning/publishing maintenance surface. Not worth it unless standalone publishing is a goal.

## Test Plan
- [x] `bun run check` — 425 pass, 0 fail (biome + tsgo + tests; +1 new rate-limit test)
- [x] `bun test lib/utils/rate-limit.test.ts` — 24 pass
- [ ] Reviewer: eyeball the CSS guide and the setup-project marketing prompt flow