### PR TITLE
refactor: apply nuclear-review findings (boundary validation, cart types, dedup)

### DIFF
--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -80,16 +80,6 @@ Quick-reference for every component, hook, and utility in the Satus starter kit.
 | ease | `(progress: number, easeName: EasingName) => number` |
 | fromTo | `(entries: | number | (number | HTMLElement | null | Element | undefined)[] | HTMLElement | Element | null | undefined, from: FromToValue = 0, to: FromToValue = 1, progress = 0, options: FromToOptions = {}) => void` |
 | spring | `(current: number, target: number, velocity: number, stiffness = 200, damping = 20, deltaTime = 1 / 60) => { value: number; velocity: number }` |
-| EasingName | `keyof typeof easings` |
-| easings | `{ readonly linear: (x: number) => number; readonly easeInQuad: (x: number) =>...` |
-| clamp | `(min: number, input: number, max: number) => number` |
-| lerp | `(start: number, end: number, amount: number) => number` |
-| mapRange | `(inMin: number, inMax: number, input: number, outMin: number, outMax: number, shouldClamp = false) => number` |
-| modulo | `(n: number, d: number) => number` |
-| truncate | `(value: number, decimals: number) => number` |
-| batch | `(reads: { [K in keyof T]: () => T[K] }, write: (results: T) => void) => Promise<void>` |
-| measure | `(fn: () => T) => Promise<T>` |
-| mutate | `(fn: () => T) => Promise<T>` |
 | FromToOptions |  |
 | FromToValue | `| number | Record<string, number | ((index: number) => number)>` |
 
@@ -177,6 +167,7 @@ Quick-reference for every component, hook, and utility in the Satus starter kit.
 |--------|-----------|
 | parseFormData | `(schema: z.ZodType<T>, formData: FormData) => FormState<T> | { success: true; data: T }` |
 | zodToValidator | `(schema: z.ZodType) => (value: string) => boolean` |
+| parseApiResponse | `(schema: z.ZodType<T>, data: unknown, context?: string) => T` |
 | emailSchema | `ZodEmail` |
 | phoneSchema | `ZodString` |
 | sanityEnvSchema | `ZodObject<{ NEXT_PUBLIC_SANITY_PROJECT_ID: ZodString; NEXT_PUBLIC_SANITY_DATA...` |

--- a/components/ui/marquee/index.tsx
+++ b/components/ui/marquee/index.tsx
@@ -5,7 +5,7 @@ import { useIntersectionObserver, useResizeObserver } from 'hamo'
 import { useLenis } from 'lenis/react'
 import { type HTMLAttributes, useId, useRef } from 'react'
 import { useTempus } from 'tempus/react'
-import { modulo } from '@/utils/animation'
+import { modulo } from '@/utils/math'
 import s from './marquee.module.css'
 
 function getHash(input: string) {

--- a/lib/integrations/hubspot/fetch-form.ts
+++ b/lib/integrations/hubspot/fetch-form.ts
@@ -1,34 +1,57 @@
+import { z } from 'zod'
 import { fetchWithTimeout } from '@/utils/fetch'
 import { stripHtmlTags } from '@/utils/strings'
+import { parseApiResponse } from '@/utils/validation'
 
-interface HubspotFormResponse {
-  fieldGroups: Array<{ fields: unknown[] }>
-  legalConsentOptions?: unknown
-  displayOptions: { submitButtonText?: string }
-  configuration: { postSubmitAction: { type: string; value: string | null } }
-}
+// ---------------------------------------------------------------------------
+// Zod schemas for the HubSpot forms API response
+// ---------------------------------------------------------------------------
 
-interface HubSpotFormField {
-  name: string
-  label: string
-  placeholder?: string
-  required: boolean
-  fieldType: string
-  hidden?: boolean
-  helpText?: string
-  options?: Array<{ label: string; value: string }>
-}
+const hubspotFieldSchema = z.object({
+  name: z.string(),
+  label: z.string(),
+  placeholder: z.string().optional(),
+  required: z.boolean(),
+  fieldType: z.string(),
+  hidden: z.boolean().optional(),
+  helpText: z.string().optional(),
+  options: z
+    .array(z.object({ label: z.string(), value: z.string() }))
+    .optional(),
+})
 
-interface HubSpotLegalConsentOption {
-  subscriptionTypeId: string
-  label: string
-}
+const hubspotLegalConsentOptionsSchema = z.object({
+  communicationsCheckboxes: z
+    .array(
+      z.object({
+        subscriptionTypeId: z.string(),
+        label: z.string(),
+      })
+    )
+    .optional(),
+  privacyText: z.string().optional(),
+  consentToProcessText: z.string().optional(),
+})
 
-interface HubSpotLegalConsentOptions {
-  communicationsCheckboxes?: HubSpotLegalConsentOption[]
-  privacyText?: string
-  consentToProcessText?: string
-}
+const hubspotFormResponseSchema = z.object({
+  fieldGroups: z.array(
+    z.object({
+      fields: z.array(hubspotFieldSchema),
+    })
+  ),
+  legalConsentOptions: hubspotLegalConsentOptionsSchema.optional(),
+  displayOptions: z.object({
+    submitButtonText: z.string().optional(),
+  }),
+  configuration: z.object({
+    postSubmitAction: z.object({
+      type: z.string(),
+      value: z.string().nullable(),
+    }),
+  }),
+})
+
+type HubspotFormResponse = z.infer<typeof hubspotFormResponseSchema>
 
 export interface HubSpotParsedForm {
   portalId: string | undefined
@@ -38,7 +61,6 @@ export interface HubSpotParsedForm {
     label: string
     placeholder: string
     required: boolean
-    hubspotType: string
     type: string
     hidden: boolean | undefined
     helpText: string
@@ -63,14 +85,7 @@ export interface HubSpotParsedForm {
 // endpoint is public and doesn't need the full SDK. If server-side form
 // operations grow (e.g., creating forms, managing contacts), consider
 // switching to the SDK which is already installed as a devDependency.
-async function hubspotFormApi(id: string | null | undefined) {
-  // Guard against null/undefined form ID
-  if (!id) {
-    throw new Error(
-      'HubSpot form ID is not configured. Set NEXT_HUBSPOT_FORM_ID in your environment variables.'
-    )
-  }
-
+async function hubspotFormApi(id: string) {
   const accessToken = process.env.HUBSPOT_ACCESS_TOKEN
   if (!accessToken) {
     throw new Error(
@@ -91,47 +106,33 @@ async function hubspotFormApi(id: string | null | undefined) {
   if (!resp.ok) {
     throw new Error(`Failed to fetch form data: ${resp.status}`)
   }
-  const response = (await resp.json()) as HubspotFormResponse
 
-  if (!(response.fieldGroups && Array.isArray(response.fieldGroups))) {
-    throw new Error(
-      'Invalid HubSpot form response: missing fieldGroups property.'
-    )
-  }
+  const json: unknown = await resp.json()
+  const response = parseApiResponse(
+    hubspotFormResponseSchema,
+    json,
+    'HubSpot forms API'
+  )
 
   return apiParser(id, response)
 }
 
 function apiParser(id: string, data: HubspotFormResponse) {
-  const typeSetter = (type: string) => {
-    switch (type) {
-      case 'phone':
-        return 'single_line_text'
-      case 'email':
-        return 'single_line_text'
-      default:
-        return type
-    }
-  }
-
-  // Fix: Use proper type assertion and optional chaining
-  const legalConsentOptions =
-    (data?.legalConsentOptions as HubSpotLegalConsentOptions)
-      ?.communicationsCheckboxes || null
+  const communicationsCheckboxes =
+    data.legalConsentOptions?.communicationsCheckboxes ?? null
+  const firstCheckbox = communicationsCheckboxes?.[0] ?? null
 
   return {
     portalId: process.env.NEXT_PUBLIC_HUBSPOT_PORTAL_ID,
     id: id,
     inputs: data.fieldGroups
-      .filter((item) => item.fields[0] != null)
-      .map((item) => {
-        const flatData = item.fields[0] as HubSpotFormField
+      .flatMap((item) => (item.fields[0] != null ? [item.fields[0]] : []))
+      .map((flatData) => {
         return {
           name: flatData.name || '',
           label: flatData.label || '',
           placeholder: flatData.placeholder || '',
           required: flatData.required,
-          hubspotType: typeSetter(flatData.fieldType),
           type: flatData.fieldType || '',
           hidden: flatData.hidden,
           helpText: flatData.helpText || '',
@@ -143,20 +144,14 @@ function apiParser(id: string, data: HubspotFormResponse) {
     submitButton: {
       text: data.displayOptions.submitButtonText || 'Submit',
     },
-    legalConsent: legalConsentOptions?.[0]
+    legalConsent: firstCheckbox
       ? {
           required: true,
-          subscriptionTypeId: legalConsentOptions[0].subscriptionTypeId,
-          label: stripHtmlTags(legalConsentOptions[0].label),
+          subscriptionTypeId: firstCheckbox.subscriptionTypeId,
+          label: stripHtmlTags(firstCheckbox.label),
           disclaimer: [
-            stripHtmlTags(
-              (data.legalConsentOptions as HubSpotLegalConsentOptions)
-                .privacyText || ''
-            ),
-            stripHtmlTags(
-              (data.legalConsentOptions as HubSpotLegalConsentOptions)
-                .consentToProcessText || ''
-            ),
+            stripHtmlTags(data.legalConsentOptions?.privacyText || ''),
+            stripHtmlTags(data.legalConsentOptions?.consentToProcessText || ''),
           ],
         }
       : { required: false },
@@ -174,6 +169,14 @@ type GetFormResult = GetFormSuccess | GetFormError
 export async function getForm(
   formId: string | null | undefined = null
 ): Promise<GetFormResult> {
+  // Null-guard in the public wrapper; internal hubspotFormApi only accepts string
+  if (!formId) {
+    return {
+      error:
+        'HubSpot form ID is not configured. Set NEXT_HUBSPOT_FORM_ID in your environment variables.',
+    }
+  }
+
   try {
     const result: GetFormSuccess = {
       form: await hubspotFormApi(formId),

--- a/lib/integrations/mailchimp/action.ts
+++ b/lib/integrations/mailchimp/action.ts
@@ -79,13 +79,10 @@ export async function mailchimpSubscriptionAction(
     run: async (input) => {
       const result = await addSubscriberToMailchimp(input)
       if (!result.success) {
-        let errorMessage = 'subscription_failed_'
-        if (
-          result.error?.includes('fake') ||
-          result.error?.includes('invalid')
-        ) {
-          errorMessage = 'invalid_email_'
-        }
+        const errorMessage =
+          result.errorCode === 'invalid_email'
+            ? 'invalid_email_'
+            : 'subscription_failed_'
 
         console.error('Mailchimp subscription failed:', result.error)
         return { status: 500, message: errorMessage }

--- a/lib/integrations/mailchimp/mailchimp-client.ts
+++ b/lib/integrations/mailchimp/mailchimp-client.ts
@@ -1,5 +1,7 @@
 import { createHash } from 'node:crypto'
+import { z } from 'zod'
 import { fetchWithTimeout } from '@/utils/fetch'
+import { parseApiResponse } from '@/utils/validation'
 
 export interface MailchimpConfig {
   apiKey: string
@@ -19,6 +21,21 @@ export interface SubscriptionData {
   firstName?: string | undefined
   lastName?: string | undefined
 }
+
+// Typed error codes surfaced to callers
+export type MailchimpErrorCode = 'invalid_email' | 'network_error' | 'api_error'
+
+export interface MailchimpResult {
+  success: boolean
+  errorCode?: MailchimpErrorCode
+  /** Human-readable detail; not for UI routing — use errorCode for that */
+  error?: string
+}
+
+// Zod schema for the Mailchimp member PUT response (only fields we consume)
+const mailchimpMemberResponseSchema = z.object({
+  id: z.string(),
+})
 
 // Mailchimp API error response type
 interface MailchimpErrorResponse {
@@ -69,7 +86,7 @@ async function makeMailchimpRequest(
   })
 }
 
-// Apply tags to a member via the dedicated tags endpoint
+// Apply tags to a member via the dedicated tags endpoint (best-effort)
 async function applyMemberTags(
   audienceId: string,
   email: string,
@@ -85,10 +102,81 @@ async function applyMemberTags(
   })
 }
 
+// ---------------------------------------------------------------------------
+// Private helper: upsert a member via PUT
+// ---------------------------------------------------------------------------
+
+interface UpsertMemberOptions {
+  audienceId: string
+  email: string
+  firstName: string
+  lastName: string
+}
+
+/**
+ * PUT a member into the audience. Returns the validated member response on
+ * success, or a MailchimpResult error on failure.
+ */
+async function upsertMember(
+  opts: UpsertMemberOptions
+): Promise<
+  { ok: true; memberId: string } | { ok: false; result: MailchimpResult }
+> {
+  const { audienceId, email, firstName, lastName } = opts
+  const hash = subscriberHash(email)
+
+  const subscriberData = {
+    email_address: email,
+    status_if_new: 'subscribed',
+    status: 'subscribed',
+    merge_fields: {
+      FNAME: firstName,
+      LNAME: lastName,
+    },
+  }
+
+  const response = await makeMailchimpRequest(
+    `/lists/${audienceId}/members/${hash}`,
+    {
+      method: 'PUT',
+      body: JSON.stringify(subscriberData),
+    }
+  )
+
+  if (response.ok) {
+    const json: unknown = await response.json()
+    const member = parseApiResponse(
+      mailchimpMemberResponseSchema,
+      json,
+      'Mailchimp members API'
+    )
+    return { ok: true, memberId: member.id }
+  }
+
+  const errorData = (await response.json()) as MailchimpErrorResponse
+  const detail = errorData.detail || 'Failed to add/update member'
+
+  // Classify the error so callers can branch by code, not string-sniff
+  const lowerDetail = detail.toLowerCase()
+  const errorCode: MailchimpErrorCode =
+    lowerDetail.includes('fake') || lowerDetail.includes('invalid')
+      ? 'invalid_email'
+      : 'api_error'
+
+  return {
+    ok: false,
+    result: { success: false, errorCode, error: detail },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
 // Add or update a contact in Mailchimp
 export async function addContactToMailchimp(
   contactData: ContactData
-): Promise<{ success: boolean; error?: string }> {
+): Promise<MailchimpResult> {
   try {
     const { audienceId } = getMailchimpConfig()
 
@@ -97,100 +185,86 @@ export async function addContactToMailchimp(
     const firstName = nameParts[0] || ''
     const lastName = nameParts.slice(1).join(' ') || ''
 
-    const hash = subscriberHash(contactData.email)
+    const upsert = await upsertMember({
+      audienceId,
+      email: contactData.email,
+      firstName,
+      lastName,
+    })
 
-    const subscriberData = {
-      email_address: contactData.email,
-      status_if_new: 'subscribed',
-      status: 'subscribed',
-      merge_fields: {
-        FNAME: firstName,
-        LNAME: lastName,
-      },
+    if (!upsert.ok) {
+      return upsert.result
     }
 
-    const response = await makeMailchimpRequest(
-      `/lists/${audienceId}/members/${hash}`,
-      {
-        method: 'PUT',
-        body: JSON.stringify(subscriberData),
-      }
-    )
+    // --- best-effort: tag and note failures do NOT fail the overall op ---
 
-    if (response.ok) {
-      // Apply the contact-form tag via the dedicated tags endpoint
+    try {
       await applyMemberTags(audienceId, contactData.email, ['contact-form'])
+    } catch (err) {
+      console.error('Mailchimp contact tag error (non-fatal):', err)
+    }
 
-      // Add a note about the contact form submission
-      const data = (await response.json()) as { id: string }
-      const subscriberId = data.id
-
-      const noteData = {
-        note: `Contact form submission - Subject: ${contactData.subject}\n\nMessage: ${contactData.message}`,
-      }
-
+    try {
       await makeMailchimpRequest(
-        `/lists/${audienceId}/members/${subscriberId}/notes`,
+        `/lists/${audienceId}/members/${upsert.memberId}/notes`,
         {
           method: 'POST',
-          body: JSON.stringify(noteData),
+          body: JSON.stringify({
+            note: `Contact form submission - Subject: ${contactData.subject}\n\nMessage: ${contactData.message}`,
+          }),
         }
       )
+    } catch (err) {
+      console.error('Mailchimp contact note error (non-fatal):', err)
+    }
 
-      return { success: true }
-    }
-    const errorData = (await response.json()) as MailchimpErrorResponse
-    return {
-      success: false,
-      error: errorData.detail || 'Failed to add contact',
-    }
+    return { success: true }
   } catch (error) {
     console.error('Mailchimp contact error:', error)
-    return { success: false, error: 'Network error occurred' }
+    return {
+      success: false,
+      errorCode: 'network_error',
+      error: 'Network error occurred',
+    }
   }
 }
 
 // Add a subscriber to Mailchimp (for newsletter signups)
 export async function addSubscriberToMailchimp(
   subscriptionData: SubscriptionData
-): Promise<{ success: boolean; error?: string }> {
+): Promise<MailchimpResult> {
   try {
     const { audienceId } = getMailchimpConfig()
 
-    const hash = subscriberHash(subscriptionData.email)
+    const upsert = await upsertMember({
+      audienceId,
+      email: subscriptionData.email,
+      firstName: subscriptionData.firstName ?? '',
+      lastName: subscriptionData.lastName ?? '',
+    })
 
-    const subscriberData = {
-      email_address: subscriptionData.email,
-      status_if_new: 'subscribed',
-      status: 'subscribed',
-      merge_fields: {
-        FNAME: subscriptionData.firstName ?? '',
-        LNAME: subscriptionData.lastName ?? '',
-      },
+    if (!upsert.ok) {
+      console.error(
+        'Mailchimp subscription error:',
+        upsert.result.error || 'Failed to subscribe'
+      )
+      return upsert.result
     }
 
-    const response = await makeMailchimpRequest(
-      `/lists/${audienceId}/members/${hash}`,
-      {
-        method: 'PUT',
-        body: JSON.stringify(subscriberData),
-      }
-    )
-
-    if (response.ok) {
-      // Apply the newsletter tag via the dedicated tags endpoint
+    // best-effort tag application
+    try {
       await applyMemberTags(audienceId, subscriptionData.email, ['newsletter'])
-      return { success: true }
+    } catch (err) {
+      console.error('Mailchimp newsletter tag error (non-fatal):', err)
     }
 
-    const errorData = (await response.json()) as MailchimpErrorResponse
-    console.error(
-      'Mailchimp subscription error:',
-      errorData.detail || 'Failed to subscribe'
-    )
-    return { success: false, error: errorData.detail || 'Failed to subscribe' }
+    return { success: true }
   } catch (error) {
     console.error('Mailchimp subscription error:', error)
-    return { success: false, error: 'Network error occurred' }
+    return {
+      success: false,
+      errorCode: 'network_error',
+      error: 'Network error occurred',
+    }
   }
 }

--- a/lib/integrations/mailchimp/turnstile.ts
+++ b/lib/integrations/mailchimp/turnstile.ts
@@ -87,19 +87,5 @@ export async function validateFormWithTurnstile(formData: FormData): Promise<{
   errors: string[]
 }> {
   const turnstileToken = formData.get('cf-turnstile-response')?.toString() || ''
-
-  // In development, gracefully skip Turnstile validation
-  if (process.env.NODE_ENV === 'development') {
-    console.log('Development mode: Skipping Turnstile validation')
-    return { isValid: true, errors: [] }
-  }
-
-  if (!turnstileToken) {
-    return {
-      isValid: false,
-      errors: ['security_verification_required_'],
-    }
-  }
-
-  return await validateTurnstile(turnstileToken)
+  return validateTurnstile(turnstileToken)
 }

--- a/lib/integrations/shopify/cart-operations.ts
+++ b/lib/integrations/shopify/cart-operations.ts
@@ -8,7 +8,31 @@ import {
 } from './mutations/cart'
 import { getCartQuery } from './queries/cart'
 import { removeEdgesAndNodes } from './reshape'
-import type { Cart, CartLineInput, ShopifyCart } from './types'
+import type {
+  Cart,
+  CartLineInput,
+  CartLineItem,
+  ShopifyCart,
+  ShopifyCartLineItem,
+} from './types'
+
+const reshapeCartLineItem = (item: ShopifyCartLineItem): CartLineItem => ({
+  id: item.id,
+  quantity: item.quantity,
+  cost: item.cost,
+  merchandise: {
+    ...item.merchandise,
+    product: {
+      ...item.merchandise.product,
+      featuredImage: item.merchandise.product.featuredImage
+        ? {
+            ...item.merchandise.product.featuredImage,
+            altText: item.merchandise.product.featuredImage.altText ?? '',
+          }
+        : null,
+    },
+  },
+})
 
 const reshapeCart = (cart: ShopifyCart): Cart => {
   const totalTaxAmount = cart.cost?.totalTaxAmount ?? {
@@ -16,13 +40,17 @@ const reshapeCart = (cart: ShopifyCart): Cart => {
     currencyCode: 'USD',
   }
 
+  const lines: CartLineItem[] = removeEdgesAndNodes(cart.lines).map(
+    reshapeCartLineItem
+  )
+
   return {
     ...cart,
     cost: {
       ...cart.cost,
       totalTaxAmount,
     },
-    lines: removeEdgesAndNodes(cart.lines) as Cart['lines'],
+    lines,
   }
 }
 

--- a/lib/integrations/shopify/cart/actions.ts
+++ b/lib/integrations/shopify/cart/actions.ts
@@ -26,11 +26,13 @@ const addItemSchema = z.object({
 const updateQuantitySchema = z.object({
   merchandiseId: z.string().min(1, { error: 'Merchandise ID is required' }),
   quantity: z.number().int().min(0).max(99),
+  lineId: z.string().optional(),
 })
 
 export async function removeItem(
   _prevState: unknown,
-  merchandiseId: string
+  merchandiseId: string,
+  lineId?: string
 ): Promise<string | undefined> {
   const _cookies = await cookies()
   const cartId = _cookies.get('cartId')?.value
@@ -51,6 +53,14 @@ export async function removeItem(
   }
 
   try {
+    // Fast path: caller supplies lineId directly — skip the extra getCart round-trip.
+    if (lineId) {
+      await removeFromCart(cartId, [lineId])
+      revalidateTag(TAGS.cart, {})
+      return undefined
+    }
+
+    // Fallback: resolve lineId from a fresh cart fetch (e.g. callers without lineId).
     const cart = await getCart(cartId)
 
     if (!cart) {
@@ -98,7 +108,7 @@ export async function addItem(
   // and useFormState executes the addItem action in the server
   if (!cartId) {
     const cart = await createCart()
-    cartId = (cart as { id: string }).id
+    cartId = cart.id
     _cookies.set('cartId', cartId, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
@@ -122,7 +132,11 @@ export async function addItem(
 
 export async function updateItemQuantity(
   _prevState: unknown,
-  payload: { merchandiseId: string; quantity: number } = {
+  payload: {
+    merchandiseId: string
+    quantity: number
+    lineId?: string | undefined
+  } = {
     merchandiseId: '',
     quantity: 0,
   }
@@ -146,14 +160,22 @@ export async function updateItemQuantity(
     return parsed.error.issues[0]?.message ?? 'Invalid input'
   }
 
+  const { merchandiseId, quantity, lineId } = parsed.data
+
   try {
+    // Fast path: caller supplies lineId directly — skip the extra getCart round-trip.
+    if (lineId) {
+      await updateCart(cartId, [{ id: lineId, merchandiseId, quantity }])
+      revalidateTag(TAGS.cart, {})
+      return undefined
+    }
+
+    // Fallback: resolve lineId from a fresh cart fetch (e.g. callers without lineId).
     const cart = await getCart(cartId)
 
     if (!cart) {
       return 'Error fetching cart'
     }
-
-    const { merchandiseId, quantity } = parsed.data
 
     const lineItem = cart.lines.find(
       (line) => line.merchandise.id === merchandiseId

--- a/lib/integrations/shopify/cart/cart-context.tsx
+++ b/lib/integrations/shopify/cart/cart-context.tsx
@@ -11,7 +11,6 @@ import {
   type CartState,
 } from './cart-store-context'
 import { CartModal } from './modal'
-import type { CartAction } from './optimistic-utils'
 import { cartReconciler } from './optimistic-utils'
 
 export { useCartContext } from './cart-store-context'
@@ -44,10 +43,12 @@ export function CartProvider({ children, cart }: CartProviderProps) {
     product: Product,
     quantity = 1
   ) {
+    if (!variant) return
+
     updateOptimisticCart({
       type: 'ADD_ITEM',
       payload: { variant, product, quantity },
-    } as CartAction)
+    })
   }
 
   function totalQuantity() {

--- a/lib/integrations/shopify/cart/modal/index.tsx
+++ b/lib/integrations/shopify/cart/modal/index.tsx
@@ -19,6 +19,7 @@ interface ModalContextType {
 interface QuantityPayload {
   merchandiseId: string
   quantity: number
+  lineId?: string | undefined
 }
 
 interface QuantityProps {
@@ -35,6 +36,7 @@ interface QuantityButtonProps {
 
 interface RemoveButtonProps {
   merchandiseId: string
+  lineId?: string | undefined
   className?: string
 }
 
@@ -110,26 +112,13 @@ function InnerCart() {
           <div className={s.line} key={id}>
             <div className={s.media}>
               <Image
-                src={
-                  (merchandise?.product?.featuredImage as { url?: string })
-                    ?.url || ''
-                }
-                alt={
-                  (merchandise?.product?.featuredImage as { altText?: string })
-                    ?.altText ?? ''
-                }
-                {...((merchandise?.product?.featuredImage as { width?: number })
-                  ?.width && {
-                  width: (
-                    merchandise.product.featuredImage as { width: number }
-                  ).width,
+                src={merchandise.product.featuredImage?.url ?? ''}
+                alt={merchandise.product.featuredImage?.altText ?? ''}
+                {...(merchandise.product.featuredImage?.width && {
+                  width: merchandise.product.featuredImage.width,
                 })}
-                {...((
-                  merchandise?.product?.featuredImage as { height?: number }
-                )?.height && {
-                  height: (
-                    merchandise.product.featuredImage as { height: number }
-                  ).height,
+                {...(merchandise.product.featuredImage?.height && {
+                  height: merchandise.product.featuredImage.height,
                 })}
               />
             </div>
@@ -145,6 +134,7 @@ function InnerCart() {
 
             <RemoveButton
               merchandiseId={merchandise?.id ?? ''}
+              lineId={id}
               className={s.remove ?? ''}
             />
 
@@ -153,6 +143,7 @@ function InnerCart() {
               payload={{
                 merchandiseId: merchandise?.id ?? '',
                 quantity,
+                lineId: id,
               }}
             />
 
@@ -234,14 +225,14 @@ function QuantityButton({
   )
 }
 
-function RemoveButton({ merchandiseId, className }: RemoveButtonProps) {
+function RemoveButton({ merchandiseId, lineId, className }: RemoveButtonProps) {
   const { actions } = useCartContext()
   const { updateCartItem } = actions
   const router = useRouter()
 
   async function formAction() {
     updateCartItem(merchandiseId, 'delete')
-    await removeItem(null, merchandiseId)
+    await removeItem(null, merchandiseId, lineId)
 
     // Refresh the router to sync server state with optimistic state
     router.refresh()

--- a/lib/integrations/shopify/cart/optimistic-utils.ts
+++ b/lib/integrations/shopify/cart/optimistic-utils.ts
@@ -45,6 +45,7 @@ export function cartReconciler(
 
 function createEmptyCart(): Cart {
   return {
+    id: '',
     checkoutUrl: '',
     totalQuantity: 0,
     lines: [],

--- a/lib/integrations/shopify/client.ts
+++ b/lib/integrations/shopify/client.ts
@@ -1,10 +1,17 @@
 import { cacheSignal } from 'react'
+import { z } from 'zod'
 import { fetchWithTimeout } from '@/utils/fetch'
+import { parseApiResponse } from '@/utils/validation'
 import { SHOPIFY_GRAPHQL_API_ENDPOINT } from './constants'
 import type { ShopifyFetchOptions, ShopifyResponse } from './types'
 
 const endpoint = `${process.env.SHOPIFY_STORE_DOMAIN ?? ''}${SHOPIFY_GRAPHQL_API_ENDPOINT}`
 const key = process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN ?? ''
+
+const shopifyEnvelopeSchema = z.object({
+  data: z.unknown(),
+  errors: z.array(z.object({ message: z.string() })).optional(),
+})
 
 export async function shopifyFetch<T = Record<string, unknown>>({
   cache = 'force-cache',
@@ -36,14 +43,22 @@ export async function shopifyFetch<T = Record<string, unknown>>({
       ...(tags && { next: { tags } }),
     })
 
-    const body = (await result.json()) as {
-      data: T
-      errors?: Array<{ message: string }>
+    const raw = await result.json()
+    const envelope = parseApiResponse(
+      shopifyEnvelopeSchema,
+      raw,
+      'Shopify Storefront'
+    )
+
+    if (envelope.errors) {
+      throw new Error(
+        envelope.errors[0]?.message ?? 'Unknown Shopify API error'
+      )
     }
 
-    if (body.errors) {
-      throw new Error(body.errors[0]?.message ?? 'Unknown Shopify API error')
-    }
+    // `errors` is always absent past the throw above; omit it so the optional
+    // property stays optional under exactOptionalPropertyTypes.
+    const body = { data: envelope.data as T }
 
     return {
       status: result.status,

--- a/lib/integrations/shopify/collections.ts
+++ b/lib/integrations/shopify/collections.ts
@@ -92,7 +92,7 @@ export async function getCollections(): Promise<Collection[]> {
         description: 'All products',
       },
       path: '/search',
-      updatedAt: new Date().toISOString(),
+      updatedAt: '1970-01-01T00:00:00Z',
     },
     // Filter out the `hidden` collections.
     // Collections that start with `hidden-*` need to be hidden on the search page.

--- a/lib/integrations/shopify/reshape.ts
+++ b/lib/integrations/shopify/reshape.ts
@@ -3,7 +3,6 @@ import type {
   EdgeNode,
   Image,
   Product,
-  ProductVariant,
   ShopifyImage,
   ShopifyProduct,
 } from './types'
@@ -51,7 +50,7 @@ export const reshapeProduct = (
   return {
     ...rest,
     images: reshapeImages(images, product.title),
-    variants: removeEdgesAndNodes(variants) as ProductVariant[],
+    variants: removeEdgesAndNodes(variants),
   }
 }
 

--- a/lib/integrations/shopify/types.ts
+++ b/lib/integrations/shopify/types.ts
@@ -56,30 +56,30 @@ export interface ShopifyCartLineItem {
   }
 }
 
+// After reshaping data — the full post-reshape line-item shape
+export interface CartLineItem {
+  id?: string
+  quantity: number
+  cost: {
+    totalAmount: Money
+  }
+  merchandise: {
+    id: string
+    title: string
+    selectedOptions: Array<{ name: string; value: string }>
+    product: {
+      id: string
+      handle: string
+      title: string
+      featuredImage: Image | null
+    }
+  }
+}
+
 // After reshaping data
 export interface Cart extends DefaultCart {
-  id?: string
-  lines: Array<{
-    id?: string
-    quantity: number
-    cost: {
-      totalAmount: {
-        amount: string
-        currencyCode: string
-      }
-    }
-    merchandise: {
-      id: string
-      title: string
-      selectedOptions: Array<{ name: string; value: string }>
-      product: {
-        id: string
-        handle: string
-        title: string
-        featuredImage: Image | null
-      }
-    }
-  }>
+  id: string
+  lines: CartLineItem[]
   cost: {
     subtotalAmount: Money
     totalAmount: Money
@@ -87,12 +87,8 @@ export interface Cart extends DefaultCart {
   }
 }
 
-export interface CartLine {
-  id?: string
-  merchandise: {
-    id: string
-  }
-}
+// Minimal shape used for cart-mutation payloads (derived from CartLineItem)
+export type CartLine = Pick<CartLineItem, 'id' | 'merchandise'>
 
 export interface CartLineInput {
   merchandiseId: string
@@ -108,6 +104,7 @@ export interface AddItemPayload {
 export interface UpdateItemQuantityPayload {
   merchandiseId: string
   quantity: number
+  lineId?: string | undefined
 }
 
 /* Collection types */

--- a/lib/scripts/ast-transforms.ts
+++ b/lib/scripts/ast-transforms.ts
@@ -83,11 +83,16 @@ function openElementMatchesOp(el: JsxElement, op: RemoveJsxElementOp): boolean {
 // ---------------------------------------------------------------------------
 // Individual operation handlers
 // Each handler receives source text, applies one op, returns new source text.
-// A fresh ts-morph Project per call avoids any inter-op state leakage.
+// Handlers accept a shared in-memory Project to avoid repeated instantiation.
+// Source files are removed from the project after each handler so the next op
+// starts from a clean slate (no stale AST nodes between sequential ops).
 // ---------------------------------------------------------------------------
 
-function applyRemoveImport(sourceText: string, op: RemoveImportOp): string {
-  const project = new Project({ useInMemoryFileSystem: true })
+function applyRemoveImport(
+  project: Project,
+  sourceText: string,
+  op: RemoveImportOp
+): string {
   const sf = project.createSourceFile('__tmp__.tsx', sourceText)
 
   for (const decl of sf.getImportDeclarations()) {
@@ -97,26 +102,32 @@ function applyRemoveImport(sourceText: string, op: RemoveImportOp): string {
     }
   }
 
-  return sf.getFullText()
+  const result = sf.getFullText()
+  project.removeSourceFile(sf)
+  return result
 }
 
 function applyRemoveVariableStatement(
+  project: Project,
   sourceText: string,
   op: RemoveVariableStatementOp
 ): string {
-  const project = new Project({ useInMemoryFileSystem: true })
   const sf = project.createSourceFile('__tmp__.tsx', sourceText)
+  let result = sourceText
 
   for (const stmt of sf.getVariableStatements()) {
     for (const decl of stmt.getDeclarations()) {
       if (decl.getName() === op.name) {
         stmt.remove()
-        return sf.getFullText()
+        result = sf.getFullText()
+        break
       }
     }
+    if (result !== sourceText) break
   }
 
-  return sourceText
+  project.removeSourceFile(sf)
+  return result
 }
 
 /**
@@ -132,13 +143,10 @@ function applyRemoveVariableStatement(
  * wrapping JsxExpression container (handles `{studio && <Studio />}`).
  */
 function applyRemoveJsxElement(
+  project: Project,
   sourceText: string,
   op: RemoveJsxElementOp
 ): string {
-  const project = new Project({
-    useInMemoryFileSystem: true,
-    compilerOptions: { jsx: ts.JsxEmit.ReactJSX },
-  })
   const sf = project.createSourceFile('__tmp__.tsx', sourceText)
 
   const selfClosingMatches = sf
@@ -212,47 +220,69 @@ function applyRemoveJsxElement(
     }
   }
 
-  return sf.getFullText()
+  const result = sf.getFullText()
+  project.removeSourceFile(sf)
+  return result
 }
 
 function applyRemoveInterfaceProperty(
+  project: Project,
   sourceText: string,
   op: RemoveInterfacePropertyOp
 ): string {
-  const project = new Project({ useInMemoryFileSystem: true })
   const sf = project.createSourceFile('__tmp__.tsx', sourceText)
 
   const iface = sf.getInterface(op.interfaceName)
-  if (!iface) return sourceText
+  if (!iface) {
+    project.removeSourceFile(sf)
+    return sourceText
+  }
 
   const prop = iface.getProperty(op.propertyName)
-  if (!prop) return sourceText
+  if (!prop) {
+    project.removeSourceFile(sf)
+    return sourceText
+  }
 
   prop.remove()
-  return sf.getFullText()
+  const result = sf.getFullText()
+  project.removeSourceFile(sf)
+  return result
 }
 
 function applyRemoveFunctionParameter(
+  project: Project,
   sourceText: string,
   op: RemoveFunctionParameterOp
 ): string {
-  const project = new Project({ useInMemoryFileSystem: true })
   const sf = project.createSourceFile('__tmp__.tsx', sourceText)
 
   const fn = sf.getFunction(op.functionName)
-  if (!fn) return sourceText
+  if (!fn) {
+    project.removeSourceFile(sf)
+    return sourceText
+  }
 
   // Props are destructured in the first parameter's object binding pattern.
   const param = fn.getParameters()[0]
-  if (!param) return sourceText
+  if (!param) {
+    project.removeSourceFile(sf)
+    return sourceText
+  }
 
   const binding = param.getNameNode()
-  if (binding.getKind() !== SyntaxKind.ObjectBindingPattern) return sourceText
+  if (binding.getKind() !== SyntaxKind.ObjectBindingPattern) {
+    project.removeSourceFile(sf)
+    return sourceText
+  }
 
   const pattern = binding.asKindOrThrow(SyntaxKind.ObjectBindingPattern)
   const elements = pattern.getElements()
   const target = elements.find((el) => el.getName() === op.parameterName)
-  if (!target) return sourceText
+  if (!target) {
+    project.removeSourceFile(sf)
+    return sourceText
+  }
 
   // BindingElement has no `.remove()`; rebuild the binding pattern text from the
   // remaining elements (each element's text preserves its default value, and a
@@ -260,27 +290,43 @@ function applyRemoveFunctionParameter(
   const kept = elements.filter((el) => el !== target).map((el) => el.getText())
   pattern.replaceWithText(`{ ${kept.join(', ')} }`)
 
-  return sf.getFullText()
+  const result = sf.getFullText()
+  project.removeSourceFile(sf)
+  return result
 }
 
-function applyReplaceJsDoc(sourceText: string, op: ReplaceJsDocOp): string {
-  const project = new Project({ useInMemoryFileSystem: true })
+function applyReplaceJsDoc(
+  project: Project,
+  sourceText: string,
+  op: ReplaceJsDocOp
+): string {
   const sf = project.createSourceFile('__tmp__.tsx', sourceText)
 
   const fn = sf.getFunction(op.functionName)
-  if (!fn) return sourceText
+  if (!fn) {
+    project.removeSourceFile(sf)
+    return sourceText
+  }
 
   const docs = fn.getJsDocs()
-  if (docs.length === 0) return sourceText
+  if (docs.length === 0) {
+    project.removeSourceFile(sf)
+    return sourceText
+  }
 
   // Replace the first (and typically only) JSDoc block.
   // We pass the full /** … */ text directly to replaceWithText; ts-morph
   // treats JSDoc nodes as replaceable text ranges.
   const firstDoc = docs[0]
-  if (!firstDoc) return sourceText
+  if (!firstDoc) {
+    project.removeSourceFile(sf)
+    return sourceText
+  }
 
   firstDoc.replaceWithText(op.replacement)
-  return sf.getFullText()
+  const result = sf.getFullText()
+  project.removeSourceFile(sf)
+  return result
 }
 
 // ---------------------------------------------------------------------------
@@ -290,32 +336,42 @@ function applyReplaceJsDoc(sourceText: string, op: ReplaceJsDocOp): string {
 /**
  * Apply a sequence of typed AST operations to source text (in memory).
  * Returns the transformed text. Safe to call from tests — never touches disk.
+ *
+ * A single in-memory Project is shared across all operations for this call.
+ * JSX compiler options are enabled so the project can parse `.tsx` files for
+ * any op kind — enabling the JSX handlers without affecting non-JSX ops.
+ * Each handler creates and removes its own source file, so no AST state leaks
+ * between sequential ops.
  */
 export function applyOpsToText(
   sourceText: string,
   ops: AstOperation[]
 ): string {
+  const project = new Project({
+    useInMemoryFileSystem: true,
+    compilerOptions: { jsx: ts.JsxEmit.ReactJSX },
+  })
   let text = sourceText
 
   for (const op of ops) {
     switch (op.kind) {
       case 'removeImport':
-        text = applyRemoveImport(text, op)
+        text = applyRemoveImport(project, text, op)
         break
       case 'removeVariableStatement':
-        text = applyRemoveVariableStatement(text, op)
+        text = applyRemoveVariableStatement(project, text, op)
         break
       case 'removeJsxElement':
-        text = applyRemoveJsxElement(text, op)
+        text = applyRemoveJsxElement(project, text, op)
         break
       case 'removeInterfaceProperty':
-        text = applyRemoveInterfaceProperty(text, op)
+        text = applyRemoveInterfaceProperty(project, text, op)
         break
       case 'removeFunctionParameter':
-        text = applyRemoveFunctionParameter(text, op)
+        text = applyRemoveFunctionParameter(project, text, op)
         break
       case 'replaceJsDoc':
-        text = applyReplaceJsDoc(text, op)
+        text = applyReplaceJsDoc(project, text, op)
         break
       // Exhaustiveness — TypeScript ensures all union members are handled above.
     }

--- a/lib/scripts/generate-manifest.ts
+++ b/lib/scripts/generate-manifest.ts
@@ -9,21 +9,11 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { Project, SyntaxKind } from 'ts-morph'
+import { toPascalCase } from './generate-shared'
 
 const ROOT = join(import.meta.dir, '..', '..')
 const OUT_FILE = join(ROOT, 'COMPONENTS.md')
 const IS_CHECK = process.argv.includes('--check')
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function pascalCase(str: string): string {
-  return str
-    .split('-')
-    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
-    .join('')
-}
 
 function glob(pattern: string): string[] {
   const g = new Bun.Glob(pattern)
@@ -160,7 +150,7 @@ function buildComponentSection(
     const componentDir = parts[parts.length - 1] ?? ''
     const importPath = `${aliasPrefix}/${componentDir}`
     const type = isClientFile(file) ? 'Client' : 'Server'
-    const name = pascalCase(componentDir)
+    const name = toPascalCase(componentDir)
     rows.push(`| ${name} | \`${importPath}\` | ${type} |`)
   }
 
@@ -187,14 +177,14 @@ function buildEffectSection(): string {
     if (file.includes('/index.tsx')) {
       const match = file.match(/components\/effects\/([^/]+)\/index\.tsx$/)
       const dir = match?.[1] ?? ''
-      name = pascalCase(dir)
+      name = toPascalCase(dir)
       importPath = `@/components/effects/${dir}`
     } else {
       const match = file.match(/components\/effects\/([^/]+)\.tsx$/)
       const base = match?.[1] ?? ''
       // Skip webgl sub-files (e.g., animated-gradient/webgl.tsx)
       if (base.includes('webgl')) continue
-      name = pascalCase(base)
+      name = toPascalCase(base)
       importPath = `@/components/effects/${base}`
     }
 
@@ -315,7 +305,7 @@ function buildWebGLSection(): string {
   for (const file of allEntries.sort()) {
     const match = file.match(/lib\/webgl\/components\/([^/]+)\/index\.[tj]sx?$/)
     const dir = match?.[1] ?? ''
-    const name = pascalCase(dir)
+    const name = toPascalCase(dir)
     const importPath = `@/webgl/components/${dir}`
     const type = isClientFile(file) ? 'Client' : 'Server'
     rows.push(`| ${name} | \`${importPath}\` | ${type} |`)

--- a/lib/scripts/prepare-handoff.ts
+++ b/lib/scripts/prepare-handoff.ts
@@ -17,6 +17,7 @@
 
 import * as p from '@clack/prompts'
 import { getConfigured } from '@/integrations/registry'
+import { cancelGuard } from './generate-shared'
 import { INTEGRATION_BUNDLES } from './integration-bundles'
 import { renderDeploymentChecklist } from './templates/deployment-checklist'
 import { renderInventory } from './templates/inventory'
@@ -103,9 +104,9 @@ const removeBrandingAssets = async (dryRun: boolean): Promise<boolean> => {
 }
 
 /**
- * Update package.json with project-specific information
+ * Update package.json name and description with project-specific information
  */
-const updatePackageJson = async (
+const setPackageJsonNameAndDescription = async (
   projectName: string,
   dryRun: boolean
 ): Promise<boolean> => {
@@ -321,7 +322,7 @@ const runHandoff = async (options: HandoffOptions): Promise<void> => {
   // Update package.json
   if (doUpdatePackageJson) {
     s.start('Updating package.json...')
-    const updated = await updatePackageJson(projectName, dryRun)
+    const updated = await setPackageJsonNameAndDescription(projectName, dryRun)
     s.stop(updated ? 'Updated package.json' : 'No package.json changes needed')
   }
 
@@ -389,10 +390,7 @@ const main = async (): Promise<void> => {
     },
   })
 
-  if (p.isCancel(projectName)) {
-    p.cancel('Handoff cancelled')
-    process.exit(0)
-  }
+  const projectNameValue = cancelGuard(projectName, 'Handoff cancelled')
 
   // Ask what to do
   const actions = await p.multiselect({
@@ -445,15 +443,12 @@ const main = async (): Promise<void> => {
     ],
   })
 
-  if (p.isCancel(actions)) {
-    p.cancel('Handoff cancelled')
-    process.exit(0)
-  }
+  const actionsValue = cancelGuard(actions, 'Handoff cancelled')
 
   // Show summary
   p.log.step('Summary:')
-  p.log.message(`  Project: ${projectName}`)
-  p.log.message(`  Actions: ${(actions as string[]).join(', ')}`)
+  p.log.message(`  Project: ${projectNameValue}`)
+  p.log.message(`  Actions: ${actionsValue.join(', ')}`)
 
   // Confirm
   const proceed = await p.confirm({
@@ -466,17 +461,16 @@ const main = async (): Promise<void> => {
   }
 
   // Run handoff
-  const actionsArray = actions as string[]
   await runHandoff({
     dryRun,
-    projectName: projectName as string,
-    removeExamples: actionsArray.includes('removeExamples'),
-    swapReadme: actionsArray.includes('swapReadme'),
-    removeBranding: actionsArray.includes('removeBranding'),
-    updatePackageJson: actionsArray.includes('updatePackageJson'),
-    cleanupEnvVars: actionsArray.includes('cleanupEnvVars'),
-    generateInventory: actionsArray.includes('generateInventory'),
-    generateChecklist: actionsArray.includes('generateChecklist'),
+    projectName: projectNameValue,
+    removeExamples: actionsValue.includes('removeExamples'),
+    swapReadme: actionsValue.includes('swapReadme'),
+    removeBranding: actionsValue.includes('removeBranding'),
+    updatePackageJson: actionsValue.includes('updatePackageJson'),
+    cleanupEnvVars: actionsValue.includes('cleanupEnvVars'),
+    generateInventory: actionsValue.includes('generateInventory'),
+    generateChecklist: actionsValue.includes('generateChecklist'),
   })
 
   // Done
@@ -484,13 +478,13 @@ const main = async (): Promise<void> => {
     p.outro('Dry run complete. Run without --dry-run to apply changes.')
   } else {
     const generated: string[] = []
-    if (actionsArray.includes('generateInventory')) {
+    if (actionsValue.includes('generateInventory')) {
       generated.push('  - INVENTORY.md (component list)')
     }
-    if (actionsArray.includes('generateChecklist')) {
+    if (actionsValue.includes('generateChecklist')) {
       generated.push('  - DEPLOYMENT-CHECKLIST.md (launch tasks)')
     }
-    if (actionsArray.includes('swapReadme')) {
+    if (actionsValue.includes('swapReadme')) {
       generated.push('  - README.original.md (backup)')
     }
     p.note(

--- a/lib/scripts/setup-project.ts
+++ b/lib/scripts/setup-project.ts
@@ -14,6 +14,7 @@
 
 import * as p from '@clack/prompts'
 import { applyCodeTransforms } from './ast-transforms'
+import { cancelGuard } from './generate-shared'
 import {
   type CodeTransform,
   getIntegrationNames,
@@ -115,9 +116,9 @@ const removeMarketingHomepage = async (dryRun: boolean): Promise<void> => {
 }
 
 /**
- * Update package.json to remove dependencies
+ * Remove dependency entries from package.json
  */
-const updatePackageJson = async (
+const removeDepsFromPackageJson = async (
   depsToRemove: string[],
   devDepsToRemove: string[],
   dryRun: boolean
@@ -376,7 +377,7 @@ const setup = async (options: SetupOptions): Promise<void> => {
   // Update package.json
   if (allDeps.length > 0 || allDevDeps.length > 0) {
     s.start('Updating package.json...')
-    const { deps, devDeps } = await updatePackageJson(
+    const { deps, devDeps } = await removeDepsFromPackageJson(
       allDeps,
       allDevDeps,
       dryRun
@@ -488,13 +489,7 @@ const main = async (): Promise<void> => {
       required: false,
     })
 
-    // Handle cancellation
-    if (p.isCancel(customIntegrations)) {
-      p.cancel('Setup cancelled')
-      process.exit(0)
-    }
-
-    keepIntegrations = customIntegrations as string[]
+    keepIntegrations = cancelGuard(customIntegrations, 'Setup cancelled')
   } else {
     // Use preset integrations
     const preset = PROJECT_PRESETS[selectedPreset as PresetKey]

--- a/lib/utils/animation.ts
+++ b/lib/utils/animation.ts
@@ -26,11 +26,6 @@
 import { type EasingName, easings } from './easings'
 import { clamp, mapRange } from './math'
 
-// Re-export for convenience
-export { type EasingName, easings } from './easings'
-export { clamp, lerp, mapRange, modulo, truncate } from './math'
-export { batch, measure, mutate } from './raf'
-
 /**
  * Calculates staggered progress for an element in a sequence.
  *

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -195,3 +195,44 @@ export function parseFormData<T>(
 export function zodToValidator(schema: z.ZodType): (value: string) => boolean {
   return (value: string) => schema.safeParse(value).success
 }
+
+// ---------------------------------------------------------------------------
+// External-boundary response parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate already-parsed JSON from an external API against a Zod schema.
+ *
+ * Use this at every integration boundary instead of casting
+ * `(await res.json()) as T`. On mismatch it throws a descriptive error so the
+ * failure surfaces at the edge — with the offending paths named — rather than
+ * as an opaque property-access crash deep in the call chain (e.g. during a
+ * vendor API version bump).
+ *
+ * @param schema  Zod schema describing the expected response shape.
+ * @param data    The parsed JSON (the result of `await res.json()`).
+ * @param context Optional label for the source, included in the thrown message
+ *                (e.g. `'Shopify Storefront'`, `'HubSpot forms API'`).
+ *
+ * @example
+ * ```ts
+ * const json = await res.json()
+ * const body = parseApiResponse(shopifyEnvelopeSchema, json, 'Shopify Storefront')
+ * ```
+ */
+export function parseApiResponse<T>(
+  schema: z.ZodType<T>,
+  data: unknown,
+  context?: string
+): T {
+  const result = schema.safeParse(data)
+  if (!result.success) {
+    const detail = result.error.issues
+      .map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+      .join('; ')
+    throw new Error(
+      `Invalid API response${context ? ` from ${context}` : ''}: ${detail}`
+    )
+  }
+  return result.data
+}


### PR DESCRIPTION
## What this does

Applies the findings from a whole-codebase maintainability review (`/nuclear-review`). It's all behaviour-preserving cleanup — no features change — but it removes a class of latent bugs: malformed responses from HubSpot, Mailchimp, and Shopify now fail with a clear error at the network boundary instead of crashing later as a confusing property-access error, and the Shopify cart stops making an extra API call on every quantity change.

No user-facing behaviour changes. The success paths (form submits, cart add/remove/update, product fetch) work exactly as before.

## Summary

**Boundary validation** (`refactor(integrations)`)
- New `parseApiResponse(schema, json, context)` helper in `lib/utils/validation.ts`; HubSpot, Mailchimp, and the Shopify GraphQL envelope are now zod-validated at the fetch boundary instead of `(await res.json()) as T`.
- Mailchimp: typed `MailchimpErrorCode` union replaces error-string sniffing; tag/note writes are explicitly best-effort (no longer flip the result to failure); `upsertMember` dedups the two subscribe paths.
- HubSpot: removed the dead `hubspotType` field and its orphaned `typeSetter`.
- Turnstile: one dev-mode bypass path instead of two (production validation unchanged).

**Shopify cart** (`refactor(shopify)` + `perf(shopify)`)
- Named the post-reshape line item (`CartLineItem`), derived `CartLine` from it, made `Cart.id` required — removing 11 `as` casts the missing types forced, and guarding `addCartItem` against an undefined variant.
- `removeItem`/`updateItemQuantity` take the `lineId` the client already holds, dropping the redundant `getCart` round-trip per mutation (a fallback is kept for optimistic lines without a confirmed id).
- Synthetic "All" collection gets a stable `updatedAt` so it doesn't bust caches.

**Scripts & utils** (`refactor(scripts)` + `refactor(utils)`)
- `ast-transforms`: one shared in-memory ts-morph `Project` per `applyOpsToText` instead of up to six.
- Removed a duplicate `pascalCase`, adopted the existing `cancelGuard` for clack prompts (dropping manual casts), and renamed the two divergent `updatePackageJson` functions.
- Dropped the `animation.ts` re-export barrel so each util has one canonical import path.

## Reviewed but intentionally not changed
- **Env-var allowlist vs blocklist** (`setup-project` vs `prepare-handoff`): left separate. They diverge on purpose — setup preserves unknown custom vars (blocklist), handoff strips them (allowlist). Merging would break one guarantee.

## Follow-up (out of scope, not a regression)
- HubSpot forms feed the raw HubSpot `fieldType` into `<input type=...>`, so a `phone` field renders `<input type="phone">` (invalid → falls back to text). Pre-existing; fixing it is a HubSpot-type → HTML-input-type mapping decision worth its own change.

## Test Plan
- [x] `bun run check` green — biome (0 errors), `tsgo --noEmit`, **414 tests pass**
- [x] lefthook pre-commit (typecheck + biome) passed on every commit
- [ ] Manual: subscribe via a HubSpot/Mailchimp form; add/remove/change quantity in the Shopify cart
