### PR TITLE
chore: add react-doctor CI + fix top React Compiler findings

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -1,0 +1,45 @@
+name: React Doctor
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  react-doctor:
+    runs-on: ubuntu-latest
+
+    # Advisory for now. The step below surfaces React Doctor findings on the
+    # files a PR changes, but does not block the merge — this lets new PRs stay
+    # visible while the existing backlog is paid down incrementally. To turn the
+    # gate on once the backlog is clear, delete this line. The `--diff` scope
+    # already keeps pre-existing issues out of the PR gate (only files the PR
+    # actually touches are scanned), so enforcing later won't retroactively fail
+    # unrelated PRs.
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so `--diff` can resolve the merge-base against the base branch.
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # React Doctor's React Compiler rules (react-hooks-js/*) only activate when
+      # eslint-plugin-react-hooks + the compiler are resolvable, so deps must be installed.
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # --diff <base>   : only scan files changed vs the PR base — keeps the
+      #                   existing backlog out of the gate; new code stays clean.
+      # --blocking error: error-severity findings set a non-zero exit (shown as a
+      #                   failed step; non-blocking today via continue-on-error above).
+      # --no-telemetry  : no score upload / share URL / crash reporting in CI.
+      # Pinned to 0.4.2 for reproducible runs — bump deliberately.
+      - name: Run React Doctor on changed files
+        run: bunx react-doctor@0.4.2 --diff origin/${{ github.base_ref }} --verbose --blocking error --no-telemetry

--- a/components/layout/theme/index.tsx
+++ b/components/layout/theme/index.tsx
@@ -52,11 +52,18 @@ export function Theme({
 }) {
   const pathname = usePathname()
 
+  // `currentTheme` defaults to the route's `theme` prop but can still be
+  // overridden at runtime via the `setTheme` action. When the prop changes
+  // (navigation), we re-sync *during render* — React's recommended replacement
+  // for a setState-in-effect "mirror". This avoids the wasted extra render and
+  // breaks the effect chain into the data-theme effect below.
+  // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
   const [currentTheme, setCurrentTheme] = useState(theme)
-
-  useEffect(() => {
+  const [prevTheme, setPrevTheme] = useState(theme)
+  if (theme !== prevTheme) {
+    setPrevTheme(theme)
     setCurrentTheme(theme)
-  }, [theme])
+  }
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: we need to trigger on path change
   useEffect(() => {

--- a/components/ui/form/fields/index.tsx
+++ b/components/ui/form/fields/index.tsx
@@ -144,9 +144,7 @@ export function TextareaField({
         placeholder={placeholder}
         rows={rows}
         className={s.textarea}
-        ref={reg.ref}
-        onChange={reg.onChange}
-        onBlur={reg.onBlur}
+        {...reg}
       />
       {error?.state && error.message && (
         <Field.Error {...(s.errorMessage && { className: s.errorMessage })}>
@@ -200,7 +198,7 @@ export function CheckboxesField({
         name={name}
         id="hidden"
         value={JSON.stringify(selected)}
-        ref={reg.ref}
+        {...reg}
       />
       <div className={s.options}>
         {options.map(({ label, value }) => (

--- a/components/ui/link/index.tsx
+++ b/components/ui/link/index.tsx
@@ -6,8 +6,7 @@ import {
   type AnchorHTMLAttributes,
   type ComponentProps,
   type MouseEvent,
-  useEffect,
-  useState,
+  useSyncExternalStore,
 } from 'react'
 
 type CustomLinkProps = Omit<
@@ -24,6 +23,34 @@ function isExternalHref(href: string) {
   return href.startsWith('http://') || href.startsWith('https://')
 }
 
+// Browser Network Information API (not in the DOM lib types). Present on Chromium.
+function getConnection():
+  | (EventTarget & { effectiveType: string; saveData: boolean })
+  | undefined {
+  return (
+    navigator as Navigator & {
+      connection?: EventTarget & { effectiveType: string; saveData: boolean }
+    }
+  ).connection
+}
+
+// Prefetch on fast, non-data-saving connections. Exposed via useSyncExternalStore
+// so the value is SSR-safe (server snapshot below) without a mount effect, and
+// re-reads if the connection quality changes.
+function subscribeConnection(onChange: () => void) {
+  const connection = getConnection()
+  connection?.addEventListener('change', onChange)
+  return () => connection?.removeEventListener('change', onChange)
+}
+function getShouldPrefetch() {
+  const connection = getConnection()
+  if (!connection) return true
+  return connection.effectiveType === '4g' && !connection.saveData
+}
+function getServerShouldPrefetch() {
+  return false
+}
+
 export function Link({
   href,
   children,
@@ -34,34 +61,19 @@ export function Link({
   const pathname = usePathname()
   const isActive = Boolean(href && pathname === href)
 
-  // Seed external from the SSR-safe URL pattern so hydration starts in agreement; refine on mount if same-host URL targets a different origin.
-  const [isExternal, setIsExternal] = useState(() =>
-    href ? isExternalHref(href) : false
+  // Derived during render straight from `href`. The string check is
+  // deterministic on both server and client, so the SSR markup and the first
+  // client render always agree — no mirror state + effect needed.
+  const isExternal = href ? isExternalHref(href) : false
+
+  // Prefetch hint from the browser Network Information API. Read via
+  // useSyncExternalStore so it's SSR-safe (server snapshot = false) with no
+  // mount effect, and re-reads if the connection quality changes.
+  const shouldPrefetch = useSyncExternalStore(
+    subscribeConnection,
+    getShouldPrefetch,
+    getServerShouldPrefetch
   )
-  const [shouldPrefetch, setShouldPrefetch] = useState(false)
-
-  useEffect(() => {
-    if (!href) return
-
-    try {
-      const url = new URL(href, window.location.href)
-      setIsExternal(url.host !== window.location.host)
-    } catch {
-      setIsExternal(false)
-    }
-
-    const connection = (
-      navigator as Navigator & {
-        connection?: { effectiveType: string; saveData: boolean }
-      }
-    ).connection
-    if (connection) {
-      const { effectiveType, saveData } = connection
-      setShouldPrefetch(effectiveType === '4g' && !saveData)
-    } else {
-      setShouldPrefetch(true)
-    }
-  }, [href])
 
   // No href + onClick → button
   if (!href && onClick) {

--- a/components/ui/real-viewport/index.tsx
+++ b/components/ui/real-viewport/index.tsx
@@ -169,22 +169,21 @@ export function useViewport<T>(selector: (state: ViewportValues) => T): T
 export function useViewport<T>(
   selector?: (state: ViewportValues) => T
 ): ViewportValues | T {
-  // Cache selector and its result to prevent unnecessary re-renders
-  const selectorRef = useRef(selector)
+  // Cache the last result so getSnapshot returns a stable reference while the
+  // underlying state is unchanged (useSyncExternalStore requires a cached
+  // snapshot). The selector is read straight from the render closure — no ref
+  // needed: getSnapshotWithSelector is rebuilt each render with the current
+  // selector, and the stable subscription is `subscribe`, not this function.
   const resultRef = useRef<T | ViewportValues | undefined>(undefined)
   const stateRef = useRef<ViewportValues | undefined>(undefined)
 
-  // Update selector ref on each render (selector may be inline function)
-  selectorRef.current = selector
-
-  // Create a stable getSnapshot that integrates the selector
-  // This ensures useSyncExternalStore only triggers re-renders
-  // when the selected value actually changes
+  // getSnapshot integrating the selector: only returns a new reference when the
+  // selected value actually changes, so subscribers re-render only on real changes.
   const getSnapshotWithSelector = (): T | ViewportValues => {
     const nextState = getSnapshot()
 
     // If no selector, return full state
-    if (!selectorRef.current) {
+    if (!selector) {
       return nextState
     }
 
@@ -194,7 +193,7 @@ export function useViewport<T>(
     }
 
     // Compute new result
-    const nextResult = selectorRef.current(nextState)
+    const nextResult = selector(nextState)
 
     // If result is the same (by value for primitives), return cached
     if (Object.is(resultRef.current, nextResult)) {
@@ -209,7 +208,7 @@ export function useViewport<T>(
 
   const getServerSnapshotWithSelector = (): T | ViewportValues => {
     const state = getServerSnapshot()
-    return selectorRef.current ? selectorRef.current(state) : state
+    return selector ? selector(state) : state
   }
 
   return useSyncExternalStore(

--- a/lib/dev/stats/index.ts
+++ b/lib/dev/stats/index.ts
@@ -1,16 +1,17 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useState } from 'react'
 import _Stats from 'stats-gl'
 import { useTempus } from 'tempus/react'
 import s from './stats.module.css'
 
 export function Stats() {
-  const statsRef = useRef<_Stats | null>(null)
-  if (!statsRef.current) {
-    statsRef.current = new _Stats({
-      minimal: false,
-    } as ConstructorParameters<typeof _Stats>[0])
-  }
-  const stats = statsRef.current
+  // Instantiate once via a lazy state initializer. The instance is stable for
+  // the component's lifetime and — unlike a ref — is safe to read during render.
+  const [stats] = useState(
+    () =>
+      new _Stats({
+        minimal: false,
+      } as ConstructorParameters<typeof _Stats>[0])
+  )
 
   useEffect(() => {
     const domElement = (stats as unknown as { dom: HTMLElement }).dom

--- a/lib/dev/theatre/hooks/use-theatre.ts
+++ b/lib/dev/theatre/hooks/use-theatre.ts
@@ -16,26 +16,17 @@ export function useTheatreObject(
 ) {
   const [object, setObject] = useState<ISheetObject>()
 
-  // Serialize config to a stable string only when the object reference changes.
-  // This avoids re-serializing on every render while still detecting real config changes.
-  const configRef = useRef(config)
-  const configKeyRef = useRef(JSON.stringify(config))
-  if (configRef.current !== config) {
-    const next = JSON.stringify(config)
-    if (next !== configKeyRef.current) {
-      configKeyRef.current = next
-    }
-    configRef.current = config
-  }
-  const configKey = configKeyRef.current
+  // Serialize config to a value-stable key for the effect dependency below.
+  // JSON.stringify yields an equal string for equal content even when `config`'s
+  // identity changes each render, so the effect re-runs only on real changes —
+  // without reading/writing refs during render (which the compiler can't track).
+  const configKey = JSON.stringify(config)
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: deps spread is intentional
   useEffect(() => {
     if (!sheet) return
 
-    setObject(
-      sheet?.object(theatreKey, configRef.current, { reconfigure: true })
-    )
+    setObject(sheet?.object(theatreKey, config, { reconfigure: true }))
 
     return () => {
       sheet.detachObject(theatreKey)
@@ -61,7 +52,9 @@ export function useTheatre<Config extends UnknownShorthandCompoundProps>(
   { onValuesChange, lazy = true, deps = [] }: UseTheatreOptions<Config> = {}
 ) {
   const onValuesChangeRef = useRef(onValuesChange)
-  onValuesChangeRef.current = onValuesChange
+  useEffect(() => {
+    onValuesChangeRef.current = onValuesChange
+  })
 
   const object = useTheatreObject(sheet, theatreKey, config, deps)
 


### PR DESCRIPTION
## What this does
Adds an advisory React Doctor check to CI and clears the highest-severity findings it flagged. The check scans only the files a PR changes and does not block merges, so new PRs stay clean while the existing backlog is paid down incrementally. The code fixes remove wasted re-renders and let React Compiler optimize components it previously could not — no user-facing behavior change except one minor, documented tweak to external-link detection.

## Summary
- **CI:** `.github/workflows/react-doctor.yml` runs `react-doctor --diff --blocking error --no-telemetry` on PRs, advisory via `continue-on-error`. `--no-telemetry` avoids a score-API network call that can otherwise hang the CLI.
- **theme:** replace a prop→state mirror effect with adjust-during-render. Removes a `setState-in-effect` error and an effect chain. (Two low-severity warnings on the `prevTheme` tracker remain — a known react-doctor limitation: tracking the previous prop value is flagged whether you use `useState` or `useRef`.)
- **link:** derive `isExternal` during render; read the prefetch network hint via `useSyncExternalStore` instead of a mount effect. Minor behavior change: same-origin **absolute** URLs now open in a new tab (string-based external detection).
- **stats / use-theatre / real-viewport / fields:** stop reading refs during render — `useState` create-once for the dev stats meter; drop a manual ref-memo dance; use the selector directly in the viewport store; spread `{...register(idx)}` to match the form's existing idiom.

## Not included (deliberately)
- **flowmaps / fluid `refs` errors:** these GPU sim instances are mutable (must be a ref) yet shared via React context (a render-time read). The `refs` and `immutability` rules are mutually exclusive there without re-architecting how the sims are shared. Left untouched; needs a separate decision.

## Test plan
- [x] `bun run typecheck` clean
- [x] `biome check` clean on touched files
- [x] `react-doctor --diff` confirms the targeted errors are gone
