### PR TITLE
docs: sync COMPONENTS.md + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,26 @@ latest tag; security fixes land on the latest release (see `SECURITY.md`).
 
 - `AGENTS.md` as the single source of truth for engineering standards; `CLAUDE.md`
   and `.cursor/rules` reduced to thin pointers (#175).
+- Auto-generated `COMPONENTS.md` manifest via `bun run generate:manifest`, with
+  `bun run manifest:check` to catch drift in CI (#178).
 - `SECURITY.md` security policy with private vulnerability reporting (#174).
 - This `CHANGELOG.md`, and `package.json` version synced to the release tag.
+
+### Changed
+
+- Consolidated root docs: folded `BOUNDARIES.md` into `ARCHITECTURE.md` and
+  refreshed the doc maps in `README.md` and `AGENTS.md` (#177).
 
 ### Fixed
 
 - Shopify cart `addItem` now validates input before creating a cart, so invalid
   requests no longer leave an orphaned cart and cookie behind (#173).
+
+### Security
+
+- Hardened HubSpot form HTML stripping into a complete `stripHtmlTags` parser
+  (a character scan, not regex), resolving the CodeQL
+  `js/incomplete-multi-character-sanitization` alert (#179, #180).
 
 ### Removed
 

--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -171,6 +171,7 @@ Quick-reference for every component, hook, and utility in the Satus starter kit.
 | lowerFirstChar | `(inputString: string)` |
 | capitalizeFirstLetter | `(inputString: string)` |
 | isEmptyArray | `(arr: string | unknown[])` |
+| stripHtmlTags | `(input: string) => string` |
 
 ### Validation (`@/utils/validation`)
 
@@ -178,15 +179,15 @@ Quick-reference for every component, hook, and utility in the Satus starter kit.
 |--------|-----------|
 | parseFormData | `(schema: z.ZodType<T>, formData: FormData) => FormState<T> | { success: true; data: T }` |
 | zodToValidator | `(schema: z.ZodType) => (value: string) => boolean` |
-| emailSchema | `import("/Users/frz/Developer/@darkroom/satus/.claude/worktrees/agent-a98040a3...` |
-| phoneSchema | `import("/Users/frz/Developer/@darkroom/satus/.claude/worktrees/agent-a98040a3...` |
-| sanityEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/.claude/worktrees/agent-a98040a3...` |
-| shopifyEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/.claude/worktrees/agent-a98040a3...` |
-| hubspotEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/.claude/worktrees/agent-a98040a3...` |
-| mailchimpEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/.claude/worktrees/agent-a98040a3...` |
-| turnstileEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/.claude/worktrees/agent-a98040a3...` |
-| analyticsEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/.claude/worktrees/agent-a98040a3...` |
-| coreEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/.claude/worktrees/agent-a98040a3...` |
+| emailSchema | `import("/Users/frz/Developer/@darkroom/satus/node_modules/zod/v4/classic/sche...` |
+| phoneSchema | `import("/Users/frz/Developer/@darkroom/satus/node_modules/zod/v4/classic/sche...` |
+| sanityEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/node_modules/zod/v4/classic/sche...` |
+| shopifyEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/node_modules/zod/v4/classic/sche...` |
+| hubspotEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/node_modules/zod/v4/classic/sche...` |
+| mailchimpEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/node_modules/zod/v4/classic/sche...` |
+| turnstileEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/node_modules/zod/v4/classic/sche...` |
+| analyticsEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/node_modules/zod/v4/classic/sche...` |
+| coreEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/node_modules/zod/v4/classic/sche...` |
 
 ### Viewport (`@/utils/viewport`)
 


### PR DESCRIPTION
Final docs-freshness pass.

- **Regenerate `COMPONENTS.md`** — it had drifted (missing the new `stripHtmlTags` util). `bun run manifest:check` now passes idempotently.
- **Update `CHANGELOG.md` `[Unreleased]`** — adds the post-2.0.1 work that wasn't recorded: COMPONENTS.md generator (#178), root-docs consolidation (#177), and the HubSpot HTML-sanitizer hardening (#179, #180).

## Audit results (the rest is clean)
- **Tracking:** `git check-ignore` confirms nothing tracked is actually gitignored (the `.vscode/*.json` are intentional shared config, not ignored).
- **Empty folders:** the only empties are under gitignored dirs (`/build` output, `.claude/worktrees`) — local cruft, not in the repo.
- **No dangling doc references** to deleted files (BOUNDARIES, the old `.cursor/rules/*.mdc`, the removed utils); `doctor.ts` only checks files that exist.

## Test plan
- [x] `bun run check` green (biome + tsgo + 414 tests)
- [x] `bun run manifest:check` idempotent