### PR TITLE
ci: enforce COMPONENTS.md freshness (manifest:check)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,7 @@ jobs:
 
       - name: Run checks
         run: bun run check
+
+      # COMPONENTS.md is generated from code; fail if it has drifted.
+      - name: Check generated manifest
+        run: bun run manifest:check


### PR DESCRIPTION
Adds a `manifest:check` step to the Test workflow so a stale `COMPONENTS.md` (drifted from the code) fails CI, instead of relying on someone running it manually.

Safe to enforce now that #183 made the generator deterministic — `manifest:check` passes on `main` and is path-independent, so it won't false-fail in CI's checkout path.

```yaml
- name: Check generated manifest
  run: bun run manifest:check
```

## Test plan
- [x] `bun run manifest:check` passes on `main` / this branch
- [ ] The new CI step runs green on this PR