### PR TITLE
fix: broken crash page (global-error) + scroll-trigger rules-of-hooks

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -15,47 +15,54 @@ export default function GlobalError({
     console.error('Global error boundary caught:', error)
   }, [error])
 
+  // global-error.tsx replaces the root layout when a root-level error occurs,
+  // so it must render its own <html> and <body>. Without them Next.js renders
+  // broken, unstyled HTML at the worst possible moment for the user.
   return (
-    <Wrapper theme="light" className="font-mono" webgl>
-      <div className="dr-gap-y-24 my-auto flex flex-col items-center justify-center uppercase">
-        <h1 className="mb-4 font-bold text-4xl">Critical Error</h1>
-        <p className="mb-6 text-gray-600 text-lg">
-          A critical error occurred. Please refresh the page or contact support
-          if the problem persists.
-        </p>
+    <html lang="en">
+      <body>
+        <Wrapper theme="light" className="font-mono" webgl>
+          <div className="dr-gap-y-24 my-auto flex flex-col items-center justify-center uppercase">
+            <h1 className="mb-4 font-bold text-4xl">Critical Error</h1>
+            <p className="mb-6 text-gray-600 text-lg">
+              A critical error occurred. Please refresh the page or contact
+              support if the problem persists.
+            </p>
 
-        {process.env.NODE_ENV === 'development' && (
-          <details className="mb-6 text-left">
-            <summary className="cursor-pointer text-gray-500 text-sm hover:text-gray-700">
-              Error Details (Development Only)
-            </summary>
-            <pre className="mt-2 overflow-auto rounded bg-gray-100 p-4 text-xs">
-              {error.message}
-              {error.digest && `\nDigest: ${error.digest}`}
-              {error.stack && `\n\n${error.stack}`}
-            </pre>
-          </details>
-        )}
+            {process.env.NODE_ENV === 'development' && (
+              <details className="mb-6 text-left">
+                <summary className="cursor-pointer text-gray-500 text-sm hover:text-gray-700">
+                  Error Details (Development Only)
+                </summary>
+                <pre className="mt-2 overflow-auto rounded bg-gray-100 p-4 text-xs">
+                  {error.message}
+                  {error.digest && `\nDigest: ${error.digest}`}
+                  {error.stack && `\n\n${error.stack}`}
+                </pre>
+              </details>
+            )}
 
-        <div className="flex justify-center gap-4">
-          <button
-            onClick={reset}
-            type="button"
-            className="rounded bg-black px-6 py-3 text-white transition-colors hover:bg-gray-800"
-          >
-            Try Again
-          </button>
-          <button
-            onClick={() => {
-              window.location.href = '/'
-            }}
-            type="button"
-            className="rounded border border-gray-300 px-6 py-3 transition-colors hover:bg-gray-50"
-          >
-            Go Home
-          </button>
-        </div>
-      </div>
-    </Wrapper>
+            <div className="flex justify-center gap-4">
+              <button
+                onClick={reset}
+                type="button"
+                className="rounded bg-black px-6 py-3 text-white transition-colors hover:bg-gray-800"
+              >
+                Try Again
+              </button>
+              <button
+                onClick={() => {
+                  window.location.href = '/'
+                }}
+                type="button"
+                className="rounded border border-gray-300 px-6 py-3 transition-colors hover:bg-gray-50"
+              >
+                Go Home
+              </button>
+            </div>
+          </div>
+        </Wrapper>
+      </body>
+    </html>
   )
 }

--- a/components/layout/lenis/scroll-trigger.tsx
+++ b/components/layout/lenis/scroll-trigger.tsx
@@ -1,7 +1,7 @@
 import gsap from 'gsap'
 import { ScrollTrigger as GSAPScrollTrigger } from 'gsap/ScrollTrigger'
 import { useLenis } from 'lenis/react'
-import { useEffect, useEffectEvent } from 'react'
+import { useEffect } from 'react'
 
 // Register ScrollTrigger once
 if (typeof window !== 'undefined') {
@@ -12,6 +12,18 @@ if (typeof window !== 'undefined') {
   //   })
 }
 
+// Stable, non-reactive handlers. They only call GSAP ScrollTrigger statics, so
+// they belong at module scope. They were previously useEffectEvent functions
+// passed into useLenis() — but Effect Event functions must not be passed to
+// other hooks (rules-of-hooks), and these read no reactive state anyway.
+function handleUpdate() {
+  GSAPScrollTrigger.update()
+}
+
+function handleRefresh() {
+  GSAPScrollTrigger.refresh()
+}
+
 /**
  * Syncs GSAP ScrollTrigger with Lenis scroll position.
  * Must be rendered inside ReactLenis context.
@@ -20,14 +32,6 @@ export function LenisScrollTriggerSync() {
   useEffect(() => {
     GSAPScrollTrigger.update()
   }, [])
-
-  const handleUpdate = useEffectEvent(() => {
-    GSAPScrollTrigger.update()
-  })
-
-  const handleRefresh = useEffectEvent(() => {
-    GSAPScrollTrigger.refresh()
-  })
 
   const lenis = useLenis(handleUpdate)
 


### PR DESCRIPTION
## What this does
Fixes the two genuine correctness bugs React Doctor flagged. The bigger one: when the app hits a root-level crash, the fallback error page rendered **without `<html>`/`<body>`** — broken, unstyled HTML at the worst possible moment. Now it renders correctly.

## Summary
- **app/global-error.tsx** — wrap the error UI in `<html><body>`. `global-error.tsx` *replaces* the root layout on a root-level error, so it must supply its own document shell.
- **components/layout/lenis/scroll-trigger.tsx** — `handleUpdate`/`handleRefresh` were `useEffectEvent` functions passed into `useLenis()`, which violates rules-of-hooks. They only call GSAP statics (no reactive state), so they're now stable module-scope functions.

## Deliberately not included
React Doctor flagged five more in this set; reading the code, they break down as:
- **False positives:** marquee `no-array-index-as-key` (static repeated content, never reorders — already `biome-ignore`d) and theatre-studio `hydration-mismatch` (`new Date()` is inside an `onClick`, not render).
- **Deferred (needs care, not a quick fix):** `use-webgl-rect` rules-of-hooks ×2 (a latest-ref refactor against the per-frame hook contract — regression risk in WebGL transform sync), `tunnel` static-components (`useContextBridge` library hook — you can't hoist a hook-created component), and theatre `no-fetch-in-effect` (dev-only, already guarded).

## Test plan
- [x] `bun run typecheck` clean
- [x] `biome` clean
- [x] `react-doctor --diff` shows both targeted errors cleared
- [ ] Manual: trigger a root error in dev, confirm the crash page renders styled (not bare HTML)
