### PR TITLE
ci: rename Test workflow to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Test
+name: CI
 permissions:
   contents: read
 
@@ -9,7 +9,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  ci:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## What this does
Renames the `Test` GitHub Actions workflow to `CI`. The old name was misleading: this workflow doesn't just run tests — it builds, type-checks (tsgo), lints (Biome), runs the test suite, and verifies the generated `COMPONENTS.md` manifest. "CI" reflects that it's the core quality gate for every push and PR.

## Summary
- `.github/workflows/test.yml` → `.github/workflows/ci.yml`
- Workflow `name: Test` → `name: CI`; job `test` → `ci`
- No behavior change — identical steps and triggers.
- `main` is not branch-protected, so there's no required-status-check name to update.

## Test plan
- [x] Steps/triggers unchanged; only names + file path renamed.
