### PR TITLE
fix(shopify): validate addItem before cart creation (nuclear-review)

### DIFF
--- a/lib/integrations/shopify/cart/actions.ts
+++ b/lib/integrations/shopify/cart/actions.ts
@@ -77,14 +77,27 @@ export async function addItem(
   _prevState: unknown,
   { variantId, quantity = 1 }: AddItemPayload
 ): Promise<string> {
+  const headersList = await headers()
+  const ip = getIPFromHeaders(headersList)
+  const rateLimitResult = rateLimit(`cart-add:${ip}`, rateLimiters.standard)
+  if (!rateLimitResult.success) {
+    return 'Too many requests. Please try again later.'
+  }
+
+  // Validate input before creating a cart, so an invalid request doesn't leave
+  // an orphaned cart + cookie behind.
+  const parsed = addItemSchema.safeParse({ variantId, quantity })
+  if (!parsed.success) {
+    return parsed.error.issues[0]?.message ?? 'Invalid input'
+  }
+
   const _cookies = await cookies()
   let cartId = _cookies.get('cartId')?.value
-  let cart: unknown
 
   // This is here because cookie can only be set server side
   // and useFormState executes the addItem action in the server
   if (!cartId) {
-    cart = await createCart()
+    const cart = await createCart()
     cartId = (cart as { id: string }).id
     _cookies.set('cartId', cartId, {
       httpOnly: true,
@@ -93,18 +106,6 @@ export async function addItem(
       maxAge: 60 * 60 * 24 * 30, // 30 days
       path: '/',
     })
-  }
-
-  const headersList = await headers()
-  const ip = getIPFromHeaders(headersList)
-  const rateLimitResult = rateLimit(`cart-add:${ip}`, rateLimiters.standard)
-  if (!rateLimitResult.success) {
-    return 'Too many requests. Please try again later.'
-  }
-
-  const parsed = addItemSchema.safeParse({ variantId, quantity })
-  if (!parsed.success) {
-    return parsed.error.issues[0]?.message ?? 'Invalid input'
   }
 
   try {


### PR DESCRIPTION
From the `/nuclear-review` audit. `cart/actions.ts` `addItem` created a cart and set the `cartId` cookie **before** validating the payload — an invalid request (e.g. empty `variantId`) left an orphaned cart + cookie behind, then returned an error. This moves the rate-limit check and the Zod `safeParse` ahead of cart creation, so invalid requests return early with no side effects. Also tightens the `let cart: unknown` to a block-scoped `const`.

Behavior on the happy path is unchanged.

## Test plan
- [x] `bun run check` — biome + tsgo + 422 tests green
- [x] `bun run build` — production build succeeds (server action in the Shopify route)