### PR TITLE
fix(react-doctor): empty-array defaults + drop blocking dev log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ next-env.d.ts
 .claude
 AGENTS.md
 plans
+
+# react-doctor — ignore generated diagnostics, keep the curated suppression list
+.react-doctor/*
+!.react-doctor/false-positives.md

--- a/.react-doctor/false-positives.md
+++ b/.react-doctor/false-positives.md
@@ -1,0 +1,24 @@
+# react-doctor — acknowledged false positives
+
+Entries here tell `react-doctor` to stop flagging diagnostics that have been
+reviewed and judged not to apply to this codebase. Re-run `npx react-doctor`
+after editing to confirm they're suppressed.
+
+## `server-auth-actions` (×12) — all false positives
+
+The rule treats every server action that touches data as a public endpoint that
+should check the caller's identity first. This template has **no auth/session
+library** (no NextAuth/Clerk/Supabase-auth — confirmed in `package.json`) and
+`proxy.ts` does rate-limiting only, so there is no `auth()` to call. Every flagged
+action is an intentionally public or anonymous endpoint, defended the correct way
+(rate-limit + Turnstile/CAPTCHA + Zod validation). Bolting on a no-op `auth()`
+stub is the exact anti-pattern the rule's own docs warn against.
+
+- `server-auth-actions` — public form actions (demo / mailchimp / hubspot) — public by design; protected by rate-limit + Turnstile + Zod validation
+- `server-auth-actions` — `shopify/cart/actions.ts` (add/remove/update/fetch) — anonymous guest cart keyed by a server-set httpOnly `cartId` cookie + IP rate-limit; no user identity exists to check
+- `server-auth-actions` — `shopify/customer` `LoginCustomerAction` / `CreateCustomerAction` — credential-establishing endpoints; run for logged-out users by definition; already rate-limited + validated
+- `server-auth-actions` — `shopify/customer` `LogoutCustomerAction` / `getCustomer` — self-scoped to the caller's own `customerAccessToken` cookie; bail/no-op when absent (a real cookie-based gate the rule doesn't recognize)
+
+> If authenticated account pages are ever added as server actions ("view my
+> orders", "update my address"), those **must** gate on the signed-in user —
+> remove the relevant entry above and add the check. None exist today.

--- a/app/(examples)/components/_components/form-demo-action.ts
+++ b/app/(examples)/components/_components/form-demo-action.ts
@@ -24,9 +24,5 @@ export async function demoFormAction(
     return result
   }
 
-  if (process.env.NODE_ENV === 'development') {
-    console.log('Form submitted:', result.data)
-  }
-
   return { status: 200, message: 'Form submitted successfully!' }
 }

--- a/components/ui/dropdown/index.tsx
+++ b/components/ui/dropdown/index.tsx
@@ -4,11 +4,15 @@ import cn from 'clsx'
 import { Activity, useEffect, useState } from 'react'
 import s from './dropdown.module.css'
 
+// Stable reference reused across renders so memoized children don't see a new
+// array identity every render when `options` is omitted.
+const EMPTY_OPTIONS: readonly string[] = []
+
 type DropdownProps = {
   className?: string
   placeholder?: string
   defaultValue?: number
-  options?: string[]
+  options?: readonly string[]
   onChange?: (value: number) => void
 }
 
@@ -16,7 +20,7 @@ export function Dropdown({
   className,
   placeholder = 'Select Option',
   defaultValue,
-  options = [],
+  options = EMPTY_OPTIONS,
   onChange,
 }: DropdownProps) {
   const [isOpened, setIsOpened] = useState(false)

--- a/components/ui/select/index.tsx
+++ b/components/ui/select/index.tsx
@@ -66,13 +66,17 @@ type Option<T = string> = {
   disabled?: boolean
 }
 
+// Stable reference reused across renders so memoized children don't see a new
+// array identity every render when `options` is omitted.
+const EMPTY_OPTIONS: readonly never[] = []
+
 type SelectProps<T = string> = {
   /** CSS class for the trigger element */
   className?: string
   /** Label displayed above the select */
   label?: string
   /** Options to display in the dropdown */
-  options?: Option<T>[]
+  options?: readonly Option<T>[]
   /** Placeholder text when no value is selected */
   placeholder?: string
   /** Custom icon for the trigger */
@@ -94,7 +98,7 @@ type SelectProps<T = string> = {
 function Select<T extends string = string>({
   className,
   label,
-  options = [],
+  options = EMPTY_OPTIONS,
   placeholder = 'Select an option',
   icon,
   value,


### PR DESCRIPTION
## What this does

Applies the verified fixes from a react-doctor pass on `main`, and records the reviewed false positives so the tool stops crying wolf.

- **`ui/select`, `ui/dropdown`** — hoist a shared `readonly EMPTY_OPTIONS` constant instead of defaulting `options = []` inline. A freshly-built `[]` each render breaks memo identity and forces needless child re-renders; one stable array fixes it. Prop types widened to `readonly` (backward-compatible — callers passing normal arrays still typecheck).
- **`form-demo-action`** — remove the dev-only `console.log` that ran before the server action returned. It was a throwaway debug line (dev-gated) in a *simulated* demo; deleting it removes the pre-response side effect entirely.
- **`.react-doctor/false-positives.md`** — document the 12 `server-auth-actions` hits as reviewed false positives. This template has **no auth/session library** and every flagged action is an intentionally public/anonymous endpoint (guest cart, login/signup, public forms) defended by rate-limit + CAPTCHA + Zod. Bolting on a no-op `auth()` is the anti-pattern the rule's own docs warn against.
- **`.gitignore`** — ignore generated react-doctor diagnostics, keep the curated `false-positives.md` tracked.

Not addressed here (deliberately): the other ~257 react-doctor diagnostics (effect cleanup, exhaustive-deps, a11y, next/image sizes, …) — a separate follow-up pass.

## Test Plan
- [x] `bun run check` green at commit time (lefthook: tsgo + biome)
- [x] typecheck confirms no caller broke from the `readonly` widening
- [ ] (optional) re-run `npx react-doctor` to confirm the 2 fixed rules + the 12 suppressed auth hits are gone