### PR TITLE
refactor: extract handoff doc templates (#156)

### DIFF
--- a/lib/scripts/prepare-handoff.ts
+++ b/lib/scripts/prepare-handoff.ts
@@ -18,6 +18,8 @@
 import * as p from '@clack/prompts'
 import { getConfigured } from '@/integrations/registry'
 import { INTEGRATION_BUNDLES } from './integration-bundles'
+import { renderDeploymentChecklist } from './templates/deployment-checklist'
+import { renderInventory } from './templates/inventory'
 import {
   parseCliFlags,
   pathExists,
@@ -25,6 +27,43 @@ import {
   removeFile,
   resolvePath,
 } from './utils'
+
+/** Current date as an ISO `YYYY-MM-DD` string for generated-document headers. */
+const today = (): string => new Date().toISOString().split('T')[0] ?? ''
+
+/**
+ * Scan a components directory for `*\/index.tsx` entries and return the sorted
+ * component names (the leading directory of each match). Returns `null` if the
+ * directory cannot be scanned, so the caller can render a fallback line.
+ */
+const scanComponentDir = async (dir: string): Promise<string[] | null> => {
+  try {
+    const components = await Array.fromAsync(
+      new Bun.Glob('*/index.tsx').scan({ cwd: resolvePath(dir) })
+    )
+    return components.sort().map((comp) => comp.replace('/index.tsx', ''))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Scan `app/` for page routes, excluding the `(examples)` group. Returns the
+ * processed, sorted routes, or `null` if the scan fails.
+ */
+const scanPages = async (): Promise<string[] | null> => {
+  try {
+    const pages = await Array.fromAsync(
+      new Bun.Glob('**/page.tsx').scan({ cwd: resolvePath('app') })
+    )
+    return pages
+      .sort()
+      .map((page) => page.replace('/page.tsx', '').replace('page.tsx', '/'))
+      .filter((route) => !route.includes('(examples)'))
+  } catch {
+    return null
+  }
+}
 
 interface HandoffOptions {
   dryRun: boolean
@@ -208,104 +247,21 @@ const swapReadme = async (
 }
 
 /**
- * Generate component inventory
+ * Generate component inventory.
+ *
+ * Scans the component and page directories, then renders the markdown via the
+ * `inventory` template. The document content lives in
+ * `./templates/inventory.ts`.
  */
 const generateInventory = async (dryRun: boolean): Promise<string> => {
-  const inventory: string[] = []
-
-  inventory.push('# Component Inventory')
-  inventory.push('')
-  inventory.push(`Generated: ${new Date().toISOString().split('T')[0]}`)
-  inventory.push('')
-
-  // Configured integrations
-  const integrations = getConfigured()
-  inventory.push('## Active Integrations')
-  inventory.push('')
-  if (integrations.length > 0) {
-    for (const integration of integrations) {
-      inventory.push(`- ${integration}`)
-    }
-  } else {
-    inventory.push('- None configured')
-  }
-  inventory.push('')
-
-  // Scan components directory
-  inventory.push('## UI Components')
-  inventory.push('')
-  try {
-    const uiComponents = await Array.fromAsync(
-      new Bun.Glob('*/index.tsx').scan({
-        cwd: resolvePath('components/ui'),
-      })
-    )
-    for (const comp of uiComponents.sort()) {
-      const name = comp.replace('/index.tsx', '')
-      inventory.push(`- \`${name}\``)
-    }
-  } catch {
-    inventory.push('- Could not scan components')
-  }
-  inventory.push('')
-
-  // Scan layout components
-  inventory.push('## Layout Components')
-  inventory.push('')
-  try {
-    const layoutComponents = await Array.fromAsync(
-      new Bun.Glob('*/index.tsx').scan({
-        cwd: resolvePath('components/layout'),
-      })
-    )
-    for (const comp of layoutComponents.sort()) {
-      const name = comp.replace('/index.tsx', '')
-      inventory.push(`- \`${name}\``)
-    }
-  } catch {
-    inventory.push('- Could not scan layout components')
-  }
-  inventory.push('')
-
-  // Scan effects components
-  inventory.push('## Effect Components')
-  inventory.push('')
-  try {
-    const effectComponents = await Array.fromAsync(
-      new Bun.Glob('*/index.tsx').scan({
-        cwd: resolvePath('components/effects'),
-      })
-    )
-    for (const comp of effectComponents.sort()) {
-      const name = comp.replace('/index.tsx', '')
-      inventory.push(`- \`${name}\``)
-    }
-  } catch {
-    inventory.push('- Could not scan effect components')
-  }
-  inventory.push('')
-
-  // Scan pages
-  inventory.push('## Pages')
-  inventory.push('')
-  try {
-    const pages = await Array.fromAsync(
-      new Bun.Glob('**/page.tsx').scan({
-        cwd: resolvePath('app'),
-      })
-    )
-    for (const page of pages.sort()) {
-      const route = page.replace('/page.tsx', '').replace('page.tsx', '/')
-      // Skip example pages
-      if (!route.includes('(examples)')) {
-        inventory.push(`- \`/${route}\``)
-      }
-    }
-  } catch {
-    inventory.push('- Could not scan pages')
-  }
-
-  const content = inventory.join('\n')
+  const content = renderInventory({
+    date: today(),
+    integrations: getConfigured(),
+    uiComponents: await scanComponentDir('components/ui'),
+    layoutComponents: await scanComponentDir('components/layout'),
+    effectComponents: await scanComponentDir('components/effects'),
+    pages: await scanPages(),
+  })
 
   if (!dryRun) {
     await Bun.write(resolvePath('INVENTORY.md'), content)
@@ -315,95 +271,20 @@ const generateInventory = async (dryRun: boolean): Promise<string> => {
 }
 
 /**
- * Generate deployment checklist
+ * Generate deployment checklist.
+ *
+ * Renders the markdown via the `deployment-checklist` template. The document
+ * content lives in `./templates/deployment-checklist.ts`.
  */
 const generateChecklist = async (
   projectName: string,
   dryRun: boolean
 ): Promise<string> => {
-  const integrations = getConfigured()
-
-  const checklist: string[] = []
-
-  checklist.push(`# ${projectName} - Deployment Checklist`)
-  checklist.push('')
-  checklist.push(`Generated: ${new Date().toISOString().split('T')[0]}`)
-  checklist.push('')
-
-  checklist.push('## Pre-Deployment')
-  checklist.push('')
-  checklist.push(
-    '- [ ] All environment variables configured in hosting platform'
-  )
-  checklist.push('- [ ] Custom domain configured')
-  checklist.push('- [ ] SSL certificate active')
-  checklist.push('- [ ] Build passes without errors (`bun run build`)')
-  checklist.push('- [ ] TypeScript passes without errors (`bun typecheck`)')
-  checklist.push('')
-
-  if (integrations.includes('Sanity')) {
-    checklist.push('## Sanity CMS')
-    checklist.push('')
-    checklist.push('- [ ] Production dataset selected')
-    checklist.push('- [ ] CORS origins configured for production domain')
-    checklist.push('- [ ] Webhook configured for revalidation')
-    checklist.push('  - URL: `https://your-domain.com/api/revalidate`')
-    checklist.push('- [ ] API tokens rotated for production')
-    checklist.push('')
-  }
-
-  if (integrations.includes('Shopify')) {
-    checklist.push('## Shopify')
-    checklist.push('')
-    checklist.push('- [ ] Storefront API access token configured')
-    checklist.push('- [ ] Webhooks configured for product/collection updates')
-    checklist.push('- [ ] Test checkout flow in production')
-    checklist.push('')
-  }
-
-  if (integrations.includes('HubSpot')) {
-    checklist.push('## HubSpot')
-    checklist.push('')
-    checklist.push('- [ ] API access token configured')
-    checklist.push('- [ ] Form IDs updated for production forms')
-    checklist.push('- [ ] Test form submissions')
-    checklist.push('')
-  }
-
-  checklist.push('## Performance')
-  checklist.push('')
-  checklist.push('- [ ] Lighthouse score > 90 for Performance')
-  checklist.push('- [ ] Lighthouse score > 90 for Accessibility')
-  checklist.push('- [ ] Images optimized and using next/image')
-  checklist.push('- [ ] No console errors in production')
-  checklist.push('')
-
-  checklist.push('## SEO')
-  checklist.push('')
-  checklist.push('- [ ] Meta titles and descriptions set for all pages')
-  checklist.push('- [ ] Open Graph images configured')
-  checklist.push('- [ ] robots.txt configured correctly')
-  checklist.push('- [ ] sitemap.xml generating correctly')
-  checklist.push('- [ ] Canonical URLs set')
-  checklist.push('')
-
-  checklist.push('## Analytics')
-  checklist.push('')
-  checklist.push('- [ ] Google Analytics or Tag Manager configured')
-  checklist.push('- [ ] Cookie consent implemented (if required)')
-  checklist.push('- [ ] Privacy policy page exists')
-  checklist.push('')
-
-  checklist.push('## Post-Deployment')
-  checklist.push('')
-  checklist.push('- [ ] Verify all pages load correctly')
-  checklist.push('- [ ] Test all forms and interactions')
-  checklist.push('- [ ] Verify analytics receiving data')
-  checklist.push('- [ ] Test on mobile devices')
-  checklist.push('- [ ] Test in different browsers')
-  checklist.push('')
-
-  const content = checklist.join('\n')
+  const content = renderDeploymentChecklist({
+    projectName,
+    integrations: getConfigured(),
+    date: today(),
+  })
 
   if (!dryRun) {
     await Bun.write(resolvePath('DEPLOYMENT-CHECKLIST.md'), content)

--- a/lib/scripts/templates/deployment-checklist.ts
+++ b/lib/scripts/templates/deployment-checklist.ts
@@ -1,0 +1,106 @@
+/**
+ * Deployment checklist template for the client handoff script.
+ *
+ * Pure render function -- no I/O. `prepare-handoff.ts` gathers the data
+ * (project name, configured integrations, date) and writes the result, so the
+ * checklist content can be edited here without touching script logic.
+ */
+
+export interface DeploymentChecklistData {
+  /** Human-readable project name used in the title. */
+  projectName: string
+  /** Configured integration display names, e.g. `['Sanity', 'Shopify']`. */
+  integrations: string[]
+  /** ISO date (YYYY-MM-DD) shown in the "Generated:" line. */
+  date: string
+}
+
+/**
+ * Render the deployment checklist markdown. Integration-specific sections are
+ * included only when that integration is configured.
+ */
+export function renderDeploymentChecklist({
+  projectName,
+  integrations,
+  date,
+}: DeploymentChecklistData): string {
+  const lines: string[] = []
+
+  lines.push(`# ${projectName} - Deployment Checklist`)
+  lines.push('')
+  lines.push(`Generated: ${date}`)
+  lines.push('')
+
+  lines.push('## Pre-Deployment')
+  lines.push('')
+  lines.push('- [ ] All environment variables configured in hosting platform')
+  lines.push('- [ ] Custom domain configured')
+  lines.push('- [ ] SSL certificate active')
+  lines.push('- [ ] Build passes without errors (`bun run build`)')
+  lines.push('- [ ] TypeScript passes without errors (`bun typecheck`)')
+  lines.push('')
+
+  if (integrations.includes('Sanity')) {
+    lines.push('## Sanity CMS')
+    lines.push('')
+    lines.push('- [ ] Production dataset selected')
+    lines.push('- [ ] CORS origins configured for production domain')
+    lines.push('- [ ] Webhook configured for revalidation')
+    lines.push('  - URL: `https://your-domain.com/api/revalidate`')
+    lines.push('- [ ] API tokens rotated for production')
+    lines.push('')
+  }
+
+  if (integrations.includes('Shopify')) {
+    lines.push('## Shopify')
+    lines.push('')
+    lines.push('- [ ] Storefront API access token configured')
+    lines.push('- [ ] Webhooks configured for product/collection updates')
+    lines.push('- [ ] Test checkout flow in production')
+    lines.push('')
+  }
+
+  if (integrations.includes('HubSpot')) {
+    lines.push('## HubSpot')
+    lines.push('')
+    lines.push('- [ ] API access token configured')
+    lines.push('- [ ] Form IDs updated for production forms')
+    lines.push('- [ ] Test form submissions')
+    lines.push('')
+  }
+
+  lines.push('## Performance')
+  lines.push('')
+  lines.push('- [ ] Lighthouse score > 90 for Performance')
+  lines.push('- [ ] Lighthouse score > 90 for Accessibility')
+  lines.push('- [ ] Images optimized and using next/image')
+  lines.push('- [ ] No console errors in production')
+  lines.push('')
+
+  lines.push('## SEO')
+  lines.push('')
+  lines.push('- [ ] Meta titles and descriptions set for all pages')
+  lines.push('- [ ] Open Graph images configured')
+  lines.push('- [ ] robots.txt configured correctly')
+  lines.push('- [ ] sitemap.xml generating correctly')
+  lines.push('- [ ] Canonical URLs set')
+  lines.push('')
+
+  lines.push('## Analytics')
+  lines.push('')
+  lines.push('- [ ] Google Analytics or Tag Manager configured')
+  lines.push('- [ ] Cookie consent implemented (if required)')
+  lines.push('- [ ] Privacy policy page exists')
+  lines.push('')
+
+  lines.push('## Post-Deployment')
+  lines.push('')
+  lines.push('- [ ] Verify all pages load correctly')
+  lines.push('- [ ] Test all forms and interactions')
+  lines.push('- [ ] Verify analytics receiving data')
+  lines.push('- [ ] Test on mobile devices')
+  lines.push('- [ ] Test in different browsers')
+  lines.push('')
+
+  return lines.join('\n')
+}

--- a/lib/scripts/templates/inventory.ts
+++ b/lib/scripts/templates/inventory.ts
@@ -1,0 +1,102 @@
+/**
+ * Component inventory template for the client handoff script.
+ *
+ * Pure render function -- no I/O. `prepare-handoff.ts` scans the filesystem for
+ * components and pages, then passes the gathered lists here. A `null` list means
+ * the corresponding scan failed and the section renders a fallback line.
+ */
+
+export interface InventoryData {
+  /** ISO date (YYYY-MM-DD) shown in the "Generated:" line. */
+  date: string
+  /** Configured integration display names. */
+  integrations: string[]
+  /** Sorted `components/ui` names, or `null` if the scan failed. */
+  uiComponents: string[] | null
+  /** Sorted `components/layout` names, or `null` if the scan failed. */
+  layoutComponents: string[] | null
+  /** Sorted `components/effects` names, or `null` if the scan failed. */
+  effectComponents: string[] | null
+  /** Processed page routes (examples excluded), or `null` if the scan failed. */
+  pages: string[] | null
+}
+
+/** Render a `## <heading>` section listing component names, or a fallback line. */
+function pushComponentSection(
+  lines: string[],
+  heading: string,
+  components: string[] | null,
+  scanErrorLine: string
+): void {
+  lines.push(heading)
+  lines.push('')
+  if (components === null) {
+    lines.push(scanErrorLine)
+  } else {
+    for (const name of components) {
+      lines.push(`- \`${name}\``)
+    }
+  }
+  lines.push('')
+}
+
+/** Render the component inventory markdown. */
+export function renderInventory({
+  date,
+  integrations,
+  uiComponents,
+  layoutComponents,
+  effectComponents,
+  pages,
+}: InventoryData): string {
+  const lines: string[] = []
+
+  lines.push('# Component Inventory')
+  lines.push('')
+  lines.push(`Generated: ${date}`)
+  lines.push('')
+
+  lines.push('## Active Integrations')
+  lines.push('')
+  if (integrations.length > 0) {
+    for (const integration of integrations) {
+      lines.push(`- ${integration}`)
+    }
+  } else {
+    lines.push('- None configured')
+  }
+  lines.push('')
+
+  pushComponentSection(
+    lines,
+    '## UI Components',
+    uiComponents,
+    '- Could not scan components'
+  )
+  pushComponentSection(
+    lines,
+    '## Layout Components',
+    layoutComponents,
+    '- Could not scan layout components'
+  )
+  pushComponentSection(
+    lines,
+    '## Effect Components',
+    effectComponents,
+    '- Could not scan effect components'
+  )
+
+  // Pages section intentionally has no trailing blank line (matches the
+  // original generator, which ended the document on the last page entry).
+  lines.push('## Pages')
+  lines.push('')
+  if (pages === null) {
+    lines.push('- Could not scan pages')
+  } else {
+    for (const route of pages) {
+      lines.push(`- \`/${route}\``)
+    }
+  }
+
+  return lines.join('\n')
+}

--- a/lib/scripts/templates/templates.test.ts
+++ b/lib/scripts/templates/templates.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Unit tests for the client-handoff document templates.
+ *
+ * Run with: bun test lib/scripts/templates/templates.test.ts
+ *
+ * The handoff CLI (`bun run handoff`) is interactive, so these tests exercise
+ * the pure render functions directly to guarantee the extracted templates
+ * produce the same documents the inline generators used to.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { renderDeploymentChecklist } from './deployment-checklist'
+import { renderInventory } from './inventory'
+
+describe('renderDeploymentChecklist', () => {
+  it('renders the exact document for a project with no integrations', () => {
+    const output = renderDeploymentChecklist({
+      projectName: 'Test Project',
+      integrations: [],
+      date: '2026-01-01',
+    })
+
+    const expected = `# Test Project - Deployment Checklist
+
+Generated: 2026-01-01
+
+## Pre-Deployment
+
+- [ ] All environment variables configured in hosting platform
+- [ ] Custom domain configured
+- [ ] SSL certificate active
+- [ ] Build passes without errors (\`bun run build\`)
+- [ ] TypeScript passes without errors (\`bun typecheck\`)
+
+## Performance
+
+- [ ] Lighthouse score > 90 for Performance
+- [ ] Lighthouse score > 90 for Accessibility
+- [ ] Images optimized and using next/image
+- [ ] No console errors in production
+
+## SEO
+
+- [ ] Meta titles and descriptions set for all pages
+- [ ] Open Graph images configured
+- [ ] robots.txt configured correctly
+- [ ] sitemap.xml generating correctly
+- [ ] Canonical URLs set
+
+## Analytics
+
+- [ ] Google Analytics or Tag Manager configured
+- [ ] Cookie consent implemented (if required)
+- [ ] Privacy policy page exists
+
+## Post-Deployment
+
+- [ ] Verify all pages load correctly
+- [ ] Test all forms and interactions
+- [ ] Verify analytics receiving data
+- [ ] Test on mobile devices
+- [ ] Test in different browsers
+`
+
+    expect(output).toBe(expected)
+  })
+
+  it('includes only the configured integration sections, in order', () => {
+    const output = renderDeploymentChecklist({
+      projectName: 'Acme',
+      integrations: ['Sanity', 'HubSpot'],
+      date: '2026-01-01',
+    })
+
+    expect(output).toContain('## Sanity CMS')
+    expect(output).toContain('- URL: `https://your-domain.com/api/revalidate`')
+    expect(output).toContain('## HubSpot')
+    expect(output).not.toContain('## Shopify')
+
+    // Integration sections appear between Pre-Deployment and Performance.
+    expect(output.indexOf('## Sanity CMS')).toBeLessThan(
+      output.indexOf('## HubSpot')
+    )
+    expect(output.indexOf('## HubSpot')).toBeLessThan(
+      output.indexOf('## Performance')
+    )
+  })
+})
+
+describe('renderInventory', () => {
+  it('renders integrations, components, and pages', () => {
+    const output = renderInventory({
+      date: '2026-01-01',
+      integrations: ['Sanity'],
+      uiComponents: ['button', 'select'],
+      layoutComponents: ['wrapper'],
+      effectComponents: ['parallax'],
+      pages: ['', 'about'],
+    })
+
+    expect(output).toContain('# Component Inventory')
+    expect(output).toContain('Generated: 2026-01-01')
+    expect(output).toContain('## Active Integrations')
+    expect(output).toContain('- Sanity')
+    expect(output).toContain('## UI Components')
+    expect(output).toContain('- `button`')
+    expect(output).toContain('- `select`')
+    expect(output).toContain('## Layout Components')
+    expect(output).toContain('- `wrapper`')
+    expect(output).toContain('## Effect Components')
+    expect(output).toContain('- `parallax`')
+    expect(output).toContain('## Pages')
+    expect(output).toContain('- `/about`')
+  })
+
+  it('renders the "none configured" fallback when no integrations', () => {
+    const output = renderInventory({
+      date: '2026-01-01',
+      integrations: [],
+      uiComponents: [],
+      layoutComponents: [],
+      effectComponents: [],
+      pages: [],
+    })
+
+    expect(output).toContain('- None configured')
+  })
+
+  it('renders scan-error fallbacks when a scan returns null', () => {
+    const output = renderInventory({
+      date: '2026-01-01',
+      integrations: ['Sanity'],
+      uiComponents: null,
+      layoutComponents: null,
+      effectComponents: null,
+      pages: null,
+    })
+
+    expect(output).toContain('- Could not scan components')
+    expect(output).toContain('- Could not scan layout components')
+    expect(output).toContain('- Could not scan effect components')
+    expect(output).toContain('- Could not scan pages')
+  })
+})


### PR DESCRIPTION
## Summary

Extracts the inline `INVENTORY.md` and `DEPLOYMENT-CHECKLIST.md` document content out of `lib/scripts/prepare-handoff.ts` into pure render functions under `lib/scripts/templates/`, so the handoff doc text is editable as plain files without touching script logic.

- `templates/deployment-checklist.ts` — `renderDeploymentChecklist()`
- `templates/inventory.ts` — `renderInventory()`
- `prepare-handoff.ts` now gathers data (configured integrations, component/page scans via new `scanComponentDir`/`scanPages` helpers) and delegates rendering. Script shrank **634 → 515 lines**.
- Adds `templates/templates.test.ts`: an exact-output assertion (proves byte-equivalence with the previous generator) plus section/fallback coverage.

Behavior-preserving — the generated documents are identical.

## Test plan
- [x] `bun run check` — biome + tsgo + 430 tests, green
- [x] Exact-match unit test confirms identical checklist output

Closes #156