### PR TITLE
ci: auto-sync bun.lock on Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,0 +1,55 @@
+name: Dependabot lockfile
+
+# Dependabot bumps package.json but not bun.lock, so Test's
+# `bun install --frozen-lockfile` fails on every Dependabot PR
+# ("lockfile had changes, but lockfile is frozen"). This job regenerates
+# bun.lock and commits it back to the PR branch so Test can pass and the
+# bumped lockfile lands on main when the PR squash-merges.
+#
+# Why pull_request_target (not pull_request): Dependabot-triggered
+# `pull_request` runs receive a read-only GITHUB_TOKEN and cannot push. A
+# `pull_request_target` run executes in the base-repo context and gets a
+# writable token. To keep that write-privileged context safe, the job is
+# scoped strictly to dependabot[bot] and installs with --ignore-scripts, so
+# no dependency lifecycle scripts execute here.
+#
+# Caveat: a commit pushed with GITHUB_TOKEN does not retrigger the Test
+# workflow, so after the lockfile is synced the PR's Test check may need one
+# manual re-run before automerge fires. For fully hands-off automerge, add a
+# PAT and push with it instead of GITHUB_TOKEN.
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: write
+
+jobs:
+  sync-lockfile:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Regenerate bun.lock (no lifecycle scripts)
+        run: bun install --ignore-scripts
+
+      - name: Commit lockfile if it changed
+        run: |
+          if git diff --quiet -- bun.lock; then
+            echo "bun.lock already in sync — nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add bun.lock
+          git commit -m "chore: sync bun.lock with Dependabot bump"
+          git push

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -2,47 +2,68 @@ name: Dependabot lockfile
 
 # Dependabot bumps package.json but not bun.lock, so Test's
 # `bun install --frozen-lockfile` fails on every Dependabot PR
-# ("lockfile had changes, but lockfile is frozen"). This job regenerates
-# bun.lock and commits it back to the PR branch so Test can pass and the
-# bumped lockfile lands on main when the PR squash-merges.
+# ("lockfile had changes, but lockfile is frozen"). This regenerates bun.lock
+# and commits it back to the PR branch so Test passes and the bumped lockfile
+# lands on main when the PR squash-merges.
 #
-# Why pull_request_target (not pull_request): Dependabot-triggered
-# `pull_request` runs receive a read-only GITHUB_TOKEN and cannot push. A
-# `pull_request_target` run executes in the base-repo context and gets a
-# writable token. To keep that write-privileged context safe, the job is
-# scoped strictly to dependabot[bot] and installs with --ignore-scripts, so
-# no dependency lifecycle scripts execute here.
+# Uses a PAT (not GITHUB_TOKEN) for the push, on a normal `pull_request`
+# trigger:
+#   - A GITHUB_TOKEN push would NOT retrigger Test (loop protection), so
+#     automerge — which gates on Test success — would never fire.
+#   - Dependabot-triggered `pull_request` runs also get a read-only
+#     GITHUB_TOKEN, so it cannot push at all.
+# A PAT push both has write access and retriggers Test, giving fully hands-off
+# automerge. Staying on `pull_request` (not pull_request_target) keeps this off
+# CodeQL's privileged-checkout radar.
 #
-# Caveat: a commit pushed with GITHUB_TOKEN does not retrigger the Test
-# workflow, so after the lockfile is synced the PR's Test check may need one
-# manual re-run before automerge fires. For fully hands-off automerge, add a
-# PAT and push with it instead of GITHUB_TOKEN.
+# SETUP (one time): create a fine-grained PAT scoped to this repo with
+# Contents: Read and write, then add it under
+#   Settings → Secrets and variables → Dependabot → New repository secret
+#   name: DEPENDABOT_PAT
+# It must live in the *Dependabot* secrets store (not Actions secrets) —
+# Dependabot-triggered runs can only read Dependabot secrets. Until it is set,
+# this workflow no-ops (it does not fail Dependabot PRs).
 
 on:
-  pull_request_target:
+  pull_request:
 
 permissions:
-  contents: write
+  contents: read # GITHUB_TOKEN stays read-only; the PAT performs the write
 
 jobs:
   sync-lockfile:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
+      - name: Verify PAT is configured
+        id: check
+        env:
+          DEPENDABOT_PAT: ${{ secrets.DEPENDABOT_PAT }}
+        run: |
+          if [ -n "$DEPENDABOT_PAT" ]; then
+            echo "has_pat=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::DEPENDABOT_PAT not set — add it under Settings → Secrets and variables → Dependabot. Skipping lockfile sync."
+            echo "has_pat=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v6
+        if: steps.check.outputs.has_pat == 'true'
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.DEPENDABOT_PAT }}
 
       - uses: oven-sh/setup-bun@v2
+        if: steps.check.outputs.has_pat == 'true'
         with:
           bun-version: latest
 
       - name: Regenerate bun.lock (no lifecycle scripts)
+        if: steps.check.outputs.has_pat == 'true'
         run: bun install --ignore-scripts
 
       - name: Commit lockfile if it changed
+        if: steps.check.outputs.has_pat == 'true'
         run: |
           if git diff --quiet -- bun.lock; then
             echo "bun.lock already in sync — nothing to do."


### PR DESCRIPTION
## What this does
Every Dependabot PR fails CI with `lockfile had changes, but lockfile is frozen` — Dependabot bumps `package.json` but never updates `bun.lock`, and Test installs `--frozen-lockfile`. Since auto-merge gates on Test passing, **no Dependabot PR can merge** without a manual lockfile fix. This adds a workflow that regenerates `bun.lock` on Dependabot PRs and commits it back, so the bump passes CI and lands the correct lockfile on `main`.

## Approach (PAT, no `pull_request_target`)
- Normal `pull_request` workflow, scoped to `dependabot[bot]`.
- Pushes the synced `bun.lock` using a **PAT**, because (a) Dependabot `pull_request` runs get a read-only `GITHUB_TOKEN` that can't push, and (b) a `GITHUB_TOKEN` push wouldn't retrigger Test — so auto-merge would never fire. A PAT push has write access **and** retriggers Test → fully hands-off auto-merge.
- Staying on `pull_request` (not `pull_request_target`) keeps it off CodeQL's privileged-checkout radar (the previous revision failed CodeQL for exactly that).
- Installs with `--ignore-scripts`; no-ops gracefully (with a warning, not a failure) until the secret is configured.

## ⚠️ One-time setup required
Create a **fine-grained PAT** scoped to this repo with **Contents: Read and write**, then add it under **Settings → Secrets and variables → Dependabot** (the *Dependabot* secrets store, not Actions) as `DEPENDABOT_PAT`. Dependabot-triggered runs can only read Dependabot secrets.

## Test Plan
- [ ] Add `DEPENDABOT_PAT`, then confirm the next Dependabot PR auto-syncs `bun.lock`, Test goes green, and auto-merge fires
- [x] CodeQL passes (no `pull_request_target`)
- [x] Non-Dependabot PRs unaffected (job gated on `dependabot[bot]`)
- [x] No-ops without the secret (warns, doesn't fail)
