### PR TITLE
chore(deps): pin hamo/tempus + exclude from Dependabot (#157)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,11 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     open-pull-requests-limit: 10
+    # hamo and tempus are first-party Darkroom packages with no stable v1 yet
+    # (npm only carries 1.0.0-dev.* prereleases, and the `latest` dist-tag lags
+    # behind the dev versions we depend on). They are pinned to exact dev
+    # versions and bumped manually — automating them would auto-merge
+    # prereleases or chase a nonexistent stable release. See #157.
+    ignore:
+      - dependency-name: "hamo"
+      - dependency-name: "tempus"


### PR DESCRIPTION
## Summary

Resolves #157. After reviewing satus's usage of the two first-party Darkroom packages:

- **hamo** is pinned to `1.0.0-dev.13` and **stays there** — satus depends on APIs that exist *only* in dev.13, not in the `latest` dist-tag (`1.0.0-dev.10`): `TransformProvider`, `TransformContext`, `useTransform`, `useScrollTrigger`, `UseScrollTriggerOptions` (used in `app/layout.tsx`, the WebGL tunnel/rect hooks, `fold`, `progress-text`, and the r3f example).
- **tempus** is pinned to `1.0.0-dev.17`, which is already the `latest` tag; satus only uses its default export.

Neither package has ever shipped a clean stable `v1` (npm only carries `1.0.0-dev.*`). Rather than chase a nonexistent stable release, we pin both to the exact dev versions we use and **exclude them from Dependabot** so the auto-merge workflow doesn't merge prereleases or propose a breaking downgrade to the older `latest` tag.

Pins are already exact in `package.json`; this PR adds the Dependabot `ignore` entries (the missing piece of #157's "blocks clean automated dependency management" concern).

## Test plan
- [x] Config-only change; no code affected
- [x] hamo/tempus usage audited against the dev.10 vs dev.13 export surface

Closes #157