### PR TITLE
fix(lenis): let the react-scan dev panel scroll natively

### DIFF
--- a/components/layout/lenis/index.tsx
+++ b/components/layout/lenis/index.tsx
@@ -58,7 +58,10 @@ export function Lenis({
         autoToggle: true,
         prevent: (node: Element | null) =>
           node?.nodeName === 'VERCEL-LIVE-FEEDBACK' ||
-          node?.id === 'theatrejs-studio-root',
+          node?.id === 'theatrejs-studio-root' ||
+          // react-scan renders its panel into a shadow root on this host;
+          // composedPath() pierces the shadow boundary so the id is matchable.
+          node?.id === 'react-scan-root',
       }}
     >
       {syncScrollTrigger && root && <LenisScrollTriggerSync />}


### PR DESCRIPTION
## What this does

The react-scan dev panel was getting its scroll hijacked by Lenis smooth-scroll, so you could not scroll inside it. This lets it scroll natively. Dev-only behaviour — no production impact (react-scan is dev-only).

## Summary

react-scan renders its panel into a **shadow root** on a `#react-scan-root` host element, so a `data-lenis-prevent` attribute is not an option (we do not control those nodes). But Lenis 1.3.x walks `event.composedPath()`, which pierces shadow-DOM boundaries, so the host id is matchable in the existing `prevent` callback. Added `node?.id === 'react-scan-root'` alongside the existing `VERCEL-LIVE-FEEDBACK` and `theatrejs-studio-root` guards in `components/layout/lenis/index.tsx`.

## Test Plan
- [x] `tsgo --noEmit` clean; biome clean; lefthook pre-commit passed
- [ ] Manual (dev): open the react-scan panel and confirm it scrolls internally instead of scrolling the page