### PR TITLE
fix(security): complete HTML sanitization in HubSpot form parser

### DIFF
--- a/lib/integrations/hubspot/fetch-form.ts
+++ b/lib/integrations/hubspot/fetch-form.ts
@@ -118,7 +118,19 @@ function apiParser(id: string, data: HubspotFormResponse) {
     (data?.legalConsentOptions as HubSpotLegalConsentOptions)
       ?.communicationsCheckboxes || null
 
-  const removeHTML = (htmlText: string) => htmlText.replace(/<[^>]*>/g, '')
+  // Strip HTML tags to plain text. A single regex pass is an incomplete
+  // sanitizer (CodeQL js/incomplete-multi-character-sanitization): removing one
+  // tag can reassemble another, and an unterminated `<script` is never matched.
+  // Loop until the result is stable, and drop any unterminated trailing tag.
+  const removeHTML = (htmlText: string) => {
+    let current = htmlText
+    let previous = ''
+    while (current !== previous) {
+      previous = current
+      current = current.replace(/<[^>]*>/g, '').replace(/<[^>]*$/g, '')
+    }
+    return current
+  }
 
   return {
     portalId: process.env.NEXT_PUBLIC_HUBSPOT_PORTAL_ID,


### PR DESCRIPTION
Fixes CodeQL **`js/incomplete-multi-character-sanitization`** (High, alert #5) in `lib/integrations/hubspot/fetch-form.ts:121`.

## The issue
`removeHTML` stripped tags with a single pass: `htmlText.replace(/<[^>]*>/g, '')`. That's an incomplete sanitizer:
- An unterminated `<script` (no closing `>`) is never matched, so it survives (CodeQL: "may still contain `<script`").
- Removing one tag can reassemble another from the remainder.

It's used on HubSpot legal-consent `label` / `privacyText` / `consentToProcessText` (external API data).

## The fix
Loop the strip until the output is stable, and also drop any unterminated trailing tag, so the result can't reintroduce markup:

```ts
let current = htmlText
let previous = ''
while (current !== previous) {
  previous = current
  current = current.replace(/<[^>]*>/g, '').replace(/<[^>]*$/g, '')
}
return current
```

## Risk note
These values currently render as **React text** (`<Field.Label>{label}</Field.Label>`), which auto-escapes, so real-world exploitability was low. This hardens the sanitizer regardless of render path and clears the High alert.

## Test plan
- [x] `bun run check` green
- [ ] CodeQL re-scan on this PR confirms alert #5 resolved