### PR TITLE
fix(sanity): wrap sanityFetch in 'use cache' for cacheComponents compatibility

### DIFF
--- a/app/(examples)/sanity/[slug]/page.tsx
+++ b/app/(examples)/sanity/[slug]/page.tsx
@@ -1,5 +1,4 @@
 import { notFound } from 'next/navigation'
-import { cache } from 'react'
 import { Wrapper } from '@/components/layout/wrapper'
 import { client } from '@/integrations/sanity/client'
 import { sanityFetch } from '@/integrations/sanity/live'
@@ -28,14 +27,17 @@ export async function generateStaticParams() {
   return params.length > 0 ? params : fallback
 }
 
-// Deduplicate the Sanity fetch across generateMetadata and the page component
-// within the same request using React's request-scoped cache.
-const fetchArticle = cache(async (slug: string) => {
+// `sanityFetch` calls `cacheTag()` internally, which under Next's Cache
+// Components (`cacheComponents: true`) is only legal inside a `'use cache'`
+// function. Wrapping here also dedupes the fetch across the page render and
+// `generateMetadata` (slug is passed as an arg so the cache keys per article).
+async function fetchArticle(slug: string) {
+  'use cache'
   return sanityFetch({
     query: articleQuery,
     params: { slug },
   })
-})
+}
 
 export default async function SanityArticlePage({
   params,

--- a/app/(examples)/sanity/page.tsx
+++ b/app/(examples)/sanity/page.tsx
@@ -1,5 +1,4 @@
 import { notFound } from 'next/navigation'
-import { cache } from 'react'
 import { Wrapper } from '@/components/layout/wrapper'
 import { NotConfigured } from '@/components/ui/not-configured'
 import { isConfigured } from '@/integrations/registry'
@@ -10,14 +9,17 @@ import { SanityTutorial } from './_components/tutorial'
 
 const SLUG = 'sanity'
 
-// Deduplicate the Sanity fetch across generateMetadata and the page component
-// within the same request using React's request-scoped cache.
-const fetchPage = cache(async () => {
+// `sanityFetch` calls `cacheTag()` internally, which under Next's Cache
+// Components (`cacheComponents: true`) is only legal inside a `'use cache'`
+// function. Wrapping here also dedupes the fetch across the page render and
+// `generateMetadata`.
+async function fetchPage() {
+  'use cache'
   return sanityFetch({
     query: pageQuery,
     params: { slug: SLUG },
   })
-})
+}
 
 export default async function SanityPage() {
   // Show setup instructions if Sanity is not configured


### PR DESCRIPTION
## What this does

`/sanity` and `/sanity/[slug]` were crashing at runtime with:

> `cacheTag()` can only be called inside a "use cache" function.

This fixes both pages so they render again.

## Root cause

`next.config.ts` enables `cacheComponents: true` (added in `50485f8`, "test experimental setting"). next-sanity's `sanityFetch` (from `defineLive`) calls `cacheTag()` internally to register the cache tag for live revalidation — and under Cache Components, `cacheTag()` is only legal inside a `'use cache'` function. The Sanity example pages called `sanityFetch` outside any `'use cache'` scope, so they threw.

This was **latent on `main`** — not introduced by a recent PR. Confirmed by reverting the `cache()` wrapper from #204 to the prior direct calls: the error persisted, so React `cache()` was never the cause (it is not a `'use cache'` boundary).

## Fix

Wrap each fetch in a `'use cache'` function — next-sanity's intended pattern under Cache Components (a cached fetch whose `cacheTag` is revalidated by `<SanityLive>`). For `[slug]`, the slug is passed as an argument so the cache keys per article. This supersedes #204's React `cache()` approach and still satisfies its goal: `'use cache'` also dedupes across the page render and `generateMetadata`, so the same document is fetched once per request.

## Test Plan
- [x] `bun run check` green — biome, `tsgo --noEmit`, 414 tests
- [x] Runtime (dev): `/sanity` and `/sanity/lorem-ipsum` render with **no console errors** (previously both threw `cacheTag()`)
- [ ] CI `next build` validates the prerender path under `cacheComponents`