### PR TITLE
fix: kill dev process tree on Windows to stop orphaned node processes

### DIFF
--- a/lib/scripts/dev.ts
+++ b/lib/scripts/dev.ts
@@ -36,11 +36,41 @@ const processes = [
   }),
 ]
 
-// Handle graceful shutdown
-const cleanup = () => {
-  for (const proc of processes) {
-    proc.kill()
+/**
+ * Terminate a spawned child AND all of its descendants.
+ *
+ * `proc.kill()` only signals the direct child. `next dev` forks several
+ * Turbopack workers, and the `bun --watch` style task spawns its own children.
+ * On Windows — which has no Unix-style process groups — killing only the direct
+ * child orphans those grandchildren on every Ctrl-C / crash / restart, and they
+ * pile up as runaway node processes (the "dozens of node.exe and growing" bug).
+ *
+ * `taskkill /T` walks and force-kills the whole tree (run synchronously so it
+ * finishes before we exit). On Unix, a SIGTERM to the child is propagated to its
+ * workers by Next/Bun, so the existing behavior is preserved there.
+ */
+const killTree = (proc: Bun.Subprocess) => {
+  const { pid } = proc
+  if (pid == null) return
+
+  if (process.platform === 'win32') {
+    Bun.spawnSync(['taskkill', '/PID', String(pid), '/T', '/F'])
+  } else {
+    try {
+      proc.kill()
+    } catch {
+      // Process already exited — nothing to clean up.
+    }
   }
+}
+
+// Handle graceful shutdown. Idempotent: a process exiting and an incoming
+// signal can both trigger this, and we must only tear down (and exit) once.
+let shuttingDown = false
+const cleanup = () => {
+  if (shuttingDown) return
+  shuttingDown = true
+  for (const proc of processes) killTree(proc)
   process.exit(0)
 }
 


### PR DESCRIPTION
## What this does
Stops satus's dev launcher from leaking Node processes on Windows. Before this, every time you stopped or restarted `bun dev` on Windows the previous Next.js dev server and its Turbopack workers were left running; they piled up across a session (a teammate saw dozens of node processes and climbing). macOS and Linux were unaffected — this is Windows-only.

## Summary
- `lib/scripts/dev.ts` now tears down the whole process **tree** on shutdown. `proc.kill()` only signals the direct child; Windows has no Unix-style process groups, so the child's descendants (Turbopack workers, the style watcher's children) were orphaned. The new `killTree()` runs `taskkill /PID <pid> /T /F` on Windows (`/T` walks the tree) and keeps the existing `proc.kill()` on Unix (Next forwards SIGTERM to its workers there).
- `cleanup()` is now idempotent — a child exit and an incoming signal can both fire, so it must only tear down once.

## Test plan
- [x] macOS: `bun dev` boots; SIGTERM frees port 3000 with no orphaned `next dev` / worker processes (verified — the Unix path is unchanged).
- [ ] **Windows (needs a check on a Windows box):** `bun dev`, Ctrl-C, then `Get-Process node,bun` shows nothing satus-related; repeat start/stop and confirm the count returns to zero instead of climbing.
