### PR TITLE
refactor: break circular imports in shopify cart and webgl canvas

### DIFF
--- a/lib/integrations/shopify/cart/cart-context.tsx
+++ b/lib/integrations/shopify/cart/cart-context.tsx
@@ -1,68 +1,26 @@
 'use client'
 
 import type { ReactNode } from 'react'
-import { createContext, use, useOptimistic } from 'react'
-import type { StandardContext } from '@/utils/context'
+import { useOptimistic } from 'react'
 import type { Cart, Product, ProductVariant } from '../types'
+import {
+  type CartActions,
+  CartContext,
+  type CartContextStandard,
+  type CartMeta,
+  type CartState,
+} from './cart-store-context'
 import { CartModal } from './modal'
 import type { CartAction } from './optimistic-utils'
 import { cartReconciler } from './optimistic-utils'
 
-// Standard context state
-export interface CartState {
-  cart: Cart | undefined
-}
-
-// Standard context actions
-export interface CartActions {
-  updateCartItem: (
-    merchandiseId: string,
-    updateType: 'plus' | 'minus' | 'delete'
-  ) => void
-  addCartItem: (
-    variant: ProductVariant | undefined,
-    product: Product,
-    quantity?: number
-  ) => void
-}
-
-// Standard context meta (computed values)
-export interface CartMeta {
-  totalQuantity: () => number
-}
-
-// Standard context type
-export type CartContextStandard = StandardContext<
-  CartState,
-  CartActions,
-  CartMeta
->
+export { useCartContext } from './cart-store-context'
+// Re-export types and hook so existing import paths keep working
+export type { CartActions, CartContextStandard, CartMeta, CartState }
 
 interface CartProviderProps {
   children: ReactNode
   cart?: Cart | undefined
-}
-
-const CartContext = createContext<CartContextStandard | null>(null)
-
-/**
- * Hook to access the cart context with standard structure.
- * Returns { state, actions, meta } for new implementations.
- *
- * @example
- * ```tsx
- * const { state, actions, meta } = useCartContext()
- * const { cart } = state
- * const { addCartItem, updateCartItem } = actions
- * const quantity = meta?.totalQuantity()
- * ```
- */
-export function useCartContext(): CartContextStandard {
-  const context = use(CartContext)
-  if (!context) {
-    throw new Error('useCartContext must be used within a CartProvider')
-  }
-  return context
 }
 
 export function CartProvider({ children, cart }: CartProviderProps) {

--- a/lib/integrations/shopify/cart/cart-store-context.ts
+++ b/lib/integrations/shopify/cart/cart-store-context.ts
@@ -1,0 +1,57 @@
+'use client'
+
+import { createContext, use } from 'react'
+import type { StandardContext } from '@/utils/context'
+import type { Cart, Product, ProductVariant } from '../types'
+
+// Standard context state
+export interface CartState {
+  cart: Cart | undefined
+}
+
+// Standard context actions
+export interface CartActions {
+  updateCartItem: (
+    merchandiseId: string,
+    updateType: 'plus' | 'minus' | 'delete'
+  ) => void
+  addCartItem: (
+    variant: ProductVariant | undefined,
+    product: Product,
+    quantity?: number
+  ) => void
+}
+
+// Standard context meta (computed values)
+export interface CartMeta {
+  totalQuantity: () => number
+}
+
+// Standard context type
+export type CartContextStandard = StandardContext<
+  CartState,
+  CartActions,
+  CartMeta
+>
+
+export const CartContext = createContext<CartContextStandard | null>(null)
+
+/**
+ * Hook to access the cart context with standard structure.
+ * Returns { state, actions, meta } for new implementations.
+ *
+ * @example
+ * ```tsx
+ * const { state, actions, meta } = useCartContext()
+ * const { cart } = state
+ * const { addCartItem, updateCartItem } = actions
+ * const quantity = meta?.totalQuantity()
+ * ```
+ */
+export function useCartContext(): CartContextStandard {
+  const context = use(CartContext)
+  if (!context) {
+    throw new Error('useCartContext must be used within a CartProvider')
+  }
+  return context
+}

--- a/lib/integrations/shopify/cart/modal/index.tsx
+++ b/lib/integrations/shopify/cart/modal/index.tsx
@@ -7,7 +7,7 @@ import { createContext, use, useState } from 'react'
 import { Image } from '@/components/ui/image'
 import { Link } from '@/components/ui/link'
 import { removeItem, updateItemQuantity } from '../actions'
-import { useCartContext } from '../cart-context'
+import { useCartContext } from '../cart-store-context'
 import s from './modal.module.css'
 
 interface ModalContextType {

--- a/lib/webgl/components/canvas/canvas-context.ts
+++ b/lib/webgl/components/canvas/canvas-context.ts
@@ -1,0 +1,11 @@
+'use client'
+
+import { createContext } from 'react'
+import type tunnel from 'tunnel-rat'
+
+export type CanvasContextValue = {
+  WebGLTunnel?: ReturnType<typeof tunnel>
+  DOMTunnel?: ReturnType<typeof tunnel>
+}
+
+export const CanvasContext = createContext<CanvasContextValue>({})

--- a/lib/webgl/components/canvas/index.tsx
+++ b/lib/webgl/components/canvas/index.tsx
@@ -1,17 +1,15 @@
 'use client'
 
 import dynamic from 'next/dynamic'
-import {
-  createContext,
-  type PropsWithChildren,
-  use,
-  useLayoutEffect,
-  useState,
-} from 'react'
+import { type PropsWithChildren, use, useLayoutEffect, useState } from 'react'
 import tunnel from 'tunnel-rat'
 import { useShallow } from 'zustand/react/shallow'
 import { useDeviceDetection } from '@/lib/hooks/use-device-detection'
 import { useWebGLStore } from '@/lib/webgl/store'
+import { CanvasContext, type CanvasContextValue } from './canvas-context'
+
+// Re-export CanvasContext so existing import paths keep working
+export { CanvasContext } from './canvas-context'
 
 const WebGLCanvas = dynamic(
   () => import('./webgl').then(({ WebGLCanvas }) => WebGLCanvas),
@@ -19,11 +17,6 @@ const WebGLCanvas = dynamic(
     ssr: false,
   }
 )
-
-type CanvasContextValue = {
-  WebGLTunnel?: ReturnType<typeof tunnel>
-  DOMTunnel?: ReturnType<typeof tunnel>
-}
 
 type CanvasProps = PropsWithChildren<{
   /**
@@ -41,8 +34,6 @@ type CanvasProps = PropsWithChildren<{
    */
   local?: boolean
 }>
-
-export const CanvasContext = createContext<CanvasContextValue>({})
 
 /**
  * Canvas component that provides WebGL context and tunnel system.

--- a/lib/webgl/components/canvas/webgl.tsx
+++ b/lib/webgl/components/canvas/webgl.tsx
@@ -13,7 +13,7 @@ import { SheetProvider } from '@/lib/dev/theatre'
 import { FlowmapProvider } from '@/webgl/components/flowmap-provider'
 import { PostProcessing } from '@/webgl/components/postprocessing'
 import { RAF } from '@/webgl/components/raf'
-import { CanvasContext } from './'
+import { CanvasContext } from './canvas-context'
 import s from './webgl.module.css'
 
 type WebGLCanvasProps = React.HTMLAttributes<HTMLDivElement> & {


### PR DESCRIPTION
## What this does
Breaks the two circular import cycles deslop flagged, at the root. No behavior change — it only moves where two React contexts are *defined* so the modules stop importing each other in a loop.

## Why it matters
Circular imports are init-order landmines: depending on which file evaluates first, an imported binding can be `undefined` at module-eval time, causing intermittent, hard-to-debug failures. Breaking them removes that whole class of risk.

## Summary
Both cycles had the same shape — context defined in the index/provider file, a child component importing it back, the index importing the child. Fix: extract each context into its own leaf module.
- **Shopify cart:** new `cart-store-context.ts` holds `CartContext` + `useCartContext` + types. `cart-context.tsx` (provider) and `modal/index.tsx` both import from it. `cart-context.tsx` re-exports the symbols so `add-to-cart` and the `show-cart` example keep working unchanged.
- **WebGL canvas:** new `canvas-context.ts` holds `CanvasContext`. `canvas/index.tsx` and `webgl.tsx` both import from it; `index.tsx` re-exports `CanvasContext`.

## Test plan
- [x] `bun run typecheck` → 0 errors
- [x] `react-doctor` full scan → no `circular-dependency` findings remain
- [x] Diff reviewed: pure extraction + re-export rewiring, no logic changes
