### PR TITLE
feat(dev): make react-scan an opt-in Orchestra toggle

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,6 @@ import Script from 'next/script'
 import { VisualEditing } from 'next-sanity/visual-editing'
 import { type PropsWithChildren, Suspense } from 'react'
 import { ReactTempus } from 'tempus/react'
-import { ReactScanProvider } from '@/components/react-scan-provider'
 import { Link } from '@/components/ui/link'
 import { RealViewport } from '@/components/ui/real-viewport'
 import { env } from '@/lib/env'
@@ -106,7 +105,6 @@ export default async function Layout({ children }: PropsWithChildren) {
         async
       >{`window.satusVersion = '${AppData.version}';`}</Script>
       <body>
-        <ReactScanProvider />
         {/* Skip link for keyboard navigation accessibility */}
         <Suspense fallback={null}>
           <Link

--- a/components/react-scan-provider.tsx
+++ b/components/react-scan-provider.tsx
@@ -1,13 +1,39 @@
 'use client'
 
-import { useScan } from 'react-scan'
+import { useEffect } from 'react'
+import { scan } from 'react-scan'
 
+// react-scan injects this shadow-host element onto <html> the first time it
+// starts. It is guarded by a module-level ref inside react-scan, so it can be
+// hidden but must NOT be removed (removal blocks re-creation on re-enable).
+const REACT_SCAN_ROOT_ID = 'react-scan-root'
+
+/**
+ * react-scan render profiler, mounted only when the 🔬 Orchestra toggle
+ * (`id="reactScan"`, ⌘O palette) is on — off by default, so a normal dev
+ * session pays no profiler cost (react-scan instruments every React commit).
+ *
+ * react-scan exposes no `stop()`, so teardown is manual: enabling + showing on
+ * mount, disabling + hiding on unmount. `enabled` gates the expensive
+ * per-commit work; hiding the shadow host removes the panel without tripping
+ * react-scan's "created once" guard.
+ */
 export function ReactScanProvider() {
-  useScan({
-    enabled: process.env.NODE_ENV === 'development',
-    animationSpeed: 'fast',
-    trackUnnecessaryRenders: true,
-  })
+  useEffect(() => {
+    scan({
+      enabled: true,
+      animationSpeed: 'fast',
+      trackUnnecessaryRenders: true,
+    })
+    document.getElementById(REACT_SCAN_ROOT_ID)?.style.removeProperty('display')
+
+    return () => {
+      scan({ enabled: false })
+      document
+        .getElementById(REACT_SCAN_ROOT_ID)
+        ?.style.setProperty('display', 'none')
+    }
+  }, [])
 
   return null
 }

--- a/lib/dev/cmdo.tsx
+++ b/lib/dev/cmdo.tsx
@@ -47,6 +47,7 @@ export function Cmdo() {
               <OrchestraToggle id="webgl" defaultValue={true}>
                 🧊
               </OrchestraToggle>
+              <OrchestraToggle id="reactScan">🔬</OrchestraToggle>
               <OrchestraToggle id="screenshot">📸</OrchestraToggle>
             </div>
           </Dialog.Popup>

--- a/lib/dev/index.tsx
+++ b/lib/dev/index.tsx
@@ -25,8 +25,17 @@ const ScrollTriggerDebugger = dynamic(
   { ssr: false }
 )
 
+const ReactScan = dynamic(
+  () =>
+    import('@/components/react-scan-provider').then(
+      ({ ReactScanProvider }) => ReactScanProvider
+    ),
+  { ssr: false }
+)
+
 export function OrchestraTools() {
-  const { stats, grid, studio, dev, minimap, screenshot } = useOrchestra()
+  const { stats, grid, studio, dev, minimap, screenshot, reactScan } =
+    useOrchestra()
 
   useEffect(() => {
     document.documentElement.classList.toggle('dev', Boolean(dev))
@@ -43,6 +52,7 @@ export function OrchestraTools() {
       {stats && <Stats />}
       {grid && <GridDebugger />}
       {minimap && <ScrollTriggerDebugger />}
+      {reactScan && <ReactScan />}
     </>
   )
 }


### PR DESCRIPTION
## What this does

react-scan was always-on in dev — mounted in the root layout, instrumenting every React commit and showing its panel every session. That's main-thread cost you pay whether or not you're profiling (and a plausible contributor to the scroll jank we were investigating). This moves it behind a 🔬 toggle in the ⌘O Orchestra palette, **off by default**, so a normal dev session pays nothing for it.

## Summary

- Removed `<ReactScanProvider>` from `app/layout.tsx`.
- Registered it as a conditionally-mounted Orchestra tool in `OrchestraTools` (`{reactScan && <ReactScan />}`), dynamic-imported and dev-only like `Studio`/`Stats`/`Grid` — so react-scan isn't even *imported* until you first toggle it on.
- Added `<OrchestraToggle id="reactScan">🔬</OrchestraToggle>` to the ⌘O palette (default off).
- react-scan exposes no `stop()` and guards its shadow-host panel as a create-once singleton, so the provider **enables + shows on mount** and **disables + hides on unmount** (hiding, not removing — removal would block re-creation). `enabled: false` gates the expensive per-commit work; the panel is hidden via the host element.

## Verified in-browser (`/r3f`)
- Default: `#react-scan-root` absent, react-scan not mounted — zero overhead, no panel.
- Toggle on: panel appears, scanning active.
- Toggle off: panel hidden (`display:none`), scanning disabled. ← fixes the "off doesn't remove the panel" issue.
- Toggle on again: panel restored.

## Notes
- **Overlap:** react-scan's FPS readout duplicates the existing `stats` (stats-gl) tool, but they're complementary — stats-gl is a frame-time/GPU meter, react-scan is a React re-render profiler — so both are kept.
- **Caveat:** react-scan patches React's reconciler on first activation; that patch persists until reload (inherent — no `stop()` API). "Off" disables scanning and hides the panel, which removes the visible cost; a full teardown would require a reload. The bigger win is that a session that never toggles it on never imports or runs react-scan at all.

## Test Plan
- [x] `bun run check` green — biome, tsgo, 414 tests
- [x] Runtime: full on/off/on cycle verified in browser
- [ ] CI build