### PR TITLE
fix(scripts): deterministic COMPONENTS.md generator

### DIFF
--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -179,15 +179,15 @@ Quick-reference for every component, hook, and utility in the Satus starter kit.
 |--------|-----------|
 | parseFormData | `(schema: z.ZodType<T>, formData: FormData) => FormState<T> | { success: true; data: T }` |
 | zodToValidator | `(schema: z.ZodType) => (value: string) => boolean` |
-| emailSchema | `import("/Users/frz/Developer/@darkroom/satus/node_modules/zod/v4/classic/sche...` |
-| phoneSchema | `import("/Users/frz/Developer/@darkroom/satus/node_modules/zod/v4/classic/sche...` |
-| sanityEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/node_modules/zod/v4/classic/sche...` |
-| shopifyEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/node_modules/zod/v4/classic/sche...` |
-| hubspotEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/node_modules/zod/v4/classic/sche...` |
-| mailchimpEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/node_modules/zod/v4/classic/sche...` |
-| turnstileEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/node_modules/zod/v4/classic/sche...` |
-| analyticsEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/node_modules/zod/v4/classic/sche...` |
-| coreEnvSchema | `import("/Users/frz/Developer/@darkroom/satus/node_modules/zod/v4/classic/sche...` |
+| emailSchema | `ZodEmail` |
+| phoneSchema | `ZodString` |
+| sanityEnvSchema | `ZodObject<{ NEXT_PUBLIC_SANITY_PROJECT_ID: ZodString; NEXT_PUBLIC_SANITY_DATA...` |
+| shopifyEnvSchema | `ZodObject<{ SHOPIFY_STORE_DOMAIN: ZodString; SHOPIFY_STOREFRONT_ACCESS_TOKEN:...` |
+| hubspotEnvSchema | `ZodObject<{ HUBSPOT_ACCESS_TOKEN: ZodOptional<ZodString>; NEXT_PUBLIC_HUBSPOT...` |
+| mailchimpEnvSchema | `ZodObject<{ MAILCHIMP_API_KEY: ZodString; MAILCHIMP_SERVER_PREFIX: ZodString;...` |
+| turnstileEnvSchema | `ZodObject<{ NEXT_PUBLIC_CLOUDFLARE_TURNSTILE_SITE_KEY: ZodString; CLOUDFLARE_...` |
+| analyticsEnvSchema | `ZodObject<{ NEXT_PUBLIC_GOOGLE_ANALYTICS: ZodOptional<ZodString>; NEXT_PUBLIC...` |
+| coreEnvSchema | `ZodObject<{ NEXT_PUBLIC_BASE_URL: ZodURL; }, $strip>` |
 
 ### Viewport (`@/utils/viewport`)
 
@@ -222,7 +222,7 @@ Quick-reference for every component, hook, and utility in the Satus starter kit.
 | getConfigured | `() => string[]` |
 | getUnconfigured | `() => string[]` |
 | IntegrationEntry |  |
-| integrations | `{ readonly sanity: { readonly name: "Sanity"; readonly envSchema: import("/Us...` |
+| integrations | `{ readonly sanity: { readonly name: "Sanity"; readonly envSchema: ZodObject<{...` |
 | IntegrationId | `keyof typeof integrations` |
 
 ---

--- a/lib/scripts/generate-manifest.ts
+++ b/lib/scripts/generate-manifest.ts
@@ -55,6 +55,20 @@ interface ExportSig {
   sig: string
 }
 
+/**
+ * Format a ts-morph type string for the manifest. Strips the machine-specific
+ * `import("/abs/path/node_modules/...").` qualifiers the compiler emits for
+ * inferred types (they bake an absolute path into the output and make it
+ * non-deterministic across checkouts), collapses whitespace, and truncates.
+ */
+function formatTypeText(raw: string): string {
+  const cleaned = raw
+    .replace(/import\("[^"]*"\)\./g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return cleaned.length > 80 ? `${cleaned.slice(0, 77)}...` : cleaned
+}
+
 function getExportedSignatures(
   project: Project,
   filePath: string
@@ -85,18 +99,16 @@ function getExportedSignatures(
         const v = decl.asKindOrThrow(SyntaxKind.VariableDeclaration)
         const typeNode = v.getTypeNode()
         if (typeNode) {
-          sig = typeNode.getText()
+          sig = formatTypeText(typeNode.getText())
         } else {
           const init = v.getInitializer()
           if (init) {
-            const t = init.getType().getText()
-            sig = t.length > 80 ? `${t.slice(0, 77)}...` : t
+            sig = formatTypeText(init.getType().getText())
           }
         }
       } else if (decl.getKind() === SyntaxKind.TypeAliasDeclaration) {
         const ta = decl.asKindOrThrow(SyntaxKind.TypeAliasDeclaration)
-        const t = ta.getTypeNode()?.getText() ?? ''
-        sig = t.length > 80 ? `${t.slice(0, 77)}...` : t
+        sig = formatTypeText(ta.getTypeNode()?.getText() ?? '')
       }
 
       const clean = sig.replace(/\n\s*/g, ' ').trim()


### PR DESCRIPTION
The `COMPONENTS.md` generator (#178) emitted machine-specific absolute paths, so the committed manifest embedded `/Users/<committer>/.../node_modules/zod/...` for every Zod schema. Consequence: `bun run manifest:check` **fails in any checkout other than the original** (other worktrees, every contributor, CI if wired) — defeating the drift guard.

## Cause
For variables without an explicit type annotation (e.g. `emailSchema = z.email(...)`), the generator used ts-morph's inferred-type text, which resolves to `import("/abs/path/node_modules/zod/...").ZodEmail`.

## Fix
Add `formatTypeText()` that strips the `import("...").` qualifier (leaving the bare type, e.g. `ZodEmail` / `ZodObject<{ NEXT_PUBLIC_BASE_URL: ZodURL }, $strip>`) **before** truncating, and regenerate `COMPONENTS.md`. Output is now path-independent.

## Verify
- [x] Regenerated `COMPONENTS.md` contains no `/Users/` or `node_modules` paths
- [x] `bun run manifest:check` passes (and is now portable across checkouts)
- [x] `bun run check` green (414 tests)