### PR TITLE
docs: align with marketing removal + useReveal, consolidate

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,29 +6,11 @@ Key architectural decisions and patterns for teams working with this codebase.
 
 ### React Compiler (No Manual Memoization)
 
-React Compiler is enabled. **Do not** use `useMemo`, `useCallback`, or `React.memo`:
-
-```tsx
-// ❌ Don't
-const memoizedValue = useMemo(() => compute(a, b), [a, b])
-
-// ✅ Do
-const value = compute(a, b)
-```
-
-**Exception**: Use `useRef` for object instantiation to prevent infinite loops.
+React Compiler is enabled — no `useMemo`, `useCallback`, or `React.memo`. See AGENTS.md § No manual memoization.
 
 ### CSS Modules + Tailwind
 
-Both are used intentionally:
-- **Tailwind** (80%): spacing, colors, typography
-- **CSS Modules**: complex animations, custom layouts, CSS specificity
-
-Import CSS modules as `s`:
-
-```tsx
-import s from './component.module.css'
-```
+Tailwind for layout/spacing/color; CSS Modules for complex animations and custom layouts. See AGENTS.md § Styling split.
 
 ### Custom Image/Link Components
 
@@ -84,6 +66,10 @@ Root Layout → LazyGlobalCanvas (mounts on first WebGL page)
 
 Context survives navigation. See [lib/webgl/README.md](lib/webgl/README.md).
 
+## Animation
+
+Use `useReveal` (CSS-driven, compositor thread) for reveal-on-scroll and entrance animations. Reserve GSAP for orchestration, scrubbing, and pinning. Always honor `prefers-reduced-motion` — `useReveal` short-circuits automatically; CSS global neutralizer is in `global.css`. See AGENTS.md § Animation.
+
 ## File Organization
 
 ```
@@ -113,7 +99,7 @@ All schemas live in `lib/utils/validation.ts`. The typed env singleton (`lib/env
 
 ### Request Proxy
 
-`proxy.ts` (project root) handles cross-cutting request concerns for Next.js 16. Currently configured with rate limiting for `/api/*` routes. Security headers remain in `next.config.ts` (they're static configuration).
+`proxy.ts` handles cross-cutting concerns (rate limiting for `/api/*`). See AGENTS.md for usage guidance.
 
 ## Deployment Checklist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ latest tag; security fixes land on the latest release (see `SECURITY.md`).
 
 ### Added
 
+- `useReveal` hook (`lib/hooks/use-reveal.ts`) — reveal-on-scroll primitive animating `transform`/`opacity` on the compositor thread via a `[data-reveal]`/`[data-reveal-item]` CSS contract in `global.css`; degrades to visible without JS and honors reduced-motion. (#189)
+- Animation standards section in AGENTS.md — CSS/`useReveal` for reveals, GSAP for orchestration. (#189)
 - `AGENTS.md` as the single source of truth for engineering standards; `CLAUDE.md`
   and `.cursor/rules` reduced to thin pointers (#175).
 - Auto-generated `COMPONENTS.md` manifest via `bun run generate:manifest`, with
@@ -33,6 +35,9 @@ latest tag; security fixes land on the latest release (see `SECURITY.md`).
 
 ### Changed
 
+- `/` now redirects to `/components` (was the marketing homepage); forks should replace `app/page.tsx` with their own homepage. (#188)
+- `spring()` (`lib/utils/animation.ts`) documentation now steers to CSS `linear()` easing for off-thread springs. (#189)
+- Dependabot PRs now auto-sync `bun.lock` via a `pull_request_target` workflow, so they pass the frozen-lockfile install in CI. (#190)
 - Consolidated root docs: folded `BOUNDARIES.md` into `ARCHITECTURE.md` and
   refreshed the doc maps in `README.md` and `AGENTS.md` (#177).
 
@@ -49,6 +54,8 @@ latest tag; security fixes land on the latest release (see `SECURITY.md`).
 
 ### Removed
 
+- In-repo marketing homepage — the `app/(marketing)` landing sections (hero, features, value-props, getting-started, presets) and marketing-only WebGL effects (`animated-gradient`, `liquid-drip`, `split-text`). Satus is a starter kit; its marketing lives at oss.darkroom.engineering/satus. (#188)
+- `/home` rewrite + redirect and the `assets.darkroom.engineering` image `remotePattern` from `next.config.ts`. (#188)
 - Dead code: orphaned WebGL GLSL utilities (`noise` / `blend` / `functions`) and
   unused `lib/utils` helpers (`normalize`, `isEmptyObject`, `twoDigits`,
   `numberWithCommas`) (#172).

--- a/app/README.md
+++ b/app/README.md
@@ -6,9 +6,8 @@ Next.js App Router pages and routes.
 
 ```
 app/
-├── page.tsx              # Homepage (renders the marketing homepage directly)
+├── page.tsx              # Redirects / → /components (replace with your own homepage)
 ├── layout.tsx            # Root layout
-├── (marketing)/          # DELETE - Satūs marketing homepage
 ├── (examples)/           # DELETE - Demo pages (components, r3f, etc.)
 ├── api/
 │   ├── draft-mode/       # Sanity draft mode
@@ -24,7 +23,6 @@ app/
 **Quick cleanup (manual):**
 ```bash
 rm -rf "app/(examples)"     # Remove example pages (r3f, sanity, shopify, etc.)
-rm -rf "app/(marketing)"    # Remove marketing homepage
 ```
 
 **Or use the interactive setup:**

--- a/components/README.md
+++ b/components/README.md
@@ -27,8 +27,6 @@ import { Header } from '@/components/layout/header'
 import { Footer } from '@/components/layout/footer'
 
 // Effects Components (GSAPRuntime is auto-loaded via OptionalFeatures - do not import manually)
-import { SplitText } from '@/components/effects/split-text'
-import { AnimatedGradient } from '@/components/effects/animated-gradient'
 ```
 
 ## Component Inventory
@@ -84,10 +82,7 @@ Built on [Base UI](https://base-ui.com/) for accessibility.
 | Component | Purpose |
 |-----------|---------|
 | `gsap/` | GSAP + Tempus integration (auto-loaded) |
-| `split-text/` | Text animation utilities |
-| `animated-gradient/` | WebGL gradients |
 | `progress-text/` | Scroll-based text reveal |
-| `liquid-drip/` | WebGL liquid drip effect |
 
 ## Best Practices
 

--- a/components/effects/README.md
+++ b/components/effects/README.md
@@ -1,58 +1,22 @@
 # Effect Components
 
-Animation and visual effect components built with GSAP.
+> **Reveal-on-scroll and entrance animations** use the `useReveal` hook + the `[data-reveal]` CSS contract — not this directory. See `lib/hooks` and AGENTS.md § Animation.
+
+This directory is for GSAP-based effects: the runtime ticker bridge and orchestrated/scroll effects.
 
 ## Components
 
 | Component | Purpose |
 |-----------|---------|
-| `gsap.tsx` | GSAP Runtime - syncs GSAP ticker with Tempus RAF |
-| `animated-gradient/` | WebGL animated gradient background |
-| `split-text/` | Text splitting for character/word/line animations |
-| `progress-text/` | Scroll-based text reveal animation |
-| `liquid-drip/` | WebGL liquid drip effect (`LiquidDrip`) |
+| `gsap.tsx` | `GSAPRuntime` — syncs GSAP's ticker to Tempus (single RAF loop) |
+| `progress-text/` | Scroll-driven progress text effect (GSAP-based) |
 
-## GSAP Runtime
+## GSAPRuntime
 
-Automatically included via `OptionalFeatures` in the root layout. Ensures GSAP animations sync with Tempus for consistent frame timing across all animations.
+Mount once in the root layout via `OptionalFeatures`. Ensures GSAP animations run on the Tempus RAF loop. ScrollTrigger↔Lenis sync is handled by the Lenis component.
 
 ```tsx
-// Already loaded - no manual import needed
-// GSAP will use Tempus RAF automatically
-```
-
-## Split Text
-
-Split text into characters, words, or lines for staggered animations.
-
-```tsx
-import { SplitText } from '@/components/effects/split-text'
-
-<SplitText type="chars" className="text-4xl">
-  Animate each character
-</SplitText>
-
-<SplitText type="words" className="text-2xl">
-  Animate each word separately
-</SplitText>
-
-<SplitText type="lines" className="text-xl">
-  Animate line by line
-  for multiline text
-</SplitText>
-```
-
-## Animated Gradient
-
-WebGL-based animated gradient background. Requires WebGL to be enabled.
-
-```tsx
-import { AnimatedGradient } from '@/components/effects/animated-gradient'
-
-<AnimatedGradient
-  colors={['#ff0000', '#00ff00', '#0000ff']}
-  speed={0.5}
-/>
+// Already loaded via OptionalFeatures — do not import manually
 ```
 
 ## Progress Text
@@ -69,6 +33,5 @@ import { ProgressText } from '@/components/effects/progress-text'
 
 ## Dependencies
 
-- **GSAP** - Animation library (gsap)
-- **Tempus** - RAF management (tempus)
-- **SplitText Plugin** - GSAP plugin for text splitting
+- **GSAP** — animation library (`gsap`)
+- **Tempus** — RAF management (`tempus`)

--- a/lib/README.md
+++ b/lib/README.md
@@ -40,6 +40,7 @@ import { useOrchestra } from '@/lib/dev'
 | [styles/](styles/README.md) | CSS & Tailwind config | ❌ Core |
 | [utils/](utils/README.md) | Pure utilities (math, fetch, metadata, strings, animation, validation) | ❌ Core |
 | `env.ts` | Typed environment variables (Zod-validated singleton) | ❌ Core |
+| [features/](features/README.md) | Optional runtime features (WebGL, dev tools, GSAP) | ✅ Yes |
 | [integrations/](integrations/README.md) | Sanity, Shopify, HubSpot | ✅ Yes |
 | [webgl/](webgl/README.md) | 3D graphics with R3F | ✅ Yes |
 | [dev/](dev/README.md) | Debug tools (CMD+O) | ✅ Yes |

--- a/lib/hooks/README.md
+++ b/lib/hooks/README.md
@@ -3,13 +3,15 @@
 Custom React hooks for common patterns.
 
 ```tsx
-import { useDeviceDetection, useMediaQuery } from '@/hooks'
+import { useDeviceDetection } from '@/hooks'
+import { useMediaQuery } from 'hamo'
 ```
 
 ## Available Hooks
 
 | Hook | Purpose |
 |------|---------|
+| `useReveal` | Reveal-on-scroll via IntersectionObserver — CSS-driven, compositor-thread; reduced-motion + no-JS safe |
 | `useDeviceDetection` | Detect mobile/desktop/tablet |
 | `usePrefetch` | Prefetch routes on visibility |
 | `useStore` | Global Zustand store |
@@ -17,6 +19,23 @@ import { useDeviceDetection, useMediaQuery } from '@/hooks'
 | `usePreferredColorScheme` | System theme preference |
 | `usePreferredReducedMotion` | Reduced motion preference |
 | `useDocumentVisibility` | Tab visibility state |
+
+## useReveal
+
+Reveal children on scroll using IntersectionObserver. Toggles `data-reveal` on the container; children marked `data-reveal-item` animate `transform`/`opacity` on the compositor thread. The CSS contract lives in `lib/styles/css/global.css`. Per-container knobs: `--reveal-transform`, `--reveal-stagger`, `--reveal-duration`. Degrades to visible without JS; short-circuits under `prefers-reduced-motion`.
+
+```tsx
+import { useReveal } from '@/hooks'
+
+function Cards({ items }) {
+  const ref = useReveal<HTMLDivElement>()
+  return (
+    <div ref={ref}>
+      {items.map((i) => <div key={i.id} data-reveal-item>{i.name}</div>)}
+    </div>
+  )
+}
+```
 
 ## Browser API Hooks
 
@@ -79,13 +98,14 @@ import { usePreferredReducedMotion } from '@/hooks'
 function AnimatedComponent() {
   const prefersReducedMotion = usePreferredReducedMotion()
 
-  const duration = prefersReducedMotion ? 0 : 300
+  // Pass as a CSS custom property or GSAP duration — CSS transitions
+  // and useReveal already short-circuit automatically.
+  const duration = prefersReducedMotion ? 0 : 0.3
 
   return (
-    <motion.div
-      animate={{ opacity: 1 }}
-      transition={{ duration: duration / 1000 }}
-    />
+    <div style={{ '--duration': `${duration}s` } as React.CSSProperties}>
+      {/* children animate via CSS transition using var(--duration) */}
+    </div>
   )
 }
 ```

--- a/lib/styles/README.md
+++ b/lib/styles/README.md
@@ -130,6 +130,8 @@ bun setup:styles
 `css/root.css` (custom properties) and `css/tailwind.css` (`@theme` + utilities)
 are **generated** by `bun setup:styles`. Hand-edits are overwritten on the next run.
 
+`css/global.css` is **not generated** — it houses the `[data-reveal]` reveal-animation contract (used by `useReveal`) and the global `prefers-reduced-motion` neutralizer. Edit it directly when adjusting global animation defaults.
+
 ## Troubleshooting
 
 - **Tokens missing / `var(--color-*)` resolves to nothing, `dr-*` classes do nothing, or `mobile-vw()` is left unparsed** — the generated CSS is stale. `bun dev` runs the generator in **watch mode** and `bun run build` runs it first, so this normally self-heals; if the watcher isn't running (CI, a one-off script, or it didn't pick up a change), regenerate manually with `bun setup:styles`.

--- a/lib/utils/README.md
+++ b/lib/utils/README.md
@@ -17,7 +17,7 @@ import { generateSanityMetadata } from '@/utils/metadata'
 |--------|-----------|
 | `math` | `clamp`, `lerp`, `mapRange`, `truncate`, `modulo`, `roundTo`, `degToRad`, `radToDeg`, `distance` |
 | `easings` | All easing functions (`easeOutCubic`, etc.) |
-| `animation` | `fromTo`, `stagger`, `ease`, `spring` |
+| `animation` | `fromTo`, `stagger`, `ease`, `spring` (prefer CSS `linear()` easing for simple springs — runs off the main thread; `spring()` is the JS fallback for canvas/WebGL/scroll-driven values) |
 | `raf` | `measure`, `mutate`, `batch` (DOM batching) |
 | `viewport` | `desktopVW`, `mobileVW`, `desktopVH`, `mobileVH` |
 | `fetch` | `fetchWithTimeout`, `fetchJSON` |


### PR DESCRIPTION
## What this does
Brings the docs in line with `main` as it stands now — after the marketing homepage was removed (#188) and the `useReveal` animation primitive landed (#189) — and applies the CSS-vs-JS animation philosophy consistently across the docs. It also folds in the still-relevant intent of the in-flight `docs/*` branches, which this **supersedes**.

The README and PROD-README are deliberately untouched: their Features list + install command + banner are what oss.darkroom.engineering renders, and none of it was stale.

## Summary
- **Staleness** — `components/effects/README.md` rewritten (the three deleted effects are gone; documents only `gsap.tsx` + `progress-text`, and points reveals at `useReveal`). `components/README.md` and `app/README.md` lose their stale effect imports/rows and the `(marketing)` tree refs + cleanup command.
- **Animation coherence** — `lib/hooks/README.md` documents `useReveal` (table row + example), fixes the `useMediaQuery` import (it's from `hamo`), and swaps the framer-motion reduced-motion example for a CSS one. `lib/styles/README.md` notes `global.css` houses the `[data-reveal]` contract; `lib/utils/README.md` steers `spring()` toward CSS `linear()`.
- **Consolidation** — `ARCHITECTURE.md` trims sections that duplicated AGENTS.md down to pointers (keeping its unique content) and gains a short Animation summary. `lib/README.md` adds the missing `features/` row.
- **CHANGELOG** — `[Unreleased]` entries for the marketing removal (#188), `useReveal` + AGENTS animation section + `spring()` doc (#189), and the Dependabot lockfile CI fix (#190).

## Supersedes
`docs/consolidate-root`, `docs/agents-md`, `docs/readme-accuracy`, `chore/docs-sync` — all based on pre-#188/#189 `main`. The `.cursor/rules`/CLAUDE.md consolidation they pursued already landed on `main`; the rest is captured here against current `main`.

## Test Plan
- [x] `bun run manifest:check` green (no code touched)
- [x] No doc references `split-text` / `animated-gradient` / `liquid-drip` / `app/(marketing)` except the CHANGELOG "Removed" entry
- [x] README / PROD-README unchanged (OSS shape preserved)
