### PR TITLE
fix(security): char-scan HTML stripper (clears CodeQL #6, no dep)

### DIFF
--- a/lib/integrations/hubspot/fetch-form.ts
+++ b/lib/integrations/hubspot/fetch-form.ts
@@ -1,4 +1,5 @@
 import { fetchWithTimeout } from '@/utils/fetch'
+import { stripHtmlTags } from '@/utils/strings'
 
 interface HubspotFormResponse {
   fieldGroups: Array<{ fields: unknown[] }>
@@ -118,20 +119,6 @@ function apiParser(id: string, data: HubspotFormResponse) {
     (data?.legalConsentOptions as HubSpotLegalConsentOptions)
       ?.communicationsCheckboxes || null
 
-  // Strip HTML tags to plain text. A single regex pass is an incomplete
-  // sanitizer (CodeQL js/incomplete-multi-character-sanitization): removing one
-  // tag can reassemble another, and an unterminated `<script` is never matched.
-  // Loop until the result is stable, and drop any unterminated trailing tag.
-  const removeHTML = (htmlText: string) => {
-    let current = htmlText
-    let previous = ''
-    while (current !== previous) {
-      previous = current
-      current = current.replace(/<[^>]*>/g, '').replace(/<[^>]*$/g, '')
-    }
-    return current
-  }
-
   return {
     portalId: process.env.NEXT_PUBLIC_HUBSPOT_PORTAL_ID,
     id: id,
@@ -160,13 +147,13 @@ function apiParser(id: string, data: HubspotFormResponse) {
       ? {
           required: true,
           subscriptionTypeId: legalConsentOptions[0].subscriptionTypeId,
-          label: removeHTML(legalConsentOptions[0].label),
+          label: stripHtmlTags(legalConsentOptions[0].label),
           disclaimer: [
-            removeHTML(
+            stripHtmlTags(
               (data.legalConsentOptions as HubSpotLegalConsentOptions)
                 .privacyText || ''
             ),
-            removeHTML(
+            stripHtmlTags(
               (data.legalConsentOptions as HubSpotLegalConsentOptions)
                 .consentToProcessText || ''
             ),

--- a/lib/utils/strings.test.ts
+++ b/lib/utils/strings.test.ts
@@ -10,6 +10,7 @@ import {
   isEmptyArray,
   lowerFirstChar,
   slugify,
+  stripHtmlTags,
 } from './strings'
 
 describe('slugify', () => {
@@ -103,5 +104,29 @@ describe('isEmptyArray', () => {
   it('should return true for null/undefined', () => {
     expect(isEmptyArray(null as unknown as unknown[])).toBe(true)
     expect(isEmptyArray(undefined as unknown as unknown[])).toBe(true)
+  })
+})
+
+describe('stripHtmlTags', () => {
+  it('removes simple and nested tags', () => {
+    expect(stripHtmlTags('<p>Hello</p>')).toBe('Hello')
+    expect(stripHtmlTags('I agree to the <a href="/x">terms</a>')).toBe(
+      'I agree to the terms'
+    )
+  })
+
+  it('drops an unterminated tag without leaving <script', () => {
+    const result = stripHtmlTags('safe <script')
+    expect(result).toBe('safe ')
+    expect(result).not.toContain('<script')
+  })
+
+  it('cannot reassemble a tag from the remainder', () => {
+    expect(stripHtmlTags('<scr<script>ipt>')).not.toContain('<')
+  })
+
+  it('leaves plain text untouched', () => {
+    expect(stripHtmlTags('No tags here')).toBe('No tags here')
+    expect(stripHtmlTags('')).toBe('')
   })
 })

--- a/lib/utils/strings.ts
+++ b/lib/utils/strings.ts
@@ -85,3 +85,36 @@ export function isEmptyArray(arr: string | unknown[]) {
   if (!arr) return true
   return Array.isArray(arr) && arr.length === 0
 }
+
+/**
+ * Strip all HTML tags to plain text via a single linear scan.
+ *
+ * Deliberately NOT a regex replace: `str.replace(/<[^>]*>/g, '')` is an
+ * incomplete sanitizer (CodeQL js/incomplete-multi-character-sanitization) that
+ * can leave an unterminated `<script` or reassemble a tag from the remainder. A
+ * character scan drops everything between `<` and the next `>` in one pass and
+ * discards a trailing unterminated tag, so the output can never contain markup.
+ *
+ * @param input - Possibly-HTML string (e.g. HubSpot rich text)
+ * @returns Plain text with all tags removed
+ *
+ * @example
+ * ```ts
+ * stripHtmlTags('<p>Hello</p>')  // 'Hello'
+ * stripHtmlTags('safe <script')  // 'safe ' (unterminated tag dropped)
+ * ```
+ */
+export function stripHtmlTags(input: string): string {
+  let output = ''
+  let insideTag = false
+  for (const char of input) {
+    if (char === '<') {
+      insideTag = true
+    } else if (char === '>') {
+      insideTag = false
+    } else if (!insideTag) {
+      output += char
+    }
+  }
+  return output
+}


### PR DESCRIPTION
Follow-up to #179. The regex stripper kept tripping CodeQL **`js/incomplete-multi-character-sanitization`** — #179 closed alert #5 but the re-scan opened **#6** on the same pattern. The query distrusts regex HTML sanitization by design, so no regex spelling clears it.

## Fix
Replace the regex with a **zero-dependency character scan** — a new tested `stripHtmlTags` util in `lib/utils/strings.ts`:

```ts
export function stripHtmlTags(input: string): string {
  let output = ''
  let insideTag = false
  for (const char of input) {
    if (char === '<') insideTag = true
    else if (char === '>') insideTag = false
    else if (!insideTag) output += char
  }
  return output
}
```

A single linear scan can't reassemble a tag or leave a partial `<script` (an unterminated tag at EOF is simply dropped). It's not the `String.replace(regex)` shape the CodeQL query targets, so it should clear #6 — and it avoids pulling in `sanitize-html` (~10+ transitive deps incl. postcss) for what is cosmetic plain-text stripping of HubSpot legal text.

`fetch-form.ts` now calls `stripHtmlTags`; added unit tests for the reassembly and unterminated-tag bypasses.

## Test plan
- [x] `bun run check` green (biome + tsgo + **414 tests**, incl. 4 new sanitizer cases)
- [ ] Post-merge CodeQL scan confirms #6 resolved with no new alert