### PR TITLE
feat: additive plugin CLI — satus add <plugin>

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -439,6 +439,8 @@ bun lint:fix         # Biome lint with auto-fix
 bun run format       # Biome format
 bun run typecheck    # tsgo --noEmit
 bun test             # Unit tests
+bun run setup:project  # Strip unused integrations (non-interactive: --preset/--keep, --yes, --clean-homepage, --skip-install)
+bun run satus        # Plugin CLI: `list`, `add <plugin>` (restore an integration from the satus repo)
 bun run doctor       # Diagnose setup issues
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ latest tag; security fixes land on the latest release (see `SECURITY.md`).
 
 ### Added
 
+- `bun run satus` plugin CLI — `satus list` shows every integration's installed status, and `satus add <plugin>` restores a stripped integration into a living project: files are copied from the public satus repo (the registry), dependencies re-pinned, and shared files re-wired through idempotent AST operations, so adding twice is a no-op. `setup:project` records the git HEAD sha as `"satus": { "ref": … }` in package.json and `satus add` fetches that pinned ref by default (`--from` uses a local checkout, `--ref` overrides). Both CLIs run non-interactively (`--preset`/`--keep`/`--yes`/`--skip-install`), verified by a network-free round-trip e2e (`lib/scripts/satus.e2e.test.ts`). (#185)
 - Storybook themed to match Satūs: stories render on the site palette through shared CSS tokens (edit the site, the catalogue follows), with a dark/light/red/evil theme toolbar and a branded manager. (#210)
 - Optional `/storybook` route that proxies to a standalone Storybook deployment, enabled per-environment via `NEXT_PUBLIC_STORYBOOK_URL` and force-disabled in Production. (#210)
 - One-click Deploy to Vercel button (README + in-app manual) and clearer domain-setup guidance. (#210)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,31 @@ Satūs keeps integrations — Sanity, Shopify, HubSpot, WebGL — isolated under
 
 - **Use one** — set its env vars (see `lib/env.ts`) and follow the `// USAGE` reference in its folder.
 - **Drop the ones you don't need** — `bun run setup:project`.
-- **Coming next** — an additive `satus add <plugin>` CLI that injects an integration into a living project. Design captured in [#185](../../issues/185).
+- **Add one back later** — `bun run satus add <plugin>` restores it into a living project.
+
+### Plugins
+
+The public satus repo is the registry: `satus add` pulls an integration's source payload from it and re-wires shared files (`next.config.ts`, barrels, env stubs) through idempotent AST operations — adding twice is a no-op.
+
+```bash
+bun run satus list           # All plugins and their installed status
+bun run satus add <plugin>   # Restore one (resolves `requires` transitively)
+```
+
+`satus add` flags:
+
+| Flag | Effect |
+|------|--------|
+| `--from <path>` | Use a local satus checkout as the payload source |
+| `--ref <gitRef>` | Fetch the GitHub tarball at this ref |
+| `--dry-run` | Print what would happen without writing anything |
+| `--force` | Overwrite existing / locally modified files |
+| `--yes` | Skip confirmation prompts (CI) |
+| `--skip-install` | Write package.json but do not run `bun install` |
+
+Payloads are version-matched: a successful `setup:project` run records the git HEAD sha into package.json as `"satus": { "ref": … }`, and `satus add` fetches that pinned ref by default (`--ref` overrides it; without either it falls back to `main`).
+
+`setup:project` is also drivable non-interactively (CI): `--preset <key>` or `--keep <id,id,...>` selects the integration set, `--yes` confirms it, `--clean-homepage` swaps in a blank starter homepage, and `--skip-install` skips the lockfile update.
 
 ## Tech Stack
 
@@ -109,6 +133,8 @@ bun storybook        # Component catalogue
 bun lint             # Biome linter
 bun run generate     # Generate pages/components
 bun run setup:project  # Strip integrations you don't need
+bun run satus list   # Plugins and their installed status
+bun run satus add <plugin>  # Restore an integration from the satus repo
 bun run handoff      # Prepare for client delivery
 ```
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -109,12 +109,13 @@ const STEPS: Step[] = [
         </p>
         <p className={s.text}>
           To turn one on, set its env vars and follow the in-folder notes marked{' '}
-          <code className={s.inline}>{'// USAGE'}</code>. To remove the ones you
-          don&apos;t need, run{' '}
-          <code className={s.inline}>bun run setup:project</code>. A command for
-          the reverse,{' '}
-          <code className={s.inline}>satus add &lt;plugin&gt;</code>, is on the
-          way (see issue #185).
+          <code className={s.inline}>{'// USAGE'}</code>. Strip the ones you
+          don&apos;t need with{' '}
+          <code className={s.inline}>bun run setup:project</code>, and bring one
+          back any time with{' '}
+          <code className={s.inline}>bun run satus add &lt;plugin&gt;</code> —
+          it pulls the integration&apos;s source from the satus repo as owned
+          code, wires it up, and is safe to run twice.
         </p>
       </>
     ),

--- a/lib/scripts/ast-transforms.test.ts
+++ b/lib/scripts/ast-transforms.test.ts
@@ -1,0 +1,565 @@
+/**
+ * Unit tests for the additive AST operations in the transform engine
+ *
+ * Run with: bun test lib/scripts/ast-transforms.test.ts
+ *
+ * Every additive op must be:
+ * 1. Effective — it inserts the construct when absent
+ * 2. Idempotent — it returns the source byte-for-byte unchanged when present
+ *    (the issue constraint: "add x twice is a no-op")
+ * 3. Format-resilient — it works on compact / quoted-key / multiline variants
+ *
+ * Plus round-trip tests: remove-then-add (and add-then-remove) on a realistic
+ * next.config-shaped fixture leaves the value present exactly once (or absent).
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { applyOpsToText } from './ast-transforms'
+import type { AstOperation } from './integration-bundles'
+
+/** Number of times `needle` occurs in `haystack`. */
+function count(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const nextConfigFixture = `const nextConfig: NextConfig = {
+  experimental: {
+    optimizePackageImports: [
+      'gsap',
+      'three',
+    ],
+  },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'cdn.shopify.com',
+      },
+    ],
+  },
+}
+
+export default nextConfig
+`
+
+// Compact / quoted-key variant — same semantics, hostile formatting.
+const compactConfigFixture = `const nextConfig = {
+  experimental: { optimizePackageImports: ["gsap","three"] },
+  images: { remotePatterns: [{"protocol":"https","hostname":"cdn.shopify.com"}] },
+}
+`
+
+// ---------------------------------------------------------------------------
+// addImport
+// ---------------------------------------------------------------------------
+
+describe('addImport', () => {
+  const canvasImport: AstOperation = {
+    kind: 'addImport',
+    text: "import { Canvas } from '@/webgl/components/canvas'",
+  }
+
+  it('should insert after the last import when absent', () => {
+    const fixture = `'use client'
+
+import { Lenis } from 'lenis/react'
+import { Theme } from '@/lib/theme'
+
+export function Wrapper() {
+  return null
+}
+`
+    const result = applyOpsToText(fixture, [canvasImport])
+
+    expect(result).toContain(
+      "import { Canvas } from '@/webgl/components/canvas'"
+    )
+    // Placement: after the last existing import, before the function.
+    expect(result.indexOf("'@/lib/theme'")).toBeLessThan(
+      result.indexOf("'@/webgl/components/canvas'")
+    )
+    expect(result.indexOf("'@/webgl/components/canvas'")).toBeLessThan(
+      result.indexOf('export function Wrapper')
+    )
+    // Adding twice is a no-op.
+    expect(applyOpsToText(result, [canvasImport])).toBe(result)
+  })
+
+  it('should insert after the directive prologue when the file has no imports', () => {
+    const fixture = `'use client'
+
+export function Thing() {
+  return null
+}
+`
+    const result = applyOpsToText(fixture, [canvasImport])
+
+    expect(result.indexOf("'use client'")).toBeLessThan(
+      result.indexOf('import { Canvas }')
+    )
+    expect(result.indexOf('import { Canvas }')).toBeLessThan(
+      result.indexOf('export function Thing')
+    )
+  })
+
+  it('should merge missing named imports into an existing declaration', () => {
+    const fixture = `import { Theme } from '@/lib/theme'
+
+export const t = Theme
+`
+    const result = applyOpsToText(fixture, [
+      {
+        kind: 'addImport',
+        text: "import { Theme, ThemeProvider } from '@/lib/theme'",
+      },
+    ])
+
+    expect(result).toContain('ThemeProvider')
+    // Merged, not duplicated — still a single declaration for the specifier.
+    expect(count(result, "from '@/lib/theme'")).toBe(1)
+    expect(count(result, 'import')).toBe(1)
+  })
+
+  it('should be an exact no-op when the import is already present', () => {
+    const fixture = `import { Canvas } from '@/webgl/components/canvas'
+
+export const c = Canvas
+`
+    expect(applyOpsToText(fixture, [canvasImport])).toBe(fixture)
+  })
+
+  it('should be an exact no-op for a multiline named import containing the binding', () => {
+    const fixture = `import {
+  Alpha,
+  Beta,
+} from '@/lib'
+
+export const x = Alpha + Beta
+`
+    const result = applyOpsToText(fixture, [
+      { kind: 'addImport', text: "import { Beta } from '@/lib'" },
+    ])
+    expect(result).toBe(fixture)
+  })
+
+  it('should merge into a multiline named import (formatting variant)', () => {
+    const fixture = `import {
+  Alpha,
+  Beta,
+} from '@/lib'
+
+export const x = Alpha + Beta
+`
+    const result = applyOpsToText(fixture, [
+      { kind: 'addImport', text: "import { Gamma } from '@/lib'" },
+    ])
+
+    expect(result).toContain('Gamma')
+    expect(count(result, "from '@/lib'")).toBe(1)
+    // Existing bindings survive the merge.
+    expect(result).toContain('Alpha')
+    expect(result).toContain('Beta')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// addArrayStringElement
+// ---------------------------------------------------------------------------
+
+describe('addArrayStringElement', () => {
+  const addLenis: AstOperation = {
+    kind: 'addArrayStringElement',
+    variableName: 'nextConfig',
+    propertyPath: 'experimental.optimizePackageImports',
+    value: 'lenis',
+  }
+
+  it('should append the string when absent', () => {
+    const result = applyOpsToText(nextConfigFixture, [addLenis])
+
+    expect(result).toContain("'lenis'")
+    expect(count(result, 'lenis')).toBe(1)
+    // Existing entries survive.
+    expect(result).toContain("'gsap'")
+    expect(result).toContain("'three'")
+    // Adding twice is a no-op.
+    expect(applyOpsToText(result, [addLenis])).toBe(result)
+  })
+
+  it('should be an exact no-op when the value is already present', () => {
+    const result = applyOpsToText(nextConfigFixture, [
+      {
+        kind: 'addArrayStringElement',
+        variableName: 'nextConfig',
+        propertyPath: 'experimental.optimizePackageImports',
+        value: 'gsap',
+      },
+    ])
+    expect(result).toBe(nextConfigFixture)
+  })
+
+  it('should match across quote styles (exact no-op on double-quoted source)', () => {
+    const result = applyOpsToText(compactConfigFixture, [
+      {
+        kind: 'addArrayStringElement',
+        variableName: 'nextConfig',
+        propertyPath: 'experimental.optimizePackageImports',
+        value: 'gsap',
+      },
+    ])
+    expect(result).toBe(compactConfigFixture)
+  })
+
+  it('should append to a compact single-line array (formatting variant)', () => {
+    const result = applyOpsToText(compactConfigFixture, [addLenis])
+
+    expect(result).toContain('lenis')
+    expect(result).toContain('gsap')
+    expect(result).toContain('three')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// addArrayObjectElement
+// ---------------------------------------------------------------------------
+
+describe('addArrayObjectElement', () => {
+  const addSanityPattern: AstOperation = {
+    kind: 'addArrayObjectElement',
+    variableName: 'nextConfig',
+    propertyPath: 'images.remotePatterns',
+    objectText: "{ protocol: 'https', hostname: 'cdn.sanity.io' }",
+    matchProperty: { name: 'hostname', value: 'cdn.sanity.io' },
+  }
+
+  it('should append the object when no element matches', () => {
+    const result = applyOpsToText(nextConfigFixture, [addSanityPattern])
+
+    expect(result).toContain('cdn.sanity.io')
+    expect(count(result, 'cdn.sanity.io')).toBe(1)
+    // Existing element survives.
+    expect(result).toContain('cdn.shopify.com')
+    // Adding twice is a no-op.
+    expect(applyOpsToText(result, [addSanityPattern])).toBe(result)
+  })
+
+  it('should be an exact no-op when a matching element is present', () => {
+    const result = applyOpsToText(nextConfigFixture, [
+      {
+        kind: 'addArrayObjectElement',
+        variableName: 'nextConfig',
+        propertyPath: 'images.remotePatterns',
+        objectText: "{ protocol: 'https', hostname: 'cdn.shopify.com' }",
+        matchProperty: { name: 'hostname', value: 'cdn.shopify.com' },
+      },
+    ])
+    expect(result).toBe(nextConfigFixture)
+  })
+
+  it('should normalize quoted keys (exact no-op on compact quoted-key source)', () => {
+    const result = applyOpsToText(compactConfigFixture, [
+      {
+        kind: 'addArrayObjectElement',
+        variableName: 'nextConfig',
+        propertyPath: 'images.remotePatterns',
+        objectText: "{ protocol: 'https', hostname: 'cdn.shopify.com' }",
+        matchProperty: { name: 'hostname', value: 'cdn.shopify.com' },
+      },
+    ])
+    expect(result).toBe(compactConfigFixture)
+  })
+
+  it('should append to a compact single-line array (formatting variant)', () => {
+    const result = applyOpsToText(compactConfigFixture, [addSanityPattern])
+
+    expect(result).toContain('cdn.sanity.io')
+    expect(result).toContain('cdn.shopify.com')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// addVariableStatement
+// ---------------------------------------------------------------------------
+
+describe('addVariableStatement', () => {
+  const lazyCanvasStatement =
+    "const LazyGlobalCanvas = dynamic(() => import('@/webgl/components/canvas').then((m) => m.GlobalCanvas))"
+
+  const addLazyCanvas: AstOperation = {
+    kind: 'addVariableStatement',
+    name: 'LazyGlobalCanvas',
+    text: lazyCanvasStatement,
+  }
+
+  const featuresFixture = `'use client'
+
+import dynamic from 'next/dynamic'
+
+export function OptionalFeatures() {
+  return null
+}
+`
+
+  it('should insert after the last import when absent', () => {
+    const result = applyOpsToText(featuresFixture, [addLazyCanvas])
+
+    expect(result).toContain('const LazyGlobalCanvas')
+    // Placement: after the import, before the function.
+    expect(result.indexOf("'next/dynamic'")).toBeLessThan(
+      result.indexOf('const LazyGlobalCanvas')
+    )
+    expect(result.indexOf('const LazyGlobalCanvas')).toBeLessThan(
+      result.indexOf('export function OptionalFeatures')
+    )
+    // Adding twice is a no-op.
+    expect(applyOpsToText(result, [addLazyCanvas])).toBe(result)
+  })
+
+  it('should be an exact no-op when the variable exists at top level', () => {
+    const fixture = `import dynamic from 'next/dynamic'
+
+const LazyGlobalCanvas = dynamic(() => import('@/webgl/components/canvas'))
+
+export function OptionalFeatures() {
+  return null
+}
+`
+    expect(applyOpsToText(fixture, [addLazyCanvas])).toBe(fixture)
+  })
+
+  it('should be an exact no-op when the variable exists in function scope (descendant scan)', () => {
+    const fixture = `export function OptionalFeatures() {
+  const LazyGlobalCanvas = null
+  return LazyGlobalCanvas
+}
+`
+    expect(applyOpsToText(fixture, [addLazyCanvas])).toBe(fixture)
+  })
+
+  it('should append at the end of the file when afterImports is false', () => {
+    const result = applyOpsToText(featuresFixture, [
+      { ...addLazyCanvas, afterImports: false },
+    ])
+
+    expect(result).toContain('const LazyGlobalCanvas')
+    expect(result.indexOf('export function OptionalFeatures')).toBeLessThan(
+      result.indexOf('const LazyGlobalCanvas')
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// addJsxChild
+// ---------------------------------------------------------------------------
+
+describe('addJsxChild', () => {
+  const addCanvasChild: AstOperation = {
+    kind: 'addJsxChild',
+    parentTagName: 'div',
+    childText: '<Canvas root />',
+    childTagName: 'Canvas',
+  }
+
+  it('should append as the last child, matching sibling indentation', () => {
+    const fixture = `export function Wrapper({ children }) {
+  return (
+    <div>
+      <main>{children}</main>
+    </div>
+  )
+}
+`
+    const result = applyOpsToText(fixture, [addCanvasChild])
+
+    expect(result).toContain(
+      '      <main>{children}</main>\n      <Canvas root />\n    </div>'
+    )
+    // Adding twice is a no-op.
+    expect(applyOpsToText(result, [addCanvasChild])).toBe(result)
+  })
+
+  it('should be an exact no-op when the child tag exists anywhere in the file', () => {
+    const fixture = `export function Wrapper({ children }) {
+  return (
+    <div>
+      <Canvas root />
+      <main>{children}</main>
+    </div>
+  )
+}
+`
+    expect(applyOpsToText(fixture, [addCanvasChild])).toBe(fixture)
+  })
+
+  it('should insert inline before the closing tag of a single-line parent (formatting variant)', () => {
+    const fixture = `export function Wrapper({ children }) {
+  return <div><main>{children}</main></div>
+}
+`
+    const result = applyOpsToText(fixture, [addCanvasChild])
+
+    expect(result).toContain('<main>{children}</main><Canvas root /></div>')
+  })
+
+  it('should indent one level past the closing tag when the parent has no element children', () => {
+    const fixture = `export function App() {
+  return (
+    <Layout>
+    </Layout>
+  )
+}
+`
+    const result = applyOpsToText(fixture, [
+      {
+        kind: 'addJsxChild',
+        parentTagName: 'Layout',
+        childText: '<Canvas root />',
+        childTagName: 'Canvas',
+      },
+    ])
+
+    expect(result).toContain(
+      '    <Layout>\n      <Canvas root />\n    </Layout>'
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Round trips — remove + add (and vice versa) on a realistic
+// next.config-shaped fixture leave the construct present exactly once.
+// ---------------------------------------------------------------------------
+
+describe('Round Trips (remove + add)', () => {
+  const nextConfigRealistic = `import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    optimizePackageImports: [
+      '@react-three/drei',
+      '@react-three/fiber',
+      'gsap',
+      'three',
+    ],
+  },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'cdn.shopify.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'cdn.sanity.io',
+      },
+    ],
+  },
+}
+
+export default nextConfig
+`
+
+  it('remove then add string element leaves the value present exactly once', () => {
+    const result = applyOpsToText(nextConfigRealistic, [
+      {
+        kind: 'removeArrayStringElement',
+        variableName: 'nextConfig',
+        propertyPath: 'experimental.optimizePackageImports',
+        value: 'gsap',
+      },
+      {
+        kind: 'addArrayStringElement',
+        variableName: 'nextConfig',
+        propertyPath: 'experimental.optimizePackageImports',
+        value: 'gsap',
+      },
+    ])
+
+    expect(count(result, "'gsap'")).toBe(1)
+    // Untouched entries are unaffected.
+    expect(count(result, "'three'")).toBe(1)
+    expect(count(result, '@react-three/drei')).toBe(1)
+  })
+
+  it('add then remove string element leaves the original array intact', () => {
+    const result = applyOpsToText(nextConfigRealistic, [
+      {
+        kind: 'addArrayStringElement',
+        variableName: 'nextConfig',
+        propertyPath: 'experimental.optimizePackageImports',
+        value: 'lenis',
+      },
+      {
+        kind: 'removeArrayStringElement',
+        variableName: 'nextConfig',
+        propertyPath: 'experimental.optimizePackageImports',
+        value: 'lenis',
+      },
+    ])
+
+    expect(result).not.toContain('lenis')
+    expect(count(result, "'gsap'")).toBe(1)
+    expect(count(result, "'three'")).toBe(1)
+    expect(count(result, '@react-three/drei')).toBe(1)
+    expect(count(result, '@react-three/fiber')).toBe(1)
+  })
+
+  it('remove then add object element leaves the element present exactly once', () => {
+    const result = applyOpsToText(nextConfigRealistic, [
+      {
+        kind: 'removeArrayObjectElement',
+        variableName: 'nextConfig',
+        propertyPath: 'images.remotePatterns',
+        matchProperty: { name: 'hostname', value: 'cdn.sanity.io' },
+      },
+      {
+        kind: 'addArrayObjectElement',
+        variableName: 'nextConfig',
+        propertyPath: 'images.remotePatterns',
+        objectText: "{ protocol: 'https', hostname: 'cdn.sanity.io' }",
+        matchProperty: { name: 'hostname', value: 'cdn.sanity.io' },
+      },
+    ])
+
+    expect(count(result, 'cdn.sanity.io')).toBe(1)
+    expect(count(result, 'cdn.shopify.com')).toBe(1)
+  })
+
+  it('add then remove object element leaves the original patterns intact', () => {
+    const result = applyOpsToText(nextConfigRealistic, [
+      {
+        kind: 'addArrayObjectElement',
+        variableName: 'nextConfig',
+        propertyPath: 'images.remotePatterns',
+        objectText: "{ protocol: 'https', hostname: 'images.ctfassets.net' }",
+        matchProperty: { name: 'hostname', value: 'images.ctfassets.net' },
+      },
+      {
+        kind: 'removeArrayObjectElement',
+        variableName: 'nextConfig',
+        propertyPath: 'images.remotePatterns',
+        matchProperty: { name: 'hostname', value: 'images.ctfassets.net' },
+      },
+    ])
+
+    expect(result).not.toContain('images.ctfassets.net')
+    expect(count(result, 'cdn.shopify.com')).toBe(1)
+    expect(count(result, 'cdn.sanity.io')).toBe(1)
+  })
+
+  it('remove then add import leaves the declaration present exactly once', () => {
+    const result = applyOpsToText(nextConfigRealistic, [
+      { kind: 'removeImport', specifier: 'next' },
+      {
+        kind: 'addImport',
+        text: "import type { NextConfig } from 'next'",
+      },
+    ])
+
+    expect(count(result, "from 'next'")).toBe(1)
+    expect(result).toContain('NextConfig')
+  })
+})

--- a/lib/scripts/ast-transforms.test.ts
+++ b/lib/scripts/ast-transforms.test.ts
@@ -429,6 +429,136 @@ describe('addJsxChild', () => {
 })
 
 // ---------------------------------------------------------------------------
+// addJsxChild — fragment parents and attribute-narrowed idempotency
+// ---------------------------------------------------------------------------
+
+describe('addJsxChild (fragment parent)', () => {
+  const fragmentFixture = `export function OptionalFeatures() {
+  return (
+    <>
+      <GSAPRuntime />
+      {isDevelopment && <OrchestraTools />}
+    </>
+  )
+}
+`
+
+  const addLazyCanvas: AstOperation = {
+    kind: 'addJsxChild',
+    parentTagName: 'Fragment',
+    childText: '<LazyGlobalCanvas />',
+    childTagName: 'LazyGlobalCanvas',
+  }
+
+  it("targets the first JSX fragment when parentTagName is 'Fragment'", () => {
+    const result = applyOpsToText(fragmentFixture, [addLazyCanvas])
+
+    expect(result).toContain('<LazyGlobalCanvas />')
+    // Appended as the last fragment child, before the closing `</>`.
+    expect(result.indexOf('<OrchestraTools />')).toBeLessThan(
+      result.indexOf('<LazyGlobalCanvas />')
+    )
+    expect(result.indexOf('<LazyGlobalCanvas />')).toBeLessThan(
+      result.indexOf('</>')
+    )
+    // Adding twice is a no-op.
+    expect(applyOpsToText(result, [addLazyCanvas])).toBe(result)
+  })
+
+  it('inserts a JSX expression child into a fragment', () => {
+    const fixture = `export function OrchestraTools() {
+  return (
+    <>
+      <Cmdo />
+      {stats && <Stats />}
+    </>
+  )
+}
+`
+    const op: AstOperation = {
+      kind: 'addJsxChild',
+      parentTagName: 'Fragment',
+      childText: '{studio && <Studio />}',
+      childTagName: 'Studio',
+    }
+    const result = applyOpsToText(fixture, [op])
+
+    expect(result).toContain('{studio && <Studio />}')
+    expect(result.indexOf('{stats && <Stats />}')).toBeLessThan(
+      result.indexOf('{studio && <Studio />}')
+    )
+    // Adding twice is a no-op (the <Studio /> element now exists).
+    expect(applyOpsToText(result, [op])).toBe(result)
+  })
+
+  it('is a no-op when the file has no fragment and no matching element', () => {
+    const fixture = `export function Thing() {
+  return <div>content</div>
+}
+`
+    expect(applyOpsToText(fixture, [addLazyCanvas])).toBe(fixture)
+  })
+})
+
+describe('addJsxChild (childAttribute disambiguation + sibling-aware parent)', () => {
+  const togglesFixture = `export function Cmdo() {
+  return (
+    <div id="orchestra">
+      <Backdrop />
+      <div className="row">
+        <OrchestraToggle id="grid">G</OrchestraToggle>
+        <OrchestraToggle id="stats">S</OrchestraToggle>
+      </div>
+    </div>
+  )
+}
+`
+
+  const addWebglToggle: AstOperation = {
+    kind: 'addJsxChild',
+    parentTagName: 'div',
+    childText: '<OrchestraToggle id="webgl">W</OrchestraToggle>',
+    childTagName: 'OrchestraToggle',
+    childAttribute: { name: 'id', value: 'webgl' },
+  }
+
+  it('inserts next to same-tag siblings (not into the first tag match)', () => {
+    const result = applyOpsToText(togglesFixture, [addWebglToggle])
+
+    expect(result).toContain('id="webgl"')
+    // Placed after the existing toggles…
+    expect(result.indexOf('id="stats"')).toBeLessThan(
+      result.indexOf('id="webgl"')
+    )
+    // …and inside the inner row div (before its closing tag), not appended
+    // to the outer `<div id="orchestra">`.
+    expect(result.indexOf('id="webgl"')).toBeLessThan(result.indexOf('</div>'))
+    // Adding twice is a no-op.
+    expect(applyOpsToText(result, [addWebglToggle])).toBe(result)
+  })
+
+  it('same-tag siblings with different attributes do not block insertion', () => {
+    // Without childAttribute the existing OrchestraToggles would no-op the
+    // add; with it, only an id="webgl" match blocks.
+    const result = applyOpsToText(togglesFixture, [addWebglToggle])
+    expect(count(result, '<OrchestraToggle')).toBe(3)
+  })
+
+  it('is an exact no-op when the matching attribute already exists', () => {
+    const blocked = applyOpsToText(togglesFixture, [
+      {
+        kind: 'addJsxChild',
+        parentTagName: 'div',
+        childText: '<OrchestraToggle id="grid">G</OrchestraToggle>',
+        childTagName: 'OrchestraToggle',
+        childAttribute: { name: 'id', value: 'grid' },
+      },
+    ])
+    expect(blocked).toBe(togglesFixture)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Round trips — remove + add (and vice versa) on a realistic
 // next.config-shaped fixture leave the construct present exactly once.
 // ---------------------------------------------------------------------------

--- a/lib/scripts/ast-transforms.ts
+++ b/lib/scripts/ast-transforms.ts
@@ -653,7 +653,9 @@ function applyAddArrayStringElement(
     return sourceText
   }
 
-  arr.addElement(`'${op.value.replace(/'/g, "\\'")}'`, {
+  // Escape backslashes before quotes so the emitted literal round-trips.
+  const escaped = op.value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+  arr.addElement(`'${escaped}'`, {
     useNewLines: arr.getText().includes('\n'),
   })
 

--- a/lib/scripts/ast-transforms.ts
+++ b/lib/scripts/ast-transforms.ts
@@ -7,16 +7,23 @@
  */
 
 import {
+  IndentationText,
   type JsxAttributeLike,
   type JsxElement,
   type JsxSelfClosingElement,
   type Node,
   Project,
+  QuoteKind,
   type SourceFile,
   SyntaxKind,
   ts,
 } from 'ts-morph'
 import type {
+  AddArrayObjectElementOp,
+  AddArrayStringElementOp,
+  AddImportOp,
+  AddJsxChildOp,
+  AddVariableStatementOp,
   AstOperation,
   CodeTransform,
   RemoveArrayObjectElementOp,
@@ -83,6 +90,56 @@ function openElementMatchesOp(el: JsxElement, op: RemoveJsxElementOp): boolean {
     if (val !== op.attribute.value) return false
   }
   return true
+}
+
+/**
+ * True when an array element is an object literal containing a property whose
+ * name and string value both match `matchProperty`. Quoted property names
+ * ("hostname": …) are normalized to bare names before comparison.
+ */
+function objectElementMatches(
+  el: Node,
+  matchProperty: { name: string; value: string }
+): boolean {
+  if (el.getKind() !== SyntaxKind.ObjectLiteralExpression) return false
+  const obj = el.asKindOrThrow(SyntaxKind.ObjectLiteralExpression)
+  const matchProp = obj.getProperties().find(
+    (p) =>
+      p.getKind() === SyntaxKind.PropertyAssignment &&
+      // Normalize quoted property names ("hostname": …) to bare names.
+      p
+        .asKindOrThrow(SyntaxKind.PropertyAssignment)
+        .getName()
+        .replace(/^['"]|['"]$/g, '') === matchProperty.name
+  )
+  if (!matchProp) return false
+  const initNode = matchProp
+    .asKindOrThrow(SyntaxKind.PropertyAssignment)
+    .getInitializer()
+  if (!initNode) return false
+  const initValue =
+    initNode.getKind() === SyntaxKind.StringLiteral
+      ? initNode.asKindOrThrow(SyntaxKind.StringLiteral).getLiteralValue()
+      : undefined
+  return initValue === matchProperty.value
+}
+
+/**
+ * Statement index immediately after the last import declaration, falling back
+ * to just past any directive prologue ('use client', …) when no imports exist.
+ */
+function insertIndexAfterImports(sf: SourceFile): number {
+  const imports = sf.getImportDeclarations()
+  const lastImport = imports[imports.length - 1]
+  if (lastImport) return lastImport.getChildIndex() + 1
+
+  let index = 0
+  for (const stmt of sf.getStatements()) {
+    const expr = stmt.asKind(SyntaxKind.ExpressionStatement)?.getExpression()
+    if (expr?.getKind() !== SyntaxKind.StringLiteral) break
+    index++
+  }
+  return index
 }
 
 // ---------------------------------------------------------------------------
@@ -434,26 +491,7 @@ function applyRemoveArrayObjectElement(
   const elements = arr.getElements()
 
   for (const el of elements) {
-    if (el.getKind() !== SyntaxKind.ObjectLiteralExpression) continue
-    const obj = el.asKindOrThrow(SyntaxKind.ObjectLiteralExpression)
-    const matchProp = obj.getProperties().find(
-      (p) =>
-        p.getKind() === SyntaxKind.PropertyAssignment &&
-        // Normalize quoted property names ("hostname": …) to bare names.
-        p
-          .asKindOrThrow(SyntaxKind.PropertyAssignment)
-          .getName()
-          .replace(/^['"]|['"]$/g, '') === op.matchProperty.name
-    )
-    if (!matchProp) continue
-    const pa = matchProp.asKindOrThrow(SyntaxKind.PropertyAssignment)
-    const initNode = pa.getInitializer()
-    if (!initNode) continue
-    const initValue =
-      initNode.getKind() === SyntaxKind.StringLiteral
-        ? initNode.asKindOrThrow(SyntaxKind.StringLiteral).getLiteralValue()
-        : undefined
-    if (initValue !== op.matchProperty.value) continue
+    if (!objectElementMatches(el, op.matchProperty)) continue
 
     // Found the matching element — remove it from the array
     arr.removeElement(el)
@@ -501,6 +539,292 @@ function applyRemoveArrayStringElement(
 }
 
 // ---------------------------------------------------------------------------
+// Additive operation handlers
+// Every additive handler is IDEMPOTENT: when the construct it would add is
+// already present, the original source text is returned byte-for-byte
+// unchanged (the no-op paths return `sourceText`, never re-printed text).
+// ---------------------------------------------------------------------------
+
+/**
+ * Add an import declaration given as full source text. The text is parsed in
+ * a throwaway file to extract its module specifier and bindings, so arbitrary
+ * formatting of both the op text and the target file is handled.
+ *
+ * - Existing import from the same specifier: merge missing named imports (and
+ *   a missing default import) into it; no-op when everything is present.
+ * - No existing import: insert after the last import declaration, or after
+ *   the directive prologue ('use client') when the file has no imports.
+ */
+function applyAddImport(
+  project: Project,
+  sourceText: string,
+  op: AddImportOp
+): string {
+  const opSf = project.createSourceFile('__op__.tsx', op.text)
+  const opDecl = opSf.getImportDeclarations()[0]
+  if (!opDecl) {
+    project.removeSourceFile(opSf)
+    return sourceText
+  }
+
+  const specifier = opDecl.getModuleSpecifierValue()
+  const namedImports = opDecl.getNamedImports().map((n) => ({
+    name: n.getName(),
+    alias: n.getAliasNode()?.getText(),
+  }))
+  const defaultImport = opDecl.getDefaultImport()?.getText()
+  project.removeSourceFile(opSf)
+
+  const sf = project.createSourceFile('__tmp__.tsx', sourceText)
+  const existing = sf
+    .getImportDeclarations()
+    .find((d) => d.getModuleSpecifierValue() === specifier)
+
+  if (existing) {
+    let changed = false
+
+    // A namespace import (`import * as X`) cannot carry named/default
+    // bindings; the module is already imported, so treat as present.
+    if (!existing.getNamespaceImport()) {
+      if (defaultImport && !existing.getDefaultImport()) {
+        existing.setDefaultImport(defaultImport)
+        changed = true
+      }
+
+      // Merge missing named imports, compared by imported name so aliased
+      // re-imports of the same binding don't duplicate.
+      const existingNames = new Set(
+        existing.getNamedImports().map((n) => n.getName())
+      )
+      const missing = namedImports.filter((n) => !existingNames.has(n.name))
+      if (missing.length > 0) {
+        existing.addNamedImports(
+          missing.map((n) => (n.alias ? `${n.name} as ${n.alias}` : n.name))
+        )
+        changed = true
+      }
+    }
+
+    const result = changed ? sf.getFullText() : sourceText
+    project.removeSourceFile(sf)
+    return result
+  }
+
+  sf.insertStatements(insertIndexAfterImports(sf), op.text)
+  const result = sf.getFullText()
+  project.removeSourceFile(sf)
+  return result
+}
+
+/**
+ * Append a string-literal element to the array at
+ * `variableName`.`propertyPath`. No-op when an element with the same literal
+ * value (regardless of quote style) already exists.
+ */
+function applyAddArrayStringElement(
+  project: Project,
+  sourceText: string,
+  op: AddArrayStringElementOp
+): string {
+  const { sf, node } = resolvePropertyPath(
+    project,
+    sourceText,
+    op.variableName,
+    op.propertyPath
+  )
+
+  if (!node || node.getKind() !== SyntaxKind.ArrayLiteralExpression) {
+    project.removeSourceFile(sf)
+    return sourceText
+  }
+
+  const arr = node.asKindOrThrow(SyntaxKind.ArrayLiteralExpression)
+  const alreadyPresent = arr
+    .getElements()
+    .some(
+      (el) =>
+        el.getKind() === SyntaxKind.StringLiteral &&
+        el.asKindOrThrow(SyntaxKind.StringLiteral).getLiteralValue() ===
+          op.value
+    )
+  if (alreadyPresent) {
+    project.removeSourceFile(sf)
+    return sourceText
+  }
+
+  arr.addElement(`'${op.value.replace(/'/g, "\\'")}'`, {
+    useNewLines: arr.getText().includes('\n'),
+  })
+
+  const result = sf.getFullText()
+  project.removeSourceFile(sf)
+  return result
+}
+
+/**
+ * Append an object-literal element (given as source text) to the array at
+ * `variableName`.`propertyPath`. No-op when an element already matches
+ * `matchProperty` — same semantics as removeArrayObjectElement, including
+ * quoted-key normalization.
+ */
+function applyAddArrayObjectElement(
+  project: Project,
+  sourceText: string,
+  op: AddArrayObjectElementOp
+): string {
+  const { sf, node } = resolvePropertyPath(
+    project,
+    sourceText,
+    op.variableName,
+    op.propertyPath
+  )
+
+  if (!node || node.getKind() !== SyntaxKind.ArrayLiteralExpression) {
+    project.removeSourceFile(sf)
+    return sourceText
+  }
+
+  const arr = node.asKindOrThrow(SyntaxKind.ArrayLiteralExpression)
+  const alreadyPresent = arr
+    .getElements()
+    .some((el) => objectElementMatches(el, op.matchProperty))
+  if (alreadyPresent) {
+    project.removeSourceFile(sf)
+    return sourceText
+  }
+
+  arr.addElement(op.objectText, {
+    useNewLines: arr.getText().includes('\n'),
+  })
+
+  const result = sf.getFullText()
+  project.removeSourceFile(sf)
+  return result
+}
+
+/**
+ * Insert a full variable statement. No-op when a variable named `name`
+ * already exists anywhere in the file — descendant scan mirrors
+ * removeVariableStatement, so function-scoped declarations count as present.
+ */
+function applyAddVariableStatement(
+  project: Project,
+  sourceText: string,
+  op: AddVariableStatementOp
+): string {
+  const sf = project.createSourceFile('__tmp__.tsx', sourceText)
+
+  const exists = sf
+    .getDescendantsOfKind(SyntaxKind.VariableDeclaration)
+    .some((d) => d.getName() === op.name)
+  if (exists) {
+    project.removeSourceFile(sf)
+    return sourceText
+  }
+
+  if (op.afterImports === false) {
+    sf.addStatements(op.text)
+  } else {
+    sf.insertStatements(insertIndexAfterImports(sf), op.text)
+  }
+
+  const result = sf.getFullText()
+  project.removeSourceFile(sf)
+  return result
+}
+
+/** JSX child kinds considered when matching an existing child's indentation. */
+const JSX_CHILD_KINDS: SyntaxKind[] = [
+  SyntaxKind.JsxElement,
+  SyntaxKind.JsxSelfClosingElement,
+  SyntaxKind.JsxExpression,
+  SyntaxKind.JsxFragment,
+]
+
+/**
+ * Line indentation of the last element-ish JSX child, when that child sits on
+ * its own line. Returns undefined for inline children (single-line parents).
+ */
+function lastJsxChildIndent(
+  parent: JsxElement,
+  sourceText: string
+): string | undefined {
+  const children = parent
+    .getJsxChildren()
+    .filter((c) => JSX_CHILD_KINDS.includes(c.getKind()))
+  const last = children[children.length - 1]
+  if (!last) return undefined
+
+  const start = last.getStart()
+  const lineStart = sourceText.lastIndexOf('\n', start - 1) + 1
+  const prefix = sourceText.slice(lineStart, start)
+  return /^[ \t]*$/.test(prefix) ? prefix : undefined
+}
+
+/**
+ * Append `childText` as the last child of the first JSX element whose opening
+ * tag matches `parentTagName`. No-op when any JSX element (or self-closing
+ * element) with tag `childTagName` already exists anywhere in the file.
+ *
+ * Indentation heuristic: when the parent's closing tag sits on its own line,
+ * the child goes on its own line matching the last existing child's indent
+ * (or one level past the closing tag). Single-line parents get the child
+ * inserted inline before the closing tag.
+ */
+function applyAddJsxChild(
+  project: Project,
+  sourceText: string,
+  op: AddJsxChildOp
+): string {
+  const sf = project.createSourceFile('__tmp__.tsx', sourceText)
+
+  const childExists =
+    sf
+      .getDescendantsOfKind(SyntaxKind.JsxSelfClosingElement)
+      .some((el) => el.getTagNameNode().getText() === op.childTagName) ||
+    sf
+      .getDescendantsOfKind(SyntaxKind.JsxElement)
+      .some(
+        (el) =>
+          el.getOpeningElement().getTagNameNode().getText() === op.childTagName
+      )
+  if (childExists) {
+    project.removeSourceFile(sf)
+    return sourceText
+  }
+
+  const parent = sf
+    .getDescendantsOfKind(SyntaxKind.JsxElement)
+    .find(
+      (el) =>
+        el.getOpeningElement().getTagNameNode().getText() === op.parentTagName
+    )
+  if (!parent) {
+    project.removeSourceFile(sf)
+    return sourceText
+  }
+
+  const closing = parent.getClosingElement()
+  const closingStart = closing.getStart()
+  const lineStart = sourceText.lastIndexOf('\n', closingStart - 1) + 1
+  const closingLinePrefix = sourceText.slice(lineStart, closingStart)
+
+  if (/^[ \t]*$/.test(closingLinePrefix)) {
+    // Closing tag on its own line — give the child its own indented line.
+    const childIndent =
+      lastJsxChildIndent(parent, sourceText) ?? `${closingLinePrefix}  `
+    sf.insertText(lineStart, `${childIndent}${op.childText}\n`)
+  } else {
+    // Single-line parent (e.g. `<main>{children}</main>`) — insert inline.
+    sf.insertText(closingStart, op.childText)
+  }
+
+  const result = sf.getFullText()
+  project.removeSourceFile(sf)
+  return result
+}
+
+// ---------------------------------------------------------------------------
 // Per-file transform runner
 // ---------------------------------------------------------------------------
 
@@ -521,6 +845,12 @@ export function applyOpsToText(
   const project = new Project({
     useInMemoryFileSystem: true,
     compilerOptions: { jsx: ts.JsxEmit.ReactJSX },
+    // Match house style (Biome: 2-space indent, single quotes) so additive
+    // ops insert text that needs no reformatting.
+    manipulationSettings: {
+      indentationText: IndentationText.TwoSpaces,
+      quoteKind: QuoteKind.Single,
+    },
   })
   let text = sourceText
 
@@ -552,6 +882,21 @@ export function applyOpsToText(
         break
       case 'removeArrayStringElement':
         text = applyRemoveArrayStringElement(project, text, op)
+        break
+      case 'addImport':
+        text = applyAddImport(project, text, op)
+        break
+      case 'addArrayStringElement':
+        text = applyAddArrayStringElement(project, text, op)
+        break
+      case 'addArrayObjectElement':
+        text = applyAddArrayObjectElement(project, text, op)
+        break
+      case 'addVariableStatement':
+        text = applyAddVariableStatement(project, text, op)
+        break
+      case 'addJsxChild':
+        text = applyAddJsxChild(project, text, op)
         break
       // Exhaustiveness — TypeScript ensures all union members are handled above.
     }

--- a/lib/scripts/ast-transforms.ts
+++ b/lib/scripts/ast-transforms.ts
@@ -10,6 +10,7 @@ import {
   IndentationText,
   type JsxAttributeLike,
   type JsxElement,
+  type JsxFragment,
   type JsxSelfClosingElement,
   type Node,
   Project,
@@ -746,7 +747,7 @@ const JSX_CHILD_KINDS: SyntaxKind[] = [
  * its own line. Returns undefined for inline children (single-line parents).
  */
 function lastJsxChildIndent(
-  parent: JsxElement,
+  parent: JsxElement | JsxFragment,
   sourceText: string
 ): string | undefined {
   const children = parent
@@ -763,8 +764,15 @@ function lastJsxChildIndent(
 
 /**
  * Append `childText` as the last child of the first JSX element whose opening
- * tag matches `parentTagName`. No-op when any JSX element (or self-closing
- * element) with tag `childTagName` already exists anywhere in the file.
+ * tag matches `parentTagName`. Among same-tag candidates, an element that
+ * already contains a direct `childTagName` child wins, so re-added elements
+ * land next to their siblings. `parentTagName: 'Fragment'` falls back to the
+ * first JSX fragment (`<>…</>`) when no `<Fragment>` element matches.
+ *
+ * No-op when any JSX element (or self-closing element) with tag
+ * `childTagName` already exists anywhere in the file — narrowed to elements
+ * whose attribute matches when `op.childAttribute` is provided (so e.g.
+ * `<OrchestraToggle id="webgl">` can be re-added next to other toggles).
  *
  * Indentation heuristic: when the parent's closing tag sits on its own line,
  * the child goes on its own line matching the last existing child's indent
@@ -778,33 +786,86 @@ function applyAddJsxChild(
 ): string {
   const sf = project.createSourceFile('__tmp__.tsx', sourceText)
 
+  const childMatches = (
+    tagName: string,
+    getAttribute: (name: string) => JsxAttributeLike | undefined
+  ): boolean => {
+    if (tagName !== op.childTagName) return false
+    if (!op.childAttribute) return true
+    return (
+      jsxAttrStringValue(getAttribute(op.childAttribute.name)) ===
+      op.childAttribute.value
+    )
+  }
+
   const childExists =
     sf
       .getDescendantsOfKind(SyntaxKind.JsxSelfClosingElement)
-      .some((el) => el.getTagNameNode().getText() === op.childTagName) ||
+      .some((el) =>
+        childMatches(el.getTagNameNode().getText(), (name) =>
+          el.getAttribute(name)
+        )
+      ) ||
     sf
       .getDescendantsOfKind(SyntaxKind.JsxElement)
-      .some(
-        (el) =>
-          el.getOpeningElement().getTagNameNode().getText() === op.childTagName
+      .some((el) =>
+        childMatches(
+          el.getOpeningElement().getTagNameNode().getText(),
+          (name) => el.getOpeningElement().getAttribute(name)
+        )
       )
   if (childExists) {
     project.removeSourceFile(sf)
     return sourceText
   }
 
-  const parent = sf
+  // True when `el` has a direct JSX child whose tag matches the op's child.
+  const hasSameTagChild = (el: JsxElement | JsxFragment): boolean =>
+    el.getJsxChildren().some((child) => {
+      if (child.getKind() === SyntaxKind.JsxSelfClosingElement) {
+        return (
+          child
+            .asKindOrThrow(SyntaxKind.JsxSelfClosingElement)
+            .getTagNameNode()
+            .getText() === op.childTagName
+        )
+      }
+      if (child.getKind() === SyntaxKind.JsxElement) {
+        return (
+          child
+            .asKindOrThrow(SyntaxKind.JsxElement)
+            .getOpeningElement()
+            .getTagNameNode()
+            .getText() === op.childTagName
+        )
+      }
+      return false
+    })
+
+  const candidates = sf
     .getDescendantsOfKind(SyntaxKind.JsxElement)
-    .find(
+    .filter(
       (el) =>
         el.getOpeningElement().getTagNameNode().getText() === op.parentTagName
     )
+
+  let parent: JsxElement | JsxFragment | undefined =
+    candidates.find(hasSameTagChild) ?? candidates[0]
+
+  if (!parent && op.parentTagName === 'Fragment') {
+    const fragments = sf.getDescendantsOfKind(SyntaxKind.JsxFragment)
+    parent = fragments.find(hasSameTagChild) ?? fragments[0]
+  }
+
   if (!parent) {
     project.removeSourceFile(sf)
     return sourceText
   }
 
-  const closing = parent.getClosingElement()
+  const closing =
+    parent.getKind() === SyntaxKind.JsxFragment
+      ? parent.asKindOrThrow(SyntaxKind.JsxFragment).getClosingFragment()
+      : parent.asKindOrThrow(SyntaxKind.JsxElement).getClosingElement()
   const closingStart = closing.getStart()
   const lineStart = sourceText.lastIndexOf('\n', closingStart - 1) + 1
   const closingLinePrefix = sourceText.slice(lineStart, closingStart)

--- a/lib/scripts/integration-bundles.ts
+++ b/lib/scripts/integration-bundles.ts
@@ -134,6 +134,108 @@ export interface RemoveArrayStringElementOp {
   value: string
 }
 
+// ---------------------------------------------------------------------------
+// Additive operations (inverse of the removals above)
+// Every additive op is IDEMPOTENT: when the construct it would add is already
+// present, the source text is returned byte-for-byte unchanged, so applying
+// the same op twice is a no-op.
+// ---------------------------------------------------------------------------
+
+/**
+ * Add a top-level import declaration, given as full source text.
+ *
+ * If an import with the same module specifier already exists, any missing
+ * named imports are merged into it (no-op when all bindings are present).
+ * Otherwise the declaration is inserted after the last existing import, e.g.
+ * re-adding `import { Canvas } from '@/webgl/components/canvas'`.
+ */
+export interface AddImportOp {
+  kind: 'addImport'
+  /** Full import declaration text, e.g. `import { Canvas } from '@/webgl/components/canvas'` */
+  text: string
+}
+
+/**
+ * Append a string-literal element to an array property nested inside a named
+ * variable declaration.  Inverse of `removeArrayStringElement`; designed for
+ * `experimental.optimizePackageImports` in next.config.ts.
+ *
+ * No-op when an element with the same literal value already exists.
+ */
+export interface AddArrayStringElementOp {
+  kind: 'addArrayStringElement'
+  /** The variable name that holds the object, e.g. `'nextConfig'`. */
+  variableName: string
+  /**
+   * Dot-separated path from the variable declaration down to the array
+   * property, e.g. `'experimental.optimizePackageImports'`.
+   */
+  propertyPath: string
+  /** The string value to append to the array. */
+  value: string
+}
+
+/**
+ * Append an object-literal element to an array property nested inside a named
+ * variable declaration.  Inverse of `removeArrayObjectElement`; designed for
+ * `images.remotePatterns` in next.config.ts.
+ *
+ * No-op when an element already matches `matchProperty` (same matching
+ * semantics as `removeArrayObjectElement`, including quoted-key
+ * normalization).
+ */
+export interface AddArrayObjectElementOp {
+  kind: 'addArrayObjectElement'
+  /** The variable name that holds the object, e.g. `'nextConfig'`. */
+  variableName: string
+  /**
+   * Dot-separated path from the variable declaration down to the array
+   * property, e.g. `'images.remotePatterns'`.
+   */
+  propertyPath: string
+  /** The object literal to append, as source text, e.g. `{ protocol: 'https', hostname: 'cdn.sanity.io' }` */
+  objectText: string
+  /** Property name + value identifying an already-present matching element. */
+  matchProperty: { name: string; value: string }
+}
+
+/**
+ * Insert a full variable statement, e.g. re-adding
+ * `const LazyGlobalCanvas = dynamic(…)` to lib/features/index.tsx.
+ *
+ * No-op when a variable named `name` already exists anywhere in the file
+ * (any scope depth, mirroring `removeVariableStatement`).
+ */
+export interface AddVariableStatementOp {
+  kind: 'addVariableStatement'
+  /** The declared variable name used for the idempotency check, e.g. 'LazyGlobalCanvas' */
+  name: string
+  /** Full statement text to insert, e.g. `const LazyGlobalCanvas = dynamic(() => …)` */
+  text: string
+  /**
+   * When true or omitted, insert after the last import declaration.
+   * When false, append at the end of the file.
+   */
+  afterImports?: boolean
+}
+
+/**
+ * Append a JSX child as the last child of the first element whose opening tag
+ * matches `parentTagName`, e.g. re-adding `<Canvas root />` inside <Wrapper>.
+ *
+ * No-op when any JSX element (or self-closing element) with tag
+ * `childTagName` already exists anywhere in the file.
+ */
+export interface AddJsxChildOp {
+  kind: 'addJsxChild'
+  /** Tag name of the parent element to append into, e.g. 'Wrapper' */
+  parentTagName: string
+  /** The JSX child to append, as source text, e.g. `<Canvas root />` */
+  childText: string
+  /** Tag name of the child, used for the idempotency check, e.g. 'Canvas' */
+  childTagName: string
+}
+
 export type AstOperation =
   | RemoveImportOp
   | RemoveVariableStatementOp
@@ -144,6 +246,11 @@ export type AstOperation =
   | ReplaceJsDocOp
   | RemoveArrayObjectElementOp
   | RemoveArrayStringElementOp
+  | AddImportOp
+  | AddArrayStringElementOp
+  | AddArrayObjectElementOp
+  | AddVariableStatementOp
+  | AddJsxChildOp
 
 export interface CodeTransform {
   /** Path to the file to transform (relative to project root) */

--- a/lib/scripts/integration-bundles.ts
+++ b/lib/scripts/integration-bundles.ts
@@ -2,7 +2,8 @@
  * Integration Bundles Configuration
  *
  * Defines which dependencies, folders, and files belong to each integration.
- * Used by the setup script to selectively remove unused integrations.
+ * Used by the setup script to selectively remove unused integrations, and by
+ * the `satus add` CLI to restore them additively from the public satus repo.
  *
  * Key types (`IntegrationId`, `RemovableId`) are imported from the registry so
  * that adding or renaming a key in one place without the other is a compile error.
@@ -223,17 +224,33 @@ export interface AddVariableStatementOp {
  * Append a JSX child as the last child of the first element whose opening tag
  * matches `parentTagName`, e.g. re-adding `<Canvas root />` inside <Wrapper>.
  *
+ * Parent selection: among same-tag candidates, an element that already
+ * contains a direct child with tag `childTagName` wins, so re-added elements
+ * land next to their siblings (e.g. an OrchestraToggle row). The special
+ * value `parentTagName: 'Fragment'` falls back to the first JSX fragment
+ * (`<>…</>`) when no `<Fragment>` element matches.
+ *
  * No-op when any JSX element (or self-closing element) with tag
- * `childTagName` already exists anywhere in the file.
+ * `childTagName` already exists anywhere in the file — narrowed to elements
+ * whose attribute matches when `childAttribute` is provided.
  */
 export interface AddJsxChildOp {
   kind: 'addJsxChild'
-  /** Tag name of the parent element to append into, e.g. 'Wrapper' */
+  /**
+   * Tag name of the parent element to append into, e.g. 'Wrapper'.
+   * 'Fragment' targets the first JSX fragment when no element matches.
+   */
   parentTagName: string
   /** The JSX child to append, as source text, e.g. `<Canvas root />` */
   childText: string
   /** Tag name of the child, used for the idempotency check, e.g. 'Canvas' */
   childTagName: string
+  /**
+   * Optional attribute narrowing the idempotency check: only an existing
+   * `childTagName` element whose attribute matches blocks insertion, so
+   * `<OrchestraToggle id="webgl">` can be re-added next to other toggles.
+   */
+  childAttribute?: { name: string; value: string }
 }
 
 export type AstOperation =
@@ -276,6 +293,27 @@ export interface IntegrationBundle {
   barrelExports: BarrelExport[]
   /** Code transformations to apply when this integration is removed */
   codeTransforms: CodeTransform[]
+  /**
+   * Other integrations this one depends on. `satus add` resolves these
+   * transitively and installs dependencies first (e.g. theatre requires
+   * webgl for its r3f bindings and the webgl-hook wiring).
+   */
+  requires?: RemovableId[]
+  /**
+   * Additive code transformations applied by `satus add` — the inverse of
+   * `codeTransforms`, built exclusively from the idempotent add* operations.
+   */
+  addTransforms?: CodeTransform[]
+  /**
+   * Integration-owned files copied wholesale from the payload source on
+   * `satus add`, used where statement-level re-injection would be brittle
+   * (e.g. the Theatre wiring inside the webgl fluid/flowmap hooks, or the
+   * webgl Canvas wiring in the Wrapper). A local file is only overwritten
+   * when it matches the payload version (no-op) or the expected lean state
+   * (payload with this bundle's removal ops applied); anything else is
+   * treated as locally modified and skipped with a warning unless --force.
+   */
+  overwriteFiles?: string[]
 }
 
 export const INTEGRATION_BUNDLES: Partial<
@@ -346,6 +384,46 @@ export const INTEGRATION_BUNDLES: Partial<
         ],
       },
     ],
+    addTransforms: [
+      {
+        file: 'next.config.ts',
+        ops: [
+          // Re-add cdn.sanity.io to images.remotePatterns
+          {
+            kind: 'addArrayObjectElement',
+            variableName: 'nextConfig',
+            propertyPath: 'images.remotePatterns',
+            objectText: "{ protocol: 'https', hostname: 'cdn.sanity.io' }",
+            matchProperty: { name: 'hostname', value: 'cdn.sanity.io' },
+          },
+          // Re-add @sanity/* packages to experimental.optimizePackageImports
+          {
+            kind: 'addArrayStringElement',
+            variableName: 'nextConfig',
+            propertyPath: 'experimental.optimizePackageImports',
+            value: '@sanity/client',
+          },
+          {
+            kind: 'addArrayStringElement',
+            variableName: 'nextConfig',
+            propertyPath: 'experimental.optimizePackageImports',
+            value: '@sanity/image-url',
+          },
+          {
+            kind: 'addArrayStringElement',
+            variableName: 'nextConfig',
+            propertyPath: 'experimental.optimizePackageImports',
+            value: '@sanity/asset-utils',
+          },
+          {
+            kind: 'addArrayStringElement',
+            variableName: 'nextConfig',
+            propertyPath: 'experimental.optimizePackageImports',
+            value: '@portabletext/react',
+          },
+        ],
+      },
+    ],
   },
 
   shopify: {
@@ -371,6 +449,21 @@ export const INTEGRATION_BUNDLES: Partial<
             kind: 'removeArrayObjectElement',
             variableName: 'nextConfig',
             propertyPath: 'images.remotePatterns',
+            matchProperty: { name: 'hostname', value: 'cdn.shopify.com' },
+          },
+        ],
+      },
+    ],
+    addTransforms: [
+      {
+        file: 'next.config.ts',
+        ops: [
+          // Re-add cdn.shopify.com to images.remotePatterns
+          {
+            kind: 'addArrayObjectElement',
+            variableName: 'nextConfig',
+            propertyPath: 'images.remotePatterns',
+            objectText: "{ protocol: 'https', hostname: 'cdn.shopify.com' }",
             matchProperty: { name: 'hostname', value: 'cdn.shopify.com' },
           },
         ],
@@ -536,6 +629,78 @@ export const INTEGRATION_BUNDLES: Partial<
         ],
       },
     ],
+    // The Wrapper's Canvas wiring (import + interface property + destructured
+    // param + <Canvas> wrapping <main> + JSDoc) cannot be expressed with the
+    // additive op set — re-wrapping children and restoring interface members
+    // would need bespoke ops. The file is restored wholesale instead, guarded
+    // by the lean-state comparison documented on `overwriteFiles`.
+    overwriteFiles: ['components/layout/wrapper/index.tsx'],
+    addTransforms: [
+      {
+        file: 'next.config.ts',
+        ops: [
+          // Re-add WebGL/Three.js packages to experimental.optimizePackageImports
+          {
+            kind: 'addArrayStringElement',
+            variableName: 'nextConfig',
+            propertyPath: 'experimental.optimizePackageImports',
+            value: '@react-three/drei',
+          },
+          {
+            kind: 'addArrayStringElement',
+            variableName: 'nextConfig',
+            propertyPath: 'experimental.optimizePackageImports',
+            value: '@react-three/fiber',
+          },
+          {
+            kind: 'addArrayStringElement',
+            variableName: 'nextConfig',
+            propertyPath: 'experimental.optimizePackageImports',
+            value: 'three',
+          },
+        ],
+      },
+      {
+        file: 'lib/features/index.tsx',
+        ops: [
+          // Ensure the dynamic() helper import is present
+          { kind: 'addImport', text: "import dynamic from 'next/dynamic'" },
+          // Re-add `const LazyGlobalCanvas = dynamic(…)`
+          {
+            kind: 'addVariableStatement',
+            name: 'LazyGlobalCanvas',
+            text: `const LazyGlobalCanvas = dynamic(
+  () =>
+    import('@/webgl/components/global-canvas').then((mod) => ({
+      default: mod.GlobalCanvas,
+    })),
+  { ssr: false }
+)`,
+          },
+          // Re-add `<LazyGlobalCanvas />` inside the OptionalFeatures fragment
+          {
+            kind: 'addJsxChild',
+            parentTagName: 'Fragment',
+            childText: '<LazyGlobalCanvas />',
+            childTagName: 'LazyGlobalCanvas',
+          },
+        ],
+      },
+      {
+        file: 'lib/dev/cmdo.tsx',
+        ops: [
+          // Re-add the webgl OrchestraToggle next to the other toggles
+          {
+            kind: 'addJsxChild',
+            parentTagName: 'div',
+            childText:
+              '<OrchestraToggle id="webgl" defaultValue={true}>🧊</OrchestraToggle>',
+            childTagName: 'OrchestraToggle',
+            childAttribute: { name: 'id', value: 'webgl' },
+          },
+        ],
+      },
+    ],
   },
 
   theatre: {
@@ -593,6 +758,55 @@ export const INTEGRATION_BUNDLES: Partial<
           {
             kind: 'removeImport',
             specifier: '@/dev/theatre/hooks/use-theatre',
+          },
+        ],
+      },
+    ],
+    // The r3f bindings and the webgl-hook wiring below depend on webgl.
+    requires: ['webgl'],
+    // The fluid/flowmap Theatre wiring (sheet const + useTheatre call inside
+    // hook bodies) is not re-injectable statement-by-statement — these files
+    // are integration-owned and restored wholesale from the payload source.
+    overwriteFiles: [
+      'lib/webgl/utils/fluid/index.tsx',
+      'lib/webgl/utils/flowmaps/index.tsx',
+    ],
+    addTransforms: [
+      {
+        file: 'lib/dev/index.tsx',
+        ops: [
+          // Ensure the dynamic() helper import is present
+          { kind: 'addImport', text: "import dynamic from 'next/dynamic'" },
+          // Re-add `const Studio = dynamic(…)`
+          {
+            kind: 'addVariableStatement',
+            name: 'Studio',
+            text: `const Studio = dynamic(
+  () => import('./theatre/studio').then(({ Studio }) => Studio),
+  { ssr: false }
+)`,
+          },
+          // Re-add `{studio && <Studio />}` inside the OrchestraTools fragment
+          // (`studio` still comes from the useOrchestra() destructuring, which
+          // the removal ops leave in place)
+          {
+            kind: 'addJsxChild',
+            parentTagName: 'Fragment',
+            childText: '{studio && <Studio />}',
+            childTagName: 'Studio',
+          },
+        ],
+      },
+      {
+        file: 'lib/dev/cmdo.tsx',
+        ops: [
+          // Re-add the studio OrchestraToggle next to the other toggles
+          {
+            kind: 'addJsxChild',
+            parentTagName: 'div',
+            childText: '<OrchestraToggle id="studio">⚙️</OrchestraToggle>',
+            childTagName: 'OrchestraToggle',
+            childAttribute: { name: 'id', value: 'studio' },
           },
         ],
       },

--- a/lib/scripts/integration-bundles.ts
+++ b/lib/scripts/integration-bundles.ts
@@ -504,12 +504,10 @@ export const INTEGRATION_BUNDLES: Partial<
     description: 'Three.js and React Three Fiber for 3D graphics',
     dependencies: ['@react-three/drei', '@react-three/fiber', 'three'],
     devDependencies: ['@types/three'],
-    folders: ['lib/webgl', 'components/effects/animated-gradient'],
+    folders: ['lib/webgl'],
     files: [],
     envVars: [],
-    barrelExports: [
-      { file: 'components/effects/index.ts', pattern: 'animated-gradient' },
-    ],
+    barrelExports: [],
     codeTransforms: [
       {
         file: 'next.config.ts',

--- a/lib/scripts/payload-source.test.ts
+++ b/lib/scripts/payload-source.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for payload source resolution (`satus add`).
+ *
+ * Run with: bun test lib/scripts/payload-source.test.ts
+ *
+ * Network-free: only the local-path (`--from`) resolution and the pure
+ * helpers are covered here. The tarball path is exercised in the Phase 3
+ * round-trip e2e.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  listPayloadFiles,
+  payloadPathExists,
+  pickRef,
+  readPayloadFile,
+  readPayloadPackageJson,
+  readPinnedRef,
+  resolvePayloadSource,
+  tarballUrl,
+} from './payload-source'
+
+describe('pickRef', () => {
+  it('prefers the explicit --ref', () => {
+    expect(pickRef('v2.0.1', 'abc123')).toEqual({
+      ref: 'v2.0.1',
+      origin: 'explicit',
+    })
+  })
+
+  it('falls back to the pinned ref', () => {
+    expect(pickRef(undefined, 'abc123')).toEqual({
+      ref: 'abc123',
+      origin: 'pinned',
+    })
+  })
+
+  it('defaults to main when nothing is pinned', () => {
+    expect(pickRef(undefined, undefined)).toEqual({
+      ref: 'main',
+      origin: 'default',
+    })
+  })
+})
+
+describe('tarballUrl', () => {
+  it('builds the codeload URL for a ref', () => {
+    expect(tarballUrl('main')).toBe(
+      'https://codeload.github.com/darkroomengineering/satus/tar.gz/main'
+    )
+  })
+
+  it('supports sha refs', () => {
+    expect(tarballUrl('6f49149')).toBe(
+      'https://codeload.github.com/darkroomengineering/satus/tar.gz/6f49149'
+    )
+  })
+})
+
+describe('readPinnedRef', () => {
+  it('reads the pinned ref from package.json', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'satus-test-'))
+    try {
+      await Bun.write(
+        join(dir, 'package.json'),
+        JSON.stringify({ satus: { ref: 'abc123' } })
+      )
+      expect(await readPinnedRef(dir)).toBe('abc123')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns undefined when package.json has no satus.ref', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'satus-test-'))
+    try {
+      await Bun.write(join(dir, 'package.json'), JSON.stringify({ name: 'x' }))
+      expect(await readPinnedRef(dir)).toBeUndefined()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns undefined when no package.json exists', async () => {
+    expect(await readPinnedRef('/definitely/not/a/real/path')).toBeUndefined()
+  })
+})
+
+describe('resolvePayloadSource (local path)', () => {
+  it('resolves --from to the absolute checkout root with a no-op cleanup', async () => {
+    const source = await resolvePayloadSource({ from: '.' })
+
+    expect(source.root).toBe(process.cwd())
+    expect(source.label).toContain('local checkout')
+    expect(await Bun.file(join(source.root, 'package.json')).exists()).toBe(
+      true
+    )
+
+    // cleanup must be a harmless no-op for local checkouts
+    await source.cleanup()
+    expect(await Bun.file(join(source.root, 'package.json')).exists()).toBe(
+      true
+    )
+  })
+
+  it('fails loudly when the path does not exist', async () => {
+    await expect(
+      resolvePayloadSource({ from: './definitely-not-here-xyz' })
+    ).rejects.toThrow('does not exist')
+  })
+
+  it('fails loudly when the path is not a satus checkout', async () => {
+    // ./app exists but has no package.json
+    await expect(resolvePayloadSource({ from: './app' })).rejects.toThrow(
+      'package.json'
+    )
+  })
+})
+
+describe('payload readers (against the repo itself)', () => {
+  it('reads files and detects existing paths', async () => {
+    const source = await resolvePayloadSource({ from: '.' })
+
+    expect(await payloadPathExists(source, 'next.config.ts')).toBe(true)
+    expect(await payloadPathExists(source, 'not/a/real/file.ts')).toBe(false)
+
+    const text = await readPayloadFile(source, 'next.config.ts')
+    expect(text).toContain('nextConfig')
+  })
+
+  it('fails loudly when reading a missing file', async () => {
+    const source = await resolvePayloadSource({ from: '.' })
+    await expect(readPayloadFile(source, 'not/a/real/file.ts')).rejects.toThrow(
+      'missing'
+    )
+  })
+
+  it('reads the payload package.json for version pinning', async () => {
+    const source = await resolvePayloadSource({ from: '.' })
+    const pkg = await readPayloadPackageJson(source)
+
+    expect(pkg.dependencies?.next).toBeTruthy()
+    expect(pkg.devDependencies?.['ts-morph']).toBeTruthy()
+  })
+
+  it('lists folder files recursively, relative to the payload root', async () => {
+    const source = await resolvePayloadSource({ from: '.' })
+    const files = await listPayloadFiles(source, 'lib/integrations/hubspot')
+
+    expect(files).toContain('lib/integrations/hubspot/action.ts')
+    expect(files).toContain('lib/integrations/hubspot/embed/index.tsx')
+    // Sorted, deterministic output
+    expect([...files].sort()).toEqual(files)
+  })
+
+  it('fails loudly when listing a missing folder', async () => {
+    const source = await resolvePayloadSource({ from: '.' })
+    await expect(
+      listPayloadFiles(source, 'lib/integrations/nope')
+    ).rejects.toThrow('missing folder')
+  })
+})

--- a/lib/scripts/payload-source.ts
+++ b/lib/scripts/payload-source.ts
@@ -1,0 +1,196 @@
+/**
+ * Payload source resolution for the `satus add` CLI.
+ *
+ * The public satus repo IS the registry: an integration's source payload is
+ * pulled either from a local checkout (`--from <path>` — the primary path for
+ * tests and local development) or from a GitHub tarball at a git ref
+ * (`--ref <gitRef>`, the pinned ref recorded in package.json as
+ * `"satus": { "ref": … }`, then `main`).
+ */
+
+import { mkdir, mkdtemp, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { pathExists, projectRoot } from './utils'
+
+export interface PayloadSourceOptions {
+  /** Local satus checkout path (--from). Highest priority. */
+  from?: string | undefined
+  /** Explicit git ref (--ref). Beats the pinned ref. */
+  ref?: string | undefined
+  /** Pinned ref recorded in package.json as `"satus": { "ref": … }`. */
+  pinnedRef?: string | undefined
+}
+
+export interface PayloadSource {
+  /** Absolute path to the root of the payload checkout / extraction. */
+  root: string
+  /** Human-readable origin, for log output. */
+  label: string
+  /** Remove any temp files created during resolution. No-op for `--from`. */
+  cleanup(): Promise<void>
+}
+
+/** Shape of the payload package.json fields the CLI reads versions from. */
+export interface PayloadPackageJson {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  [key: string]: unknown
+}
+
+const REPO_TARBALL_BASE =
+  'https://codeload.github.com/darkroomengineering/satus/tar.gz/'
+
+/** URL of the GitHub tarball for a satus git ref. */
+export const tarballUrl = (ref: string): string => `${REPO_TARBALL_BASE}${ref}`
+
+/** Pick the git ref to fetch: explicit `--ref` > pinned ref > `main`. */
+export const pickRef = (
+  explicitRef: string | undefined,
+  pinnedRef: string | undefined
+): { ref: string; origin: 'explicit' | 'pinned' | 'default' } => {
+  if (explicitRef) return { ref: explicitRef, origin: 'explicit' }
+  if (pinnedRef) return { ref: pinnedRef, origin: 'pinned' }
+  return { ref: 'main', origin: 'default' }
+}
+
+/** Read the pinned satus ref from a project's package.json, if recorded. */
+export const readPinnedRef = async (
+  rootDir: string = projectRoot
+): Promise<string | undefined> => {
+  const pkgFile = Bun.file(join(rootDir, 'package.json'))
+  if (!(await pkgFile.exists())) return undefined
+  const pkg = (await pkgFile.json()) as { satus?: { ref?: unknown } }
+  const ref = pkg.satus?.ref
+  return typeof ref === 'string' && ref.length > 0 ? ref : undefined
+}
+
+/**
+ * Resolve where integration source payloads come from.
+ *
+ * `--from <localPath>` wins; otherwise the GitHub tarball for the resolved
+ * ref is downloaded and extracted into a temp directory via the system `tar`.
+ * Callers must `await source.cleanup()` when done.
+ */
+export const resolvePayloadSource = async (
+  options: PayloadSourceOptions
+): Promise<PayloadSource> => {
+  if (options.from) {
+    const root = resolve(options.from)
+    if (!(await pathExists(root))) {
+      throw new Error(`--from path does not exist: ${root}`)
+    }
+    if (!(await Bun.file(join(root, 'package.json')).exists())) {
+      throw new Error(
+        `--from path is not a satus checkout (no package.json): ${root}`
+      )
+    }
+    return {
+      root,
+      label: `local checkout ${root}`,
+      cleanup: async () => {},
+    }
+  }
+
+  const { ref, origin } = pickRef(options.ref, options.pinnedRef)
+  const tempDir = await mkdtemp(join(tmpdir(), 'satus-payload-'))
+
+  try {
+    const response = await fetch(tarballUrl(ref))
+    if (!response.ok) {
+      throw new Error(
+        `Failed to download satus@${ref}: HTTP ${response.status} ${response.statusText}`
+      )
+    }
+
+    const tarPath = join(tempDir, 'satus.tar.gz')
+    await Bun.write(tarPath, response)
+
+    const extractRoot = join(tempDir, 'src')
+    await mkdir(extractRoot, { recursive: true })
+
+    // System tar (flags shared by BSD and GNU tar); --strip-components drops
+    // the tarball's `satus-<ref>/` top-level directory.
+    const proc = Bun.spawn(
+      ['tar', '-xzf', tarPath, '-C', extractRoot, '--strip-components=1'],
+      { stdout: 'ignore', stderr: 'pipe' }
+    )
+    const exitCode = await proc.exited
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text()
+      throw new Error(
+        `tar extraction failed (exit ${exitCode}): ${stderr.trim()}`
+      )
+    }
+
+    return {
+      root: extractRoot,
+      label: `satus@${ref} (${origin} ref, GitHub tarball)`,
+      cleanup: () => rm(tempDir, { recursive: true, force: true }),
+    }
+  } catch (error) {
+    await rm(tempDir, { recursive: true, force: true })
+    throw error
+  }
+}
+
+/** True when `relPath` exists in the payload source (file or directory). */
+export const payloadPathExists = (
+  source: PayloadSource,
+  relPath: string
+): Promise<boolean> => pathExists(join(source.root, relPath))
+
+/** Read a payload file as text. Fails loudly when missing. */
+export const readPayloadFile = async (
+  source: PayloadSource,
+  relPath: string
+): Promise<string> => {
+  const file = Bun.file(join(source.root, relPath))
+  if (!(await file.exists())) {
+    throw new Error(`Payload source (${source.label}) is missing ${relPath}`)
+  }
+  return file.text()
+}
+
+/** Parsed package.json of the payload source, for dependency version pinning. */
+export const readPayloadPackageJson = async (
+  source: PayloadSource
+): Promise<PayloadPackageJson> => {
+  const text = await readPayloadFile(source, 'package.json')
+  return JSON.parse(text) as PayloadPackageJson
+}
+
+/**
+ * Recursively list the files under a payload directory, returned as paths
+ * relative to the payload root (e.g. 'lib/integrations/sanity/client.ts'),
+ * sorted for deterministic output. Fails loudly when the directory is absent.
+ */
+export const listPayloadFiles = async (
+  source: PayloadSource,
+  relDir: string
+): Promise<string[]> => {
+  if (!(await payloadPathExists(source, relDir))) {
+    throw new Error(
+      `Payload source (${source.label}) is missing folder ${relDir}`
+    )
+  }
+
+  const files: string[] = []
+
+  const walk = async (rel: string): Promise<void> => {
+    const entries = await readdir(join(source.root, rel), {
+      withFileTypes: true,
+    })
+    for (const entry of entries) {
+      const childRel = `${rel}/${entry.name}`
+      if (entry.isDirectory()) {
+        await walk(childRel)
+      } else {
+        files.push(childRel)
+      }
+    }
+  }
+
+  await walk(relDir)
+  return files.sort()
+}

--- a/lib/scripts/satus.e2e.test.ts
+++ b/lib/scripts/satus.e2e.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Round-trip e2e for `setup:project` (subtract) → `satus add` (restore).
+ *
+ * Run with: bun test lib/scripts/satus.e2e.test.ts
+ *
+ * Builds a real throwaway project on disk from this repo's source files, runs
+ * the actual CLIs against it via Bun.spawn (cwd = temp project, so the
+ * cwd-based project root in lib/scripts/utils.ts targets the temp tree), and
+ * asserts the add restores what the subtract removed. Entirely network-free:
+ * the payload source is `--from <this repo>`, package resolution reuses the
+ * repo's node_modules via a symlink, and both CLIs run with --skip-install.
+ *
+ * Pilots:
+ * - shopify — payload folder + next.config.ts remotePattern + env stubs
+ * - webgl   — richest shared-file wiring (features barrel, Wrapper overwrite,
+ *             next.config.ts) plus the theatre interplay: theatre stays
+ *             absent, so the Theatre.js wiring shipped inside the freshly
+ *             copied fluid/flowmap hooks must be stripped again
+ */
+
+import { afterAll, describe, expect, it, setDefaultTimeout } from 'bun:test'
+import { cp, mkdtemp, readdir, rm, symlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { applyOpsToText } from './ast-transforms'
+import { INTEGRATION_BUNDLES } from './integration-bundles'
+import { pathExists } from './utils'
+
+const REPO_ROOT = join(import.meta.dir, '..', '..')
+
+// Each test spawns one or two CLI processes (ts-morph boot included).
+setDefaultTimeout(120_000)
+
+// ---------------------------------------------------------------------------
+// Temp-project helper
+// ---------------------------------------------------------------------------
+
+const COPY_DIRS = ['app', 'components', 'lib', 'public']
+const COPY_FILES = [
+  'package.json',
+  'next.config.ts',
+  'tsconfig.json',
+  'biome.json',
+  'bunfig.toml',
+  '.env.example',
+]
+
+/**
+ * Copy this repo's source files into a fresh mkdtemp directory and symlink the
+ * repo's node_modules into it (so spawned scripts resolve @clack/prompts and
+ * ts-morph without any install). Never copies node_modules/.git/.next/.claude
+ * — only the explicit source lists above.
+ */
+const createTempProject = async (): Promise<string> => {
+  const root = await mkdtemp(join(tmpdir(), 'satus-e2e-'))
+
+  for (const dir of COPY_DIRS) {
+    if (await pathExists(join(REPO_ROOT, dir))) {
+      await cp(join(REPO_ROOT, dir), join(root, dir), { recursive: true })
+    }
+  }
+  for (const file of COPY_FILES) {
+    if (await Bun.file(join(REPO_ROOT, file)).exists()) {
+      await cp(join(REPO_ROOT, file), join(root, file))
+    }
+  }
+
+  await symlink(join(REPO_ROOT, 'node_modules'), join(root, 'node_modules'))
+  return root
+}
+
+// ---------------------------------------------------------------------------
+// CLI runners
+// ---------------------------------------------------------------------------
+
+interface RunResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+/** Run a repo script with the temp project as cwd (non-TTY, so no prompts). */
+const runScript = async (
+  cwd: string,
+  scriptRelPath: string,
+  args: string[]
+): Promise<RunResult> => {
+  const proc = Bun.spawn([process.execPath, scriptRelPath, ...args], {
+    cwd,
+    stdin: 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: { ...process.env, NO_COLOR: '1' },
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { exitCode, stdout, stderr }
+}
+
+/** Subtract: keep only `keep`, removing the rest — no prompts, no install. */
+const runSetup = (cwd: string, keep: string): Promise<RunResult> =>
+  runScript(cwd, 'lib/scripts/setup-project.ts', [
+    '--keep',
+    keep,
+    '--yes',
+    '--skip-install',
+  ])
+
+/** Restore: add `plugin` back from this repo as the local payload source. */
+const runAdd = (cwd: string, plugin: string): Promise<RunResult> =>
+  runScript(cwd, 'lib/scripts/satus.ts', [
+    'add',
+    plugin,
+    '--from',
+    REPO_ROOT,
+    '--yes',
+    '--skip-install',
+  ])
+
+/** Fail loudly with the CLI output when a spawned script exits non-zero. */
+const expectClean = (result: RunResult, label: string): void => {
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `${label} failed (exit ${result.exitCode})\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// File assertions
+// ---------------------------------------------------------------------------
+
+const readRepoFile = (rel: string): Promise<string> =>
+  Bun.file(join(REPO_ROOT, rel)).text()
+
+const readProjectFile = (root: string, rel: string): Promise<string> =>
+  Bun.file(join(root, rel)).text()
+
+interface PackageJsonDeps {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+const readPackageJson = (root: string): Promise<PackageJsonDeps> =>
+  Bun.file(join(root, 'package.json')).json() as Promise<PackageJsonDeps>
+
+/** Recursively list files under `root/relDir`, repo-relative, sorted. */
+const listFiles = async (root: string, relDir: string): Promise<string[]> => {
+  const files: string[] = []
+  const walk = async (rel: string): Promise<void> => {
+    const entries = await readdir(join(root, rel), { withFileTypes: true })
+    for (const entry of entries) {
+      const childRel = `${rel}/${entry.name}`
+      if (entry.isDirectory()) {
+        await walk(childRel)
+      } else {
+        files.push(childRel)
+      }
+    }
+  }
+  await walk(relDir)
+  return files.sort()
+}
+
+/**
+ * Assert every file of a source-repo folder exists in the temp project with
+ * identical content. `expectedOverrides` swaps the expected text for files
+ * that legitimately differ from the repo (e.g. theatre-stripped webgl hooks).
+ */
+const expectFolderMatchesSource = async (
+  projectRoot: string,
+  folder: string,
+  expectedOverrides: Record<string, string> = {}
+): Promise<void> => {
+  const sourceFiles = await listFiles(REPO_ROOT, folder)
+  expect(sourceFiles.length).toBeGreaterThan(0)
+
+  for (const rel of sourceFiles) {
+    const local = Bun.file(join(projectRoot, rel))
+    expect(await local.exists(), `${rel} should exist after add`).toBe(true)
+    const expected = expectedOverrides[rel] ?? (await readRepoFile(rel))
+    expect(await local.text(), `${rel} should match the payload source`).toBe(
+      expected
+    )
+  }
+}
+
+/** Assert every bundle dependency is pinned to the payload repo's version. */
+const expectDepsMatchPayload = (
+  localDeps: Record<string, string> | undefined,
+  payloadDeps: Record<string, string> | undefined,
+  names: string[]
+): void => {
+  for (const dep of names) {
+    const version = payloadDeps?.[dep]
+    expect(version, `payload package.json should declare ${dep}`).toBeTruthy()
+    expect(localDeps?.[dep], `${dep} should be pinned after add`).toBe(
+      version as string
+    )
+  }
+}
+
+/** Files snapshotted after the first add to prove the second add is a no-op. */
+const IDEMPOTENCY_FILES = [
+  'package.json',
+  'next.config.ts',
+  'lib/features/index.tsx',
+]
+
+const snapshotFiles = async (root: string): Promise<Record<string, string>> => {
+  const snapshot: Record<string, string> = {}
+  for (const rel of IDEMPOTENCY_FILES) {
+    snapshot[rel] = await readProjectFile(root, rel)
+  }
+  return snapshot
+}
+
+const expectSnapshotUnchanged = async (
+  root: string,
+  snapshot: Record<string, string>
+): Promise<void> => {
+  for (const rel of IDEMPOTENCY_FILES) {
+    const after = await readProjectFile(root, rel)
+    expect(after, `${rel} should be unchanged by a repeated add`).toBe(
+      snapshot[rel] as string
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pilot 1: shopify — payload folder + remotePatterns + env stubs + deps
+// ---------------------------------------------------------------------------
+
+describe('round trip: shopify', () => {
+  const shopify = INTEGRATION_BUNDLES.shopify
+  if (!shopify) throw new Error('shopify bundle not found')
+
+  let project = ''
+  let snapshot: Record<string, string> = {}
+
+  afterAll(async () => {
+    if (project) await rm(project, { recursive: true, force: true })
+  })
+
+  it('subtract then add restores the bundle from the payload', async () => {
+    project = await createTempProject()
+
+    expectClean(
+      await runSetup(project, 'sanity,hubspot,mailchimp,webgl,theatre'),
+      'setup:project (subtract shopify)'
+    )
+
+    expect(await pathExists(join(project, 'lib/integrations/shopify'))).toBe(
+      false
+    )
+    expect(await readProjectFile(project, 'next.config.ts')).not.toContain(
+      'cdn.shopify.com'
+    )
+
+    expectClean(await runAdd(project, 'shopify'), 'satus add shopify')
+
+    // The whole payload folder is back, byte-identical to the source repo
+    await expectFolderMatchesSource(project, 'lib/integrations/shopify')
+
+    // next.config.ts regains the remotePatterns entry
+    expect(await readProjectFile(project, 'next.config.ts')).toContain(
+      'cdn.shopify.com'
+    )
+
+    // Every env var is present in .env.example (appended as `# VAR=` stubs)
+    const envExample = await readProjectFile(project, '.env.example')
+    for (const envVar of shopify.envVars) {
+      expect(envExample, `.env.example should carry ${envVar}`).toMatch(
+        new RegExp(`^#?\\s*${envVar}=`, 'm')
+      )
+    }
+
+    // package.json carries every bundle dependency at the payload's pin
+    // (vacuous today — shopify declares none — but guards future additions)
+    const pkg = await readPackageJson(project)
+    const repoPkg = await readPackageJson(REPO_ROOT)
+    expectDepsMatchPayload(
+      pkg.dependencies,
+      repoPkg.dependencies,
+      shopify.dependencies
+    )
+
+    snapshot = await snapshotFiles(project)
+  })
+
+  it('a second add is byte-stable on the shared files', async () => {
+    if (!project) throw new Error('first shopify round-trip test must run')
+
+    expectClean(await runAdd(project, 'shopify'), 'satus add shopify (rerun)')
+    await expectSnapshotUnchanged(project, snapshot)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Pilot 2: webgl — shared-file wiring + theatre interplay (theatre stays out)
+// ---------------------------------------------------------------------------
+
+describe('round trip: webgl without theatre', () => {
+  const webgl = INTEGRATION_BUNDLES.webgl
+  const theatre = INTEGRATION_BUNDLES.theatre
+  if (!(webgl && theatre)) throw new Error('webgl/theatre bundles not found')
+
+  let project = ''
+  let snapshot: Record<string, string> = {}
+
+  afterAll(async () => {
+    if (project) await rm(project, { recursive: true, force: true })
+  })
+
+  it('add webgl after subtract: wiring restored, leak stripped', async () => {
+    project = await createTempProject()
+
+    expectClean(
+      await runSetup(project, 'sanity,shopify,hubspot,mailchimp'),
+      'setup:project (subtract webgl + theatre)'
+    )
+
+    expect(await pathExists(join(project, 'lib/webgl'))).toBe(false)
+    expect(await pathExists(join(project, 'lib/dev/theatre'))).toBe(false)
+    expect(
+      await readProjectFile(project, 'lib/features/index.tsx')
+    ).not.toContain('LazyGlobalCanvas')
+
+    expectClean(await runAdd(project, 'webgl'), 'satus add webgl')
+
+    // Theatre was not requested and must stay absent
+    expect(await pathExists(join(project, 'lib/dev/theatre'))).toBe(false)
+
+    // The payload ships the fluid/flowmap hooks WITH Theatre wiring; with
+    // theatre absent, the add must strip it again — the expected text is the
+    // payload content with theatre's removal ops applied.
+    const expectedOverrides: Record<string, string> = {}
+    for (const rel of [
+      'lib/webgl/utils/fluid/index.tsx',
+      'lib/webgl/utils/flowmaps/index.tsx',
+    ]) {
+      const ops = theatre.codeTransforms.find((t) => t.file === rel)?.ops ?? []
+      expectedOverrides[rel] = applyOpsToText(await readRepoFile(rel), ops)
+    }
+    await expectFolderMatchesSource(project, 'lib/webgl', expectedOverrides)
+
+    const fluid = await readProjectFile(
+      project,
+      'lib/webgl/utils/fluid/index.tsx'
+    )
+    expect(fluid).not.toContain('@theatre/core')
+    expect(fluid).not.toContain('useTheatre')
+
+    // Integration-owned Wrapper is restored wholesale from the payload
+    expect(
+      await readProjectFile(project, 'components/layout/wrapper/index.tsx')
+    ).toBe(await readRepoFile('components/layout/wrapper/index.tsx'))
+
+    // lib/features/index.tsx regains the LazyGlobalCanvas const + JSX
+    const features = await readProjectFile(project, 'lib/features/index.tsx')
+    expect(features).toContain('const LazyGlobalCanvas = dynamic(')
+    expect(features).toContain('<LazyGlobalCanvas />')
+
+    // next.config.ts regains the optimizePackageImports entries
+    const nextConfig = await readProjectFile(project, 'next.config.ts')
+    expect(nextConfig).toContain("'@react-three/drei'")
+    expect(nextConfig).toContain("'@react-three/fiber'")
+    expect(nextConfig).toContain("'three'")
+
+    // package.json regains every webgl dependency at the payload's pin
+    const pkg = await readPackageJson(project)
+    const repoPkg = await readPackageJson(REPO_ROOT)
+    expectDepsMatchPayload(
+      pkg.dependencies,
+      repoPkg.dependencies,
+      webgl.dependencies
+    )
+    expectDepsMatchPayload(
+      pkg.devDependencies,
+      repoPkg.devDependencies,
+      webgl.devDependencies
+    )
+
+    snapshot = await snapshotFiles(project)
+  })
+
+  it('a second add is byte-stable on the shared files', async () => {
+    if (!project) throw new Error('first webgl round-trip test must run')
+
+    expectClean(await runAdd(project, 'webgl'), 'satus add webgl (rerun)')
+    await expectSnapshotUnchanged(project, snapshot)
+  })
+})

--- a/lib/scripts/satus.test.ts
+++ b/lib/scripts/satus.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Unit tests for the `satus add` CLI pure helpers.
+ *
+ * Run with: bun test lib/scripts/satus.test.ts
+ *
+ * Covers argument parsing, transitive `requires` resolution, the installed
+ * probe, and the barrel-line restore helpers. Disk-writing steps are
+ * exercised by the Phase 3 round-trip e2e.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { INTEGRATION_BUNDLES } from './integration-bundles'
+import {
+  bundleProbePath,
+  findBarrelLine,
+  insertBarrelLine,
+  parseAddArgs,
+  resolveAddSet,
+} from './satus'
+
+// ---------------------------------------------------------------------------
+// parseAddArgs
+// ---------------------------------------------------------------------------
+
+describe('parseAddArgs', () => {
+  it('separates plugins from flags', () => {
+    const { plugins, flags } = parseAddArgs([
+      'sanity',
+      'webgl',
+      '--from',
+      '.',
+      '--dry-run',
+      '--yes',
+    ])
+
+    expect(plugins).toEqual(['sanity', 'webgl'])
+    expect(flags.from).toBe('.')
+    expect(flags.dryRun).toBe(true)
+    expect(flags.yes).toBe(true)
+    expect(flags.force).toBe(false)
+    expect(flags.ref).toBeUndefined()
+  })
+
+  it('supports the --flag=value form', () => {
+    const { flags } = parseAddArgs(['theatre', '--from=../satus', '--ref=v2'])
+    expect(flags.from).toBe('../satus')
+    expect(flags.ref).toBe('v2')
+  })
+
+  it('supports --ref with a separate value', () => {
+    const { flags } = parseAddArgs(['sanity', '--ref', '6f49149', '--force'])
+    expect(flags.ref).toBe('6f49149')
+    expect(flags.force).toBe(true)
+  })
+
+  it('fails loudly when a value flag has no value', () => {
+    expect(() => parseAddArgs(['sanity', '--from'])).toThrow(
+      '--from requires a value'
+    )
+    expect(() => parseAddArgs(['sanity', '--from', '--dry-run'])).toThrow(
+      '--from requires a value'
+    )
+  })
+
+  it('fails loudly on unknown flags', () => {
+    expect(() => parseAddArgs(['sanity', '--frmo', '.'])).toThrow(
+      'Unknown flag: --frmo'
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveAddSet — transitive `requires` resolution
+// ---------------------------------------------------------------------------
+
+describe('resolveAddSet', () => {
+  it('resolves a standalone plugin to itself', () => {
+    expect(resolveAddSet(['sanity'])).toEqual({
+      order: ['sanity'],
+      implied: [],
+    })
+  })
+
+  it('pulls in required plugins before the requester (theatre → webgl)', () => {
+    const { order, implied } = resolveAddSet(['theatre'])
+
+    expect(order).toEqual(['webgl', 'theatre'])
+    expect(implied).toEqual(['webgl'])
+  })
+
+  it('does not mark explicitly requested dependencies as implied', () => {
+    const { order, implied } = resolveAddSet(['theatre', 'webgl'])
+
+    expect(order).toEqual(['webgl', 'theatre'])
+    expect(implied).toEqual([])
+  })
+
+  it('deduplicates repeated requests', () => {
+    const { order } = resolveAddSet(['webgl', 'webgl', 'theatre'])
+    expect(order).toEqual(['webgl', 'theatre'])
+  })
+
+  it('fails loudly on unknown plugin ids', () => {
+    expect(() => resolveAddSet(['sanityy'])).toThrow('Unknown plugin "sanityy"')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// bundleProbePath — installed detection
+// ---------------------------------------------------------------------------
+
+describe('bundleProbePath', () => {
+  it('uses the first folder as the installed probe', () => {
+    const sanity = INTEGRATION_BUNDLES.sanity
+    if (!sanity) throw new Error('sanity bundle not found')
+    expect(bundleProbePath(sanity)).toBe('lib/integrations/sanity')
+  })
+
+  it('every bundle has a probe path', () => {
+    for (const bundle of Object.values(INTEGRATION_BUNDLES)) {
+      expect(bundleProbePath(bundle)).toBeTruthy()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Barrel-line restore helpers
+// ---------------------------------------------------------------------------
+
+describe('findBarrelLine', () => {
+  const barrel = `export * from './accordion'
+export * from './marquee'
+export * from './sanity-image'
+`
+
+  it('finds the line matching a removal pattern', () => {
+    expect(findBarrelLine(barrel, 'sanity-image')).toBe(
+      "export * from './sanity-image'"
+    )
+  })
+
+  it('returns undefined when no line matches', () => {
+    expect(findBarrelLine(barrel, 'animated-gradient')).toBeUndefined()
+  })
+})
+
+describe('insertBarrelLine', () => {
+  it('inserts in sorted position among export lines', () => {
+    const barrel = `export * from './accordion'
+export * from './tabs'
+`
+    const result = insertBarrelLine(barrel, "export * from './marquee'")
+
+    expect(result).toBe(`export * from './accordion'
+export * from './marquee'
+export * from './tabs'
+`)
+  })
+
+  it('appends after the last export when it sorts last', () => {
+    const barrel = `export * from './accordion'
+export * from './marquee'
+`
+    const result = insertBarrelLine(barrel, "export * from './tabs'")
+
+    expect(result).toBe(`export * from './accordion'
+export * from './marquee'
+export * from './tabs'
+`)
+  })
+
+  it('is idempotent when the line already exists', () => {
+    const barrel = `export * from './accordion'
+export * from './sanity-image'
+`
+    expect(insertBarrelLine(barrel, "export * from './sanity-image'")).toBe(
+      barrel
+    )
+  })
+
+  it('creates content for an empty barrel', () => {
+    expect(insertBarrelLine('', "export * from './sanity-image'")).toBe(
+      "export * from './sanity-image'\n"
+    )
+  })
+
+  it('appends to a file without export lines', () => {
+    const result = insertBarrelLine(
+      '// barrel\n',
+      "export * from './sanity-image'"
+    )
+    expect(result).toBe("// barrel\nexport * from './sanity-image'\n")
+  })
+
+  it('keeps comment headers above the sorted insert', () => {
+    const barrel = `// UI components barrel
+export * from './accordion'
+export * from './tabs'
+`
+    const result = insertBarrelLine(barrel, "export * from './marquee'")
+
+    expect(result.startsWith('// UI components barrel\n')).toBe(true)
+    expect(result.indexOf('./accordion')).toBeLessThan(
+      result.indexOf('./marquee')
+    )
+    expect(result.indexOf('./marquee')).toBeLessThan(result.indexOf('./tabs'))
+  })
+})

--- a/lib/scripts/satus.test.ts
+++ b/lib/scripts/satus.test.ts
@@ -38,7 +38,14 @@ describe('parseAddArgs', () => {
     expect(flags.dryRun).toBe(true)
     expect(flags.yes).toBe(true)
     expect(flags.force).toBe(false)
+    expect(flags.skipInstall).toBe(false)
     expect(flags.ref).toBeUndefined()
+  })
+
+  it('parses --skip-install', () => {
+    const { flags } = parseAddArgs(['shopify', '--skip-install', '--yes'])
+    expect(flags.skipInstall).toBe(true)
+    expect(flags.yes).toBe(true)
   })
 
   it('supports the --flag=value form', () => {

--- a/lib/scripts/satus.ts
+++ b/lib/scripts/satus.ts
@@ -1,0 +1,687 @@
+#!/usr/bin/env bun
+/**
+ * Satūs Plugin CLI — the additive inverse of `setup:project`.
+ *
+ * In a lean project (one that ran `bun run setup:project` and stripped
+ * integrations), restore an integration by pulling its source payload from
+ * the public satus repo and re-wiring shared files via idempotent AST ops:
+ *
+ *   bun run satus list
+ *   bun run satus add <plugin...> [--from path] [--ref ref] [--dry-run] [--force] [--yes]
+ *
+ * Payload source priority: `--from <localPath>` (a satus checkout) →
+ * `--ref <gitRef>` → the pinned ref in package.json `satus.ref` → `main`
+ * (GitHub tarball). Every prompt is skippable via `--yes` (or runs
+ * non-interactively outside a TTY), so the CLI is drivable in CI.
+ */
+
+import { mkdir } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import * as p from '@clack/prompts'
+import type { RemovableId } from '@/integrations/registry'
+import { applyCodeTransforms, applyOpsToText } from './ast-transforms'
+import {
+  type CodeTransform,
+  getIntegrationEntries,
+  INTEGRATION_BUNDLES,
+  type IntegrationBundle,
+} from './integration-bundles'
+import {
+  listPayloadFiles,
+  type PayloadPackageJson,
+  type PayloadSource,
+  payloadPathExists,
+  readPayloadFile,
+  readPayloadPackageJson,
+  readPinnedRef,
+  resolvePayloadSource,
+} from './payload-source'
+import { pathExists, resolvePath } from './utils'
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+export interface AddFlags {
+  from?: string
+  ref?: string
+  dryRun: boolean
+  force: boolean
+  yes: boolean
+}
+
+/**
+ * Parse `satus add` arguments into plugin ids and flags.
+ * Fails loudly on unknown flags and on value flags missing their value.
+ */
+export function parseAddArgs(argv: string[]): {
+  plugins: string[]
+  flags: AddFlags
+} {
+  const plugins: string[] = []
+  const flags: AddFlags = { dryRun: false, force: false, yes: false }
+
+  const takeValue = (
+    flag: '--from' | '--ref',
+    arg: string,
+    next: string | undefined
+  ): { value: string; consumedNext: boolean } => {
+    if (arg.includes('=')) {
+      return { value: arg.slice(flag.length + 1), consumedNext: false }
+    }
+    if (next === undefined || next.startsWith('-')) {
+      throw new Error(`${flag} requires a value`)
+    }
+    return { value: next, consumedNext: true }
+  }
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === undefined) continue
+
+    if (arg === '--from' || arg.startsWith('--from=')) {
+      const { value, consumedNext } = takeValue('--from', arg, argv[i + 1])
+      flags.from = value
+      if (consumedNext) i++
+    } else if (arg === '--ref' || arg.startsWith('--ref=')) {
+      const { value, consumedNext } = takeValue('--ref', arg, argv[i + 1])
+      flags.ref = value
+      if (consumedNext) i++
+    } else if (arg === '--dry-run') {
+      flags.dryRun = true
+    } else if (arg === '--force') {
+      flags.force = true
+    } else if (arg === '--yes') {
+      flags.yes = true
+    } else if (arg.startsWith('-')) {
+      throw new Error(`Unknown flag: ${arg}`)
+    } else {
+      plugins.push(arg)
+    }
+  }
+
+  return { plugins, flags }
+}
+
+// ---------------------------------------------------------------------------
+// Pure plugin-resolution helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve requested plugin ids plus their transitive `requires` into install
+ * order (dependencies first). Fails loudly on unknown ids and circular
+ * `requires` chains. `implied` lists ids pulled in beyond the request.
+ */
+export function resolveAddSet(requested: string[]): {
+  order: RemovableId[]
+  implied: RemovableId[]
+} {
+  const knownIds = Object.keys(INTEGRATION_BUNDLES) as RemovableId[]
+
+  const requestedIds: RemovableId[] = requested.map((id) => {
+    if (!(knownIds as string[]).includes(id)) {
+      throw new Error(
+        `Unknown plugin "${id}". Available: ${knownIds.join(', ')}`
+      )
+    }
+    return id as RemovableId
+  })
+
+  const order: RemovableId[] = []
+  const visiting = new Set<RemovableId>()
+
+  const visit = (id: RemovableId): void => {
+    if (order.includes(id)) return
+    if (visiting.has(id)) {
+      throw new Error(`Circular "requires" chain detected at "${id}"`)
+    }
+    visiting.add(id)
+    for (const dep of INTEGRATION_BUNDLES[id]?.requires ?? []) {
+      visit(dep)
+    }
+    visiting.delete(id)
+    order.push(id)
+  }
+
+  for (const id of requestedIds) {
+    visit(id)
+  }
+
+  const implied = order.filter((id) => !requestedIds.includes(id))
+  return { order, implied }
+}
+
+/** A bundle counts as installed when its first folder (or file) exists. */
+export function bundleProbePath(bundle: IntegrationBundle): string | undefined {
+  return bundle.folders[0] ?? bundle.files[0]
+}
+
+// ---------------------------------------------------------------------------
+// Barrel export restoration (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the export line in a source barrel matching the removal `pattern`,
+ * using the same matching as setup-project's removal (quoted pattern or
+ * quoted './pattern' specifier).
+ */
+export function findBarrelLine(
+  sourceText: string,
+  pattern: string
+): string | undefined {
+  return sourceText
+    .split('\n')
+    .find(
+      (line) => line.includes(`'${pattern}'`) || line.includes(`'./${pattern}'`)
+    )
+}
+
+/**
+ * Insert a barrel export line when absent (sorted position among existing
+ * `export` lines, best-effort). Returns the text unchanged when an identical
+ * line already exists — idempotent.
+ */
+export function insertBarrelLine(localText: string, line: string): string {
+  const newLine = line.trim()
+  if (newLine.length === 0) return localText
+
+  const lines = localText.split('\n')
+  if (lines.some((existing) => existing.trim() === newLine)) return localText
+
+  const exportIndexes: number[] = []
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i]?.startsWith('export ')) exportIndexes.push(i)
+  }
+
+  if (exportIndexes.length === 0) {
+    const base =
+      localText.length === 0 || localText.endsWith('\n')
+        ? localText
+        : `${localText}\n`
+    return `${base}${newLine}\n`
+  }
+
+  const sortedAfter = exportIndexes.find(
+    (i) => (lines[i] ?? '').localeCompare(newLine) > 0
+  )
+  const lastExport = exportIndexes[exportIndexes.length - 1] ?? 0
+  const insertAt = sortedAfter ?? lastExport + 1
+  lines.splice(insertAt, 0, newLine)
+  return lines.join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Install steps
+// ---------------------------------------------------------------------------
+
+const isInstalled = async (bundle: IntegrationBundle): Promise<boolean> => {
+  const probe = bundleProbePath(bundle)
+  if (!probe) return false
+  return pathExists(resolvePath(probe))
+}
+
+/**
+ * Copy the bundle's `folders` and `files` from the payload source into the
+ * project. Existing files are kept (unless --force); missing ones are always
+ * copied. Fails loudly when the payload lacks a declared folder or file.
+ */
+const copyBundleFiles = async (
+  source: PayloadSource,
+  bundle: IntegrationBundle,
+  options: { dryRun: boolean; force: boolean }
+): Promise<{ copied: number; skipped: number }> => {
+  const relFiles: string[] = []
+
+  for (const folder of bundle.folders) {
+    relFiles.push(...(await listPayloadFiles(source, folder)))
+  }
+  for (const file of bundle.files) {
+    if (!(await payloadPathExists(source, file))) {
+      throw new Error(`Payload source (${source.label}) is missing ${file}`)
+    }
+    relFiles.push(file)
+  }
+
+  let copied = 0
+  let skipped = 0
+
+  for (const rel of relFiles) {
+    const dest = resolvePath(rel)
+    if ((await pathExists(dest)) && !options.force) {
+      skipped++
+      continue
+    }
+    if (!options.dryRun) {
+      await mkdir(dirname(dest), { recursive: true })
+      await Bun.write(dest, Bun.file(join(source.root, rel)))
+    }
+    copied++
+  }
+
+  return { copied, skipped }
+}
+
+/**
+ * Copy the bundle's integration-owned `overwriteFiles` wholesale from the
+ * payload source. A local file is only overwritten when it matches either
+ * the payload version (already wired — no-op) or the expected lean state
+ * (the payload version with this bundle's removal codeTransforms applied).
+ * Anything else means local modifications — skip with a warning unless
+ * --force.
+ */
+const applyOverwriteFiles = async (
+  source: PayloadSource,
+  bundle: IntegrationBundle,
+  options: { dryRun: boolean; force: boolean }
+): Promise<{ written: string[]; skipped: string[] }> => {
+  const written: string[] = []
+  const skipped: string[] = []
+
+  for (const rel of bundle.overwriteFiles ?? []) {
+    const payloadText = await readPayloadFile(source, rel)
+    const dest = resolvePath(rel)
+
+    if (!(await pathExists(dest))) {
+      if (!options.dryRun) {
+        await mkdir(dirname(dest), { recursive: true })
+        await Bun.write(dest, payloadText)
+      }
+      written.push(rel)
+      continue
+    }
+
+    const localText = await Bun.file(dest).text()
+    if (localText === payloadText) continue // already wired
+
+    const removalOps =
+      bundle.codeTransforms.find((t) => t.file === rel)?.ops ?? []
+    const expectedLean = applyOpsToText(payloadText, removalOps)
+
+    if (localText === expectedLean || options.force) {
+      if (!options.dryRun) {
+        await Bun.write(dest, payloadText)
+      }
+      written.push(rel)
+    } else {
+      skipped.push(rel)
+    }
+  }
+
+  return { written, skipped }
+}
+
+const sortRecord = (record: Record<string, string>): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(record).sort(([a], [b]) => a.localeCompare(b))
+  )
+
+/**
+ * Add the bundle's dependencies to the local package.json, pinning each to
+ * the version declared by the payload source's package.json. Dependencies
+ * already present locally keep their existing pin.
+ */
+const addDependencies = async (
+  bundle: IntegrationBundle,
+  payloadPkg: PayloadPackageJson,
+  options: { dryRun: boolean }
+): Promise<{ added: string[]; missing: string[] }> => {
+  const pkgPath = resolvePath('package.json')
+  const pkg = (await Bun.file(pkgPath).json()) as {
+    dependencies?: Record<string, string>
+    devDependencies?: Record<string, string>
+    [key: string]: unknown
+  }
+
+  const added: string[] = []
+  const missing: string[] = []
+
+  const addFrom = (
+    names: string[],
+    target: 'dependencies' | 'devDependencies'
+  ): void => {
+    for (const name of names) {
+      const version =
+        payloadPkg.dependencies?.[name] ?? payloadPkg.devDependencies?.[name]
+      if (!version) {
+        missing.push(name)
+        continue
+      }
+      const record = pkg[target] ?? {}
+      pkg[target] = record
+      if (record[name]) continue // already present — keep the local pin
+      record[name] = version
+      added.push(`${name}@${version}`)
+    }
+  }
+
+  addFrom(bundle.dependencies, 'dependencies')
+  addFrom(bundle.devDependencies, 'devDependencies')
+
+  if (added.length > 0 && !options.dryRun) {
+    if (pkg.dependencies) pkg.dependencies = sortRecord(pkg.dependencies)
+    if (pkg.devDependencies) {
+      pkg.devDependencies = sortRecord(pkg.devDependencies)
+    }
+    await Bun.write(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`)
+  }
+
+  return { added, missing }
+}
+
+/**
+ * Restore the bundle's barrel export lines: read each pattern's line from the
+ * SOURCE repo's barrel file and insert it into the local barrel when absent
+ * (created when missing). Warns when the payload has no matching barrel/line.
+ */
+const restoreBarrelExports = async (
+  source: PayloadSource,
+  bundle: IntegrationBundle,
+  options: { dryRun: boolean }
+): Promise<number> => {
+  let changes = 0
+
+  for (const { file, pattern } of bundle.barrelExports) {
+    if (!(await payloadPathExists(source, file))) {
+      p.log.warn(
+        `Payload source has no barrel file ${file} — skipping export restore for "${pattern}"`
+      )
+      continue
+    }
+
+    const sourceText = await readPayloadFile(source, file)
+    const line = findBarrelLine(sourceText, pattern)
+    if (!line) {
+      p.log.warn(
+        `No export line matching "${pattern}" in payload ${file} — skipping`
+      )
+      continue
+    }
+
+    const localPath = resolvePath(file)
+    const localText = (await pathExists(localPath))
+      ? await Bun.file(localPath).text()
+      : ''
+    const updated = insertBarrelLine(localText, line)
+
+    if (updated !== localText) {
+      if (!options.dryRun) {
+        await mkdir(dirname(localPath), { recursive: true })
+        await Bun.write(localPath, updated)
+      }
+      changes++
+    }
+  }
+
+  return changes
+}
+
+/** Append missing env vars as commented stubs to .env.example (created when absent). */
+const appendEnvStubs = async (
+  envVars: string[],
+  dryRun: boolean
+): Promise<number> => {
+  if (envVars.length === 0) return 0
+
+  const envPath = resolvePath('.env.example')
+  const exists = await pathExists(envPath)
+  const content = exists ? await Bun.file(envPath).text() : ''
+
+  const missing = envVars.filter(
+    (envVar) => !new RegExp(`^#?\\s*${envVar}=`, 'm').test(content)
+  )
+  if (missing.length === 0) return 0
+
+  if (!dryRun) {
+    const base =
+      content.length === 0 || content.endsWith('\n') ? content : `${content}\n`
+    const stubs = missing.map((envVar) => `# ${envVar}=`).join('\n')
+    await Bun.write(envPath, `${base}${stubs}\n`)
+  }
+
+  return missing.length
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+const runList = async (): Promise<void> => {
+  p.intro('Satūs Plugins')
+
+  const entries = getIntegrationEntries()
+  const idWidth = Math.max(...entries.map(([id]) => id.length))
+  const nameWidth = Math.max(...entries.map(([, bundle]) => bundle.name.length))
+
+  for (const [id, bundle] of entries) {
+    const status = (await isInstalled(bundle)) ? 'installed' : 'absent'
+    const requires = bundle.requires?.length
+      ? `  (requires ${bundle.requires.join(', ')})`
+      : ''
+    p.log.message(
+      `${id.padEnd(idWidth + 2)}${bundle.name.padEnd(nameWidth + 2)}${status}${requires}`
+    )
+  }
+
+  p.outro('Add one with: bun run satus add <plugin>')
+}
+
+const runAdd = async (plugins: string[], flags: AddFlags): Promise<void> => {
+  p.intro('Satūs Plugin Add')
+
+  if (flags.dryRun) {
+    p.log.warn('Dry run mode - no files will be modified')
+  }
+
+  const { order, implied } = resolveAddSet(plugins)
+
+  const statuses: {
+    id: RemovableId
+    bundle: IntegrationBundle
+    installed: boolean
+  }[] = []
+  for (const id of order) {
+    const bundle = INTEGRATION_BUNDLES[id]
+    if (!bundle) continue // unreachable — resolveAddSet validates ids
+    statuses.push({ id, bundle, installed: await isInstalled(bundle) })
+  }
+
+  for (const { bundle } of statuses.filter((s) => s.installed)) {
+    p.log.info(`${bundle.name} is already installed — nothing to do`)
+  }
+
+  const toInstall = statuses.filter((s) => !s.installed)
+  if (toInstall.length === 0) {
+    p.outro('Everything requested is already installed.')
+    return
+  }
+
+  if (implied.length > 0) {
+    p.log.step(
+      `Also adding required plugin${implied.length > 1 ? 's' : ''}: ${implied.join(', ')}`
+    )
+  }
+  p.log.step(`Will add: ${toInstall.map((s) => s.bundle.name).join(', ')}`)
+
+  const interactive = Boolean(process.stdout.isTTY && process.stdin.isTTY)
+  if (!flags.yes && interactive) {
+    const proceed = await p.confirm({
+      message: flags.dryRun ? 'Preview changes?' : 'Proceed?',
+    })
+    if (p.isCancel(proceed) || !proceed) {
+      p.cancel('Add cancelled')
+      process.exit(0)
+    }
+  }
+
+  const pinnedRef = await readPinnedRef()
+  if (!(flags.from || flags.ref || pinnedRef)) {
+    p.log.warn(
+      'No pinned ref in package.json ("satus": { "ref": … }) — falling back to main. Pass --ref to pin.'
+    )
+  }
+
+  const source = await resolvePayloadSource({
+    from: flags.from,
+    ref: flags.ref,
+    pinnedRef,
+  })
+  p.log.step(`Payload source: ${source.label}`)
+
+  let depsAdded = 0
+
+  try {
+    const payloadPkg = await readPayloadPackageJson(source)
+    const s = p.spinner()
+
+    for (const { bundle } of toInstall) {
+      s.start(`Adding ${bundle.name}...`)
+      const details: string[] = []
+
+      const { copied, skipped } = await copyBundleFiles(source, bundle, flags)
+      if (copied > 0) details.push(`${copied} files copied`)
+      if (skipped > 0) details.push(`${skipped} existing files kept`)
+
+      const overwrite = await applyOverwriteFiles(source, bundle, flags)
+      if (overwrite.written.length > 0) {
+        details.push(
+          `${overwrite.written.length} integration-owned files restored`
+        )
+      }
+
+      const deps = await addDependencies(bundle, payloadPkg, flags)
+      depsAdded += deps.added.length
+      if (deps.added.length > 0) {
+        details.push(`${deps.added.length} dependencies pinned`)
+      }
+
+      const barrelChanges = await restoreBarrelExports(source, bundle, flags)
+      if (barrelChanges > 0) {
+        details.push(`${barrelChanges} barrel exports restored`)
+      }
+
+      const envChanges = await appendEnvStubs(bundle.envVars, flags.dryRun)
+      if (envChanges > 0) details.push(`${envChanges} env stubs appended`)
+
+      const transformChanges = await applyCodeTransforms(
+        bundle.addTransforms ?? [],
+        flags.dryRun
+      )
+      if (transformChanges > 0) {
+        details.push(`${transformChanges} files re-wired`)
+      }
+
+      const verb = flags.dryRun ? 'Would add' : 'Added'
+      const detail = details.length > 0 ? ` (${details.join(', ')})` : ''
+      s.stop(`${verb} ${bundle.name}${detail}`)
+
+      for (const rel of overwrite.skipped) {
+        p.log.warn(
+          `${rel} is locally modified — skipped. Re-run with --force to overwrite.`
+        )
+      }
+      for (const dep of deps.missing) {
+        p.log.warn(
+          `"${dep}" is not in the payload package.json — install it manually.`
+        )
+      }
+
+      if (deps.added.length > 0) {
+        p.log.message(`  Pinned: ${deps.added.join(', ')}`)
+      }
+    }
+
+    // Freshly copied payload files ship with EVERY integration's wiring (the
+    // payload is the full repo) — e.g. lib/webgl/utils/fluid contains Theatre
+    // hooks. Reuse the subtractive codeTransforms of each bundle that is
+    // neither installed nor part of this add, so absent integrations stay
+    // absent. These ops are no-ops on files already in the lean state.
+    const stripTransforms: CodeTransform[] = []
+    for (const [id, bundle] of getIntegrationEntries()) {
+      if (order.includes(id)) continue
+      if (await isInstalled(bundle)) continue
+      stripTransforms.push(...bundle.codeTransforms)
+    }
+    if (stripTransforms.length > 0) {
+      const stripped = await applyCodeTransforms(stripTransforms, flags.dryRun)
+      if (stripped > 0) {
+        p.log.step(
+          `Stripped absent-integration wiring from ${stripped} copied files`
+        )
+      }
+    }
+
+    if (depsAdded > 0 && !flags.dryRun) {
+      s.start('Installing dependencies...')
+      await Bun.$`bun install`.quiet()
+      s.stop('Dependencies installed')
+    }
+  } finally {
+    await source.cleanup()
+  }
+
+  if (flags.dryRun) {
+    p.outro('Dry run complete. Run without --dry-run to apply changes.')
+  } else {
+    p.outro('Done. Review the changes, then run: bun dev')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+const HELP = `Satūs Plugin CLI
+
+Usage: bun run satus <command>
+
+Commands:
+  list                Show all plugins and their installed status
+  add <plugin...>     Restore plugins from the satus repo payload
+
+Options for add:
+  --from <path>       Use a local satus checkout as the payload source
+  --ref <gitRef>      Fetch the GitHub tarball at this ref
+                      (default: package.json "satus.ref", then main)
+  --dry-run           Print what would happen without writing anything
+  --force             Overwrite existing / locally modified files
+  --yes               Skip confirmation prompts (CI)
+`
+
+const main = async (): Promise<void> => {
+  const argv = process.argv.slice(2)
+  const command = argv[0]
+
+  if (
+    command === undefined ||
+    command === 'help' ||
+    command === '--help' ||
+    command === '-h'
+  ) {
+    console.log(HELP)
+    return
+  }
+
+  if (command === 'list') {
+    await runList()
+    return
+  }
+
+  if (command === 'add') {
+    const { plugins, flags } = parseAddArgs(argv.slice(1))
+    if (plugins.length === 0) {
+      throw new Error('No plugins given. Usage: bun run satus add <plugin...>')
+    }
+    await runAdd(plugins, flags)
+    return
+  }
+
+  throw new Error(`Unknown command "${command}". Run: bun run satus --help`)
+}
+
+// Run only when executed directly (not when imported by tests)
+if (import.meta.main) {
+  main().catch((error) => {
+    p.log.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  })
+}

--- a/lib/scripts/satus.ts
+++ b/lib/scripts/satus.ts
@@ -7,7 +7,8 @@
  * the public satus repo and re-wiring shared files via idempotent AST ops:
  *
  *   bun run satus list
- *   bun run satus add <plugin...> [--from path] [--ref ref] [--dry-run] [--force] [--yes]
+ *   bun run satus add <plugin...> [--from path] [--ref ref] [--dry-run]
+ *                                 [--force] [--yes] [--skip-install]
  *
  * Payload source priority: `--from <localPath>` (a satus checkout) →
  * `--ref <gitRef>` → the pinned ref in package.json `satus.ref` → `main`
@@ -48,6 +49,8 @@ export interface AddFlags {
   dryRun: boolean
   force: boolean
   yes: boolean
+  /** Write package.json but skip running `bun install` (offline / tests). */
+  skipInstall: boolean
 }
 
 /**
@@ -59,7 +62,12 @@ export function parseAddArgs(argv: string[]): {
   flags: AddFlags
 } {
   const plugins: string[] = []
-  const flags: AddFlags = { dryRun: false, force: false, yes: false }
+  const flags: AddFlags = {
+    dryRun: false,
+    force: false,
+    yes: false,
+    skipInstall: false,
+  }
 
   const takeValue = (
     flag: '--from' | '--ref',
@@ -93,6 +101,8 @@ export function parseAddArgs(argv: string[]): {
       flags.force = true
     } else if (arg === '--yes') {
       flags.yes = true
+    } else if (arg === '--skip-install') {
+      flags.skipInstall = true
     } else if (arg.startsWith('-')) {
       throw new Error(`Unknown flag: ${arg}`)
     } else {
@@ -611,9 +621,13 @@ const runAdd = async (plugins: string[], flags: AddFlags): Promise<void> => {
     }
 
     if (depsAdded > 0 && !flags.dryRun) {
-      s.start('Installing dependencies...')
-      await Bun.$`bun install`.quiet()
-      s.stop('Dependencies installed')
+      if (flags.skipInstall) {
+        p.log.step('Skipped bun install (--skip-install) — run it manually')
+      } else {
+        s.start('Installing dependencies...')
+        await Bun.$`bun install`.quiet()
+        s.stop('Dependencies installed')
+      }
     }
   } finally {
     await source.cleanup()
@@ -645,6 +659,7 @@ Options for add:
   --dry-run           Print what would happen without writing anything
   --force             Overwrite existing / locally modified files
   --yes               Skip confirmation prompts (CI)
+  --skip-install      Write package.json but do not run bun install
 `
 
 const main = async (): Promise<void> => {

--- a/lib/scripts/setup-project.test.ts
+++ b/lib/scripts/setup-project.test.ts
@@ -31,6 +31,9 @@ beforeAll(async () => {
     for (const transform of bundle.codeTransforms) {
       filesToLoad.add(transform.file)
     }
+    for (const transform of bundle.addTransforms ?? []) {
+      filesToLoad.add(transform.file)
+    }
   }
 
   for (const file of filesToLoad) {
@@ -118,6 +121,74 @@ describe('Integration Bundle Configuration', () => {
             expect(op.value).toBeTruthy()
           }
         }
+      }
+    }
+  })
+
+  it('should have valid additive transform configurations (addTransforms shape)', () => {
+    // `satus add` may only use the idempotent ADDITIVE op kinds — a removal
+    // op in addTransforms would silently undo an install.
+    const additiveKinds = [
+      'addImport',
+      'addArrayStringElement',
+      'addArrayObjectElement',
+      'addVariableStatement',
+      'addJsxChild',
+    ]
+
+    for (const [_name, bundle] of getIntegrationEntries()) {
+      for (const transform of bundle.addTransforms ?? []) {
+        expect(transform.file).toBeTruthy()
+        expect(Array.isArray(transform.ops)).toBe(true)
+
+        for (const op of transform.ops) {
+          // Every additive op must have a known ADDITIVE kind
+          expect(additiveKinds).toContain(op.kind)
+
+          // Each op kind must carry its required fields
+          if (op.kind === 'addImport') {
+            expect(op.text).toBeTruthy()
+          } else if (op.kind === 'addArrayStringElement') {
+            expect(op.variableName).toBeTruthy()
+            expect(op.propertyPath).toBeTruthy()
+            expect(op.value).toBeTruthy()
+          } else if (op.kind === 'addArrayObjectElement') {
+            expect(op.variableName).toBeTruthy()
+            expect(op.propertyPath).toBeTruthy()
+            expect(op.objectText).toBeTruthy()
+            expect(op.matchProperty).toBeTruthy()
+          } else if (op.kind === 'addVariableStatement') {
+            expect(op.name).toBeTruthy()
+            expect(op.text).toBeTruthy()
+          } else if (op.kind === 'addJsxChild') {
+            expect(op.parentTagName).toBeTruthy()
+            expect(op.childText).toBeTruthy()
+            expect(op.childTagName).toBeTruthy()
+          }
+        }
+      }
+    }
+  })
+
+  it('should only reference known bundle ids in requires (no self-reference)', () => {
+    const known = getIntegrationNames()
+    for (const [name, bundle] of getIntegrationEntries()) {
+      for (const required of bundle.requires ?? []) {
+        expect(known).toContain(required)
+        expect(required).not.toBe(name)
+      }
+    }
+  })
+
+  it('theatre should require webgl', () => {
+    expect(INTEGRATION_BUNDLES.theatre?.requires).toEqual(['webgl'])
+  })
+
+  it('should declare overwriteFiles as non-empty relative paths', () => {
+    for (const [_name, bundle] of getIntegrationEntries()) {
+      for (const file of bundle.overwriteFiles ?? []) {
+        expect(file).toBeTruthy()
+        expect(file.startsWith('/')).toBe(false)
       }
     }
   })
@@ -534,5 +605,141 @@ describe('Combined Transforms (Multiple Integrations Removed)', () => {
         expect(result).toMatch(/export (?<keyword>function|const)/)
       }
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Additive transforms — remove → add round trips on the real sources
+// (`satus add` applied to the lean state produced by `setup:project`)
+// ---------------------------------------------------------------------------
+
+describe('Additive Transforms (remove → add round trips)', () => {
+  /** Number of times `needle` occurs in `haystack`. */
+  const count = (haystack: string, needle: string): number =>
+    haystack.split(needle).length - 1
+
+  /**
+   * Apply a bundle's removal ops for `file`, then its additive ops, and
+   * assert the additive ops are idempotent on the restored result.
+   */
+  const roundTrip = (
+    bundleName: 'sanity' | 'shopify' | 'webgl' | 'theatre',
+    file: string
+  ): { lean: string; restored: string } | undefined => {
+    const bundle = INTEGRATION_BUNDLES[bundleName]
+    const content = sourceFiles[file]
+    if (!(bundle && content)) return undefined
+
+    const removal = bundle.codeTransforms.find((t) => t.file === file)
+    const additive = bundle.addTransforms?.find((t) => t.file === file)
+    if (!(removal && additive)) return undefined
+
+    const lean = applyOpsToText(content, removal.ops)
+    const restored = applyOpsToText(lean, additive.ops)
+
+    // Issue constraint: adding twice is a no-op.
+    expect(applyOpsToText(restored, additive.ops)).toBe(restored)
+
+    return { lean, restored }
+  }
+
+  it('webgl: lib/features/index.tsx regains the LazyGlobalCanvas wiring', () => {
+    const result = roundTrip('webgl', 'lib/features/index.tsx')
+    if (!result) return
+
+    expect(result.lean).not.toContain('LazyGlobalCanvas')
+    expect(result.restored).toContain('const LazyGlobalCanvas')
+    expect(result.restored).toContain('<LazyGlobalCanvas />')
+    expect(result.restored).toContain("import dynamic from 'next/dynamic'")
+    // Untouched features survive
+    expect(result.restored).toContain('GSAPRuntime')
+    expect(result.restored).toContain('OrchestraTools')
+  })
+
+  it('webgl: lib/dev/cmdo.tsx regains the webgl toggle next to its siblings', () => {
+    const result = roundTrip('webgl', 'lib/dev/cmdo.tsx')
+    if (!result) return
+
+    expect(result.lean).not.toContain('id="webgl"')
+    expect(count(result.restored, 'id="webgl"')).toBe(1)
+    // Inserted inside the toggle row, not appended to the outer dialog div:
+    // the webgl toggle must come before the row's closing tag, i.e. before
+    // the screenshot toggle's container ends.
+    expect(result.restored).toContain('id="screenshot"')
+    expect(result.restored.indexOf('id="webgl"')).toBeGreaterThan(
+      result.restored.indexOf('id="grid"')
+    )
+  })
+
+  it('webgl: next.config.ts regains the three.js optimizePackageImports entries', () => {
+    const result = roundTrip('webgl', 'next.config.ts')
+    if (!result) return
+
+    expect(result.lean).not.toContain('@react-three/drei')
+    expect(count(result.restored, "'@react-three/drei'")).toBe(1)
+    expect(count(result.restored, "'@react-three/fiber'")).toBe(1)
+    expect(count(result.restored, "'three'")).toBe(1)
+  })
+
+  it('theatre: lib/dev/index.tsx regains the Studio wiring', () => {
+    const result = roundTrip('theatre', 'lib/dev/index.tsx')
+    if (!result) return
+
+    expect(result.lean).not.toContain('Studio')
+    expect(result.restored).toContain('const Studio = dynamic(')
+    expect(result.restored).toContain('{studio && <Studio />}')
+    // The `studio` binding the JSX expression relies on is still destructured
+    expect(result.restored).toContain('useOrchestra()')
+  })
+
+  it('theatre: lib/dev/cmdo.tsx regains the studio toggle', () => {
+    const result = roundTrip('theatre', 'lib/dev/cmdo.tsx')
+    if (!result) return
+
+    expect(result.lean).not.toContain('id="studio"')
+    expect(count(result.restored, 'id="studio"')).toBe(1)
+    // The webgl toggle is untouched by the theatre round trip
+    expect(count(result.restored, 'id="webgl"')).toBe(1)
+  })
+
+  it('sanity: next.config.ts regains remotePattern and package imports exactly once', () => {
+    const result = roundTrip('sanity', 'next.config.ts')
+    if (!result) return
+
+    expect(result.lean).not.toContain('cdn.sanity.io')
+    expect(count(result.restored, 'cdn.sanity.io')).toBe(1)
+    expect(count(result.restored, "'@sanity/client'")).toBe(1)
+    expect(count(result.restored, "'@sanity/image-url'")).toBe(1)
+    expect(count(result.restored, "'@sanity/asset-utils'")).toBe(1)
+    expect(count(result.restored, "'@portabletext/react'")).toBe(1)
+    // The shopify pattern is untouched
+    expect(count(result.restored, 'cdn.shopify.com')).toBe(1)
+  })
+
+  it('shopify: next.config.ts regains the cdn.shopify.com remotePattern exactly once', () => {
+    const result = roundTrip('shopify', 'next.config.ts')
+    if (!result) return
+
+    expect(result.lean).not.toContain('cdn.shopify.com')
+    expect(count(result.restored, 'cdn.shopify.com')).toBe(1)
+    expect(count(result.restored, 'cdn.sanity.io')).toBe(1)
+  })
+
+  it('webgl overwrite: the lean wrapper matches the expected lean state', () => {
+    // `satus add webgl` restores the Wrapper wholesale; its safety check
+    // compares the local file against the payload-with-removal-ops state.
+    // Verify the equation holds on the real source: applying the removal ops
+    // twice equals applying them once (so a lean wrapper is recognized).
+    const bundle = INTEGRATION_BUNDLES.webgl
+    const content = sourceFiles['components/layout/wrapper/index.tsx']
+    if (!(bundle && content)) return
+
+    const removal = bundle.codeTransforms.find(
+      (t) => t.file === 'components/layout/wrapper/index.tsx'
+    )
+    if (!removal) return
+
+    const lean = applyOpsToText(content, removal.ops)
+    expect(applyOpsToText(lean, removal.ops)).toBe(lean)
   })
 })

--- a/lib/scripts/setup-project.ts
+++ b/lib/scripts/setup-project.ts
@@ -15,7 +15,9 @@
  *   bun run setup:project --keep '' --clean-homepage --yes
  *
  * `--clean-homepage` replaces the manual landing page (default: keep it);
- * `--yes` is accepted alongside either selection flag. A successful run
+ * `--yes` is accepted alongside either selection flag; `--skip-install`
+ * writes package.json without running `bun install` (offline / tests).
+ * A successful run
  * records the current git HEAD sha into package.json as `"satus": { "ref" }`,
  * which `bun run satus add` uses to fetch matching integration payloads.
  *
@@ -99,6 +101,8 @@ interface SetupOptions {
   keepIntegrations: string[]
   /** Replace the manual landing page with a blank starter homepage. */
   cleanMarketing: boolean
+  /** Write package.json but skip running `bun install` (offline / tests). */
+  skipInstall: boolean
 }
 
 /**
@@ -248,7 +252,7 @@ const updateBarrelExports = async (
  * Main setup function
  */
 const setup = async (options: SetupOptions): Promise<void> => {
-  const { dryRun, keepIntegrations, cleanMarketing } = options
+  const { dryRun, keepIntegrations, cleanMarketing, skipInstall } = options
   const integrationNames = getIntegrationNames()
 
   // Replace the manual landing page first (independent of integration removal).
@@ -378,7 +382,7 @@ const setup = async (options: SetupOptions): Promise<void> => {
   }
 
   // Run bun install to update lockfile
-  if (!dryRun) {
+  if (!(dryRun || skipInstall)) {
     s.start('Updating lockfile...')
     await Bun.$`bun install`.quiet()
     s.stop('Dependencies updated')
@@ -524,6 +528,7 @@ const main = async (): Promise<void> => {
   const keepFlag = getFlagValue(argv, '--keep')
   const yes = argv.includes('--yes')
   const cleanHomepageFlag = argv.includes('--clean-homepage')
+  const skipInstall = argv.includes('--skip-install')
 
   // Throws on conflicting / unknown values — fails loudly before any prompt.
   const flagKeep = resolveKeepFromFlags(presetFlag, keepFlag)
@@ -618,6 +623,7 @@ const main = async (): Promise<void> => {
     dryRun,
     keepIntegrations: keepIntegrations as string[],
     cleanMarketing,
+    skipInstall,
   })
 
   // Pin the payload ref for `satus add` (skipped silently without git)

--- a/lib/scripts/setup-project.ts
+++ b/lib/scripts/setup-project.ts
@@ -9,6 +9,16 @@
  * 2. Remove unused code and dependencies
  * 3. Clean up configuration files
  *
+ * Non-interactive (CI) usage — skips every prompt:
+ *   bun run setup:project --preset <key>           Use a preset's integrations
+ *   bun run setup:project --keep <id,id,...>       Keep an explicit set ('' = lean)
+ *   bun run setup:project --keep '' --clean-homepage --yes
+ *
+ * `--clean-homepage` replaces the manual landing page (default: keep it);
+ * `--yes` is accepted alongside either selection flag. A successful run
+ * records the current git HEAD sha into package.json as `"satus": { "ref" }`,
+ * which `bun run satus add` uses to fetch matching integration payloads.
+ *
  * Cross-platform compatible (Windows, macOS, Linux)
  */
 
@@ -22,6 +32,7 @@ import {
   INTEGRATION_BUNDLES,
 } from './integration-bundles'
 import {
+  getFlagValue,
   parseCliFlags,
   pathExists,
   removeDir,
@@ -375,19 +386,77 @@ const setup = async (options: SetupOptions): Promise<void> => {
 }
 
 /**
- * CLI entry point
+ * Record the current git HEAD sha into package.json as the pinned satus ref
+ * (`"satus": { "ref": … }`), used by `satus add` to fetch matching payloads.
+ * Skips silently when git is unavailable — the ref is optional metadata.
  */
-const main = async (): Promise<void> => {
-  const { dryRun } = parseCliFlags()
+const recordPinnedRef = async (): Promise<void> => {
+  try {
+    const proc = Bun.spawn(['git', 'rev-parse', 'HEAD'], {
+      stdout: 'pipe',
+      stderr: 'ignore',
+    })
+    const exitCode = await proc.exited
+    if (exitCode !== 0) return
 
-  console.clear()
+    const sha = (await new Response(proc.stdout).text()).trim()
+    if (!sha) return
 
-  p.intro('Satūs Project Setup')
+    const pkgPath = resolvePath('package.json')
+    const pkg = (await Bun.file(pkgPath).json()) as {
+      satus?: Record<string, unknown>
+      [key: string]: unknown
+    }
+    pkg.satus = { ...(pkg.satus ?? {}), ref: sha }
+    await Bun.write(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`)
+  } catch {
+    // git not installed / not a repo — the pinned ref is optional metadata
+  }
+}
 
-  if (dryRun) {
-    p.log.warn('Dry run mode - no files will be modified')
+/**
+ * Resolve the integrations to keep from the non-interactive flags.
+ * Returns undefined when neither --preset nor --keep was passed.
+ * Fails loudly on conflicting flags and unknown preset / integration ids.
+ */
+export const resolveKeepFromFlags = (
+  presetFlag: string | undefined,
+  keepFlag: string | undefined
+): RemovableId[] | undefined => {
+  if (presetFlag !== undefined && keepFlag !== undefined) {
+    throw new Error('Use either --preset or --keep, not both')
   }
 
+  if (presetFlag !== undefined) {
+    if (!(presetFlag in PROJECT_PRESETS)) {
+      throw new Error(
+        `Unknown preset "${presetFlag}". Available: ${Object.keys(PROJECT_PRESETS).join(', ')}`
+      )
+    }
+    return [...PROJECT_PRESETS[presetFlag as PresetKey].integrations]
+  }
+
+  if (keepFlag !== undefined) {
+    const ids = keepFlag
+      .split(',')
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0)
+    const known = getIntegrationNames()
+    for (const id of ids) {
+      if (!(known as string[]).includes(id)) {
+        throw new Error(
+          `Unknown integration "${id}". Available: ${known.join(', ')}`
+        )
+      }
+    }
+    return ids as RemovableId[]
+  }
+
+  return undefined
+}
+
+/** Interactive integration selection (preset select or custom multiselect). */
+const promptForIntegrations = async (): Promise<RemovableId[]> => {
   // Build preset options
   const presetOptions = [
     ...Object.entries(PROJECT_PRESETS).map(([key, preset]) => ({
@@ -414,8 +483,6 @@ const main = async (): Promise<void> => {
     process.exit(0)
   }
 
-  let keepIntegrations: RemovableId[] = []
-
   if (selectedPreset === 'custom') {
     // Build options for multiselect
     const integrationOptions = getIntegrationNames().map((key) => ({
@@ -432,27 +499,75 @@ const main = async (): Promise<void> => {
       required: false,
     })
 
-    keepIntegrations = cancelGuard(customIntegrations, 'Setup cancelled')
-  } else {
-    // Use preset integrations
-    const preset = PROJECT_PRESETS[selectedPreset as PresetKey]
-    keepIntegrations = [...preset.integrations]
+    return cancelGuard(customIntegrations, 'Setup cancelled')
+  }
 
-    p.log.step(`Selected preset: ${preset.name}`)
-    p.log.message(
-      `  Includes: ${keepIntegrations.length > 0 ? keepIntegrations.map((k) => INTEGRATION_BUNDLES[k]?.name).join(', ') : 'None'}`
+  // Use preset integrations
+  const preset = PROJECT_PRESETS[selectedPreset as PresetKey]
+  const keepIntegrations = [...preset.integrations]
+
+  p.log.step(`Selected preset: ${preset.name}`)
+  p.log.message(
+    `  Includes: ${keepIntegrations.length > 0 ? keepIntegrations.map((k) => INTEGRATION_BUNDLES[k]?.name).join(', ') : 'None'}`
+  )
+
+  return keepIntegrations
+}
+
+/**
+ * CLI entry point
+ */
+const main = async (): Promise<void> => {
+  const argv = process.argv.slice(2)
+  const { dryRun } = parseCliFlags(argv)
+  const presetFlag = getFlagValue(argv, '--preset')
+  const keepFlag = getFlagValue(argv, '--keep')
+  const yes = argv.includes('--yes')
+  const cleanHomepageFlag = argv.includes('--clean-homepage')
+
+  // Throws on conflicting / unknown values — fails loudly before any prompt.
+  const flagKeep = resolveKeepFromFlags(presetFlag, keepFlag)
+  const nonInteractive = flagKeep !== undefined
+
+  if (yes && !nonInteractive) {
+    throw new Error(
+      '--yes requires --preset <key> or --keep <id,id,...> to define the integration set'
     )
   }
 
-  // Offer to drop the manual landing page for a clean slate.
-  const cleanMarketing = await p.confirm({
-    message: 'Replace the manual landing page with a blank starter homepage?',
-    initialValue: false,
-  })
+  if (!nonInteractive) {
+    console.clear()
+  }
 
-  if (p.isCancel(cleanMarketing)) {
-    p.cancel('Setup cancelled')
-    process.exit(0)
+  p.intro('Satūs Project Setup')
+
+  if (dryRun) {
+    p.log.warn('Dry run mode - no files will be modified')
+  }
+
+  let keepIntegrations: RemovableId[]
+  let cleanMarketing: boolean
+
+  if (flagKeep !== undefined) {
+    keepIntegrations = flagKeep
+    // Default behavior preserved: the landing page is only replaced when
+    // --clean-homepage is passed explicitly.
+    cleanMarketing = cleanHomepageFlag
+  } else {
+    keepIntegrations = await promptForIntegrations()
+
+    // Offer to drop the manual landing page for a clean slate.
+    const cleanMarketingAnswer = await p.confirm({
+      message: 'Replace the manual landing page with a blank starter homepage?',
+      initialValue: false,
+    })
+
+    if (p.isCancel(cleanMarketingAnswer)) {
+      p.cancel('Setup cancelled')
+      process.exit(0)
+    }
+
+    cleanMarketing = cleanMarketingAnswer
   }
 
   const toRemove = getIntegrationNames().filter(
@@ -486,14 +601,16 @@ const main = async (): Promise<void> => {
     )
   }
 
-  // Confirm
-  const proceed = await p.confirm({
-    message: dryRun ? 'Preview changes?' : 'Proceed with setup?',
-  })
+  // Confirm — skipped in non-interactive mode (--preset / --keep imply --yes)
+  if (!nonInteractive) {
+    const proceed = await p.confirm({
+      message: dryRun ? 'Preview changes?' : 'Proceed with setup?',
+    })
 
-  if (p.isCancel(proceed) || !proceed) {
-    p.cancel('Setup cancelled')
-    process.exit(0)
+    if (p.isCancel(proceed) || !proceed) {
+      p.cancel('Setup cancelled')
+      process.exit(0)
+    }
   }
 
   // Run setup
@@ -502,6 +619,11 @@ const main = async (): Promise<void> => {
     keepIntegrations: keepIntegrations as string[],
     cleanMarketing,
   })
+
+  // Pin the payload ref for `satus add` (skipped silently without git)
+  if (!dryRun) {
+    await recordPinnedRef()
+  }
 
   // Done
   if (dryRun) {

--- a/lib/scripts/utils.ts
+++ b/lib/scripts/utils.ts
@@ -151,6 +151,31 @@ export const parseCliFlags = (
   }
 }
 
+/**
+ * Read the value of a `--flag value` or `--flag=value` CLI argument.
+ *
+ * Returns `undefined` when the flag is absent, and the empty string when the
+ * flag is present without a value (`--keep=` / trailing `--keep`), so callers
+ * can distinguish "not passed" from "passed empty".
+ */
+export const getFlagValue = (
+  argv: string[],
+  flag: string
+): string | undefined => {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === undefined) continue
+    if (arg === flag) {
+      const next = argv[i + 1]
+      // A following flag (or nothing) means this one carries no value.
+      if (next === undefined || next.startsWith('--')) return ''
+      return next
+    }
+    if (arg.startsWith(`${flag}=`)) return arg.slice(flag.length + 1)
+  }
+  return undefined
+}
+
 // ============================================================================
 // Clipboard Utilities (Cross-platform)
 // ============================================================================

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dev:inspect": "bun ./lib/scripts/dev.ts --inspect",
     "lighthouse": "bunx @unlighthouse/cli --site http://localhost:3000",
     "setup:project": "bun ./lib/scripts/setup-project.ts",
+    "satus": "bun ./lib/scripts/satus.ts",
     "test": "bun test",
     "test:setup": "bun test lib/scripts/setup-project.test.ts",
     "doctor": "bun ./lib/scripts/doctor.ts",


### PR DESCRIPTION
## What this does
Inverts the setup model from #185: instead of only stripping integrations from a full clone, a lean project can now pull them back in. `bun run satus add shopify` fetches the integration's source from the satus repo itself (a local checkout via `--from`, or a pinned ref via GitHub tarball), drops it in as owned code, pins the deps, and re-wires shared files — running it twice is a no-op.

Closes #185

## Summary
- Five additive, idempotent AST ops (`addImport`, `addArrayStringElement`, `addArrayObjectElement`, `addVariableStatement`, `addJsxChild`) mirror the existing removal ops in `lib/scripts/ast-transforms.ts`
- `lib/scripts/satus.ts`: `satus list` + `satus add <plugin...> [--from|--ref|--dry-run|--force|--yes|--skip-install]`; transitive `requires` resolution (theatre → webgl); deps pinned to the payload's versions; barrel lines, env stubs, and `next.config.ts` wiring restored via the AST ops; integration-owned files (`overwriteFiles`) copied wholesale behind a modified-locally guard; absent plugins' removal transforms re-applied after copy so cross-bundle leaks (webgl's Theatre wiring) never reach a project that didn't ask for them
- `lib/scripts/payload-source.ts`: payload resolution `--from` → `--ref` → package.json-pinned `satus.ref` → `main`; `setup:project` records the ref at scaffold time
- `setup:project` gains `--preset/--keep/--yes/--clean-homepage/--skip-install` for non-interactive/CI use
- Network-free e2e proves the subtract→add round-trip for shopify and webgl-without-theatre, including byte-identical payloads and idempotent re-runs; fixes stale webgl bundle references to the removed animated-gradient effect

## Scope note
`create-satus` as a published npm front door (`bunx create-satus my-app`) is intentionally not in this PR — it's a packaging/release task on top of the now-non-interactive `setup:project`. Everything else from the issue (additive model, repo-as-registry, idempotency, requires, CI-drivable flags, Shopify pilot) ships here.

## Test Plan
- [x] `bun run check` — biome + tsgo + 318 tests (incl. 4 e2e round-trips), 0 fail
- [x] `bun run build` clean
- [x] Smoke: `satus list`, `satus add sanity --from . --dry-run --yes` (idempotent no-op)