### PR TITLE
fix: normalize glob path separators in generate-manifest (Windows)

### DIFF
--- a/lib/scripts/generate-manifest.ts
+++ b/lib/scripts/generate-manifest.ts
@@ -17,7 +17,12 @@ const IS_CHECK = process.argv.includes('--check')
 
 function glob(pattern: string): string[] {
   const g = new Bun.Glob(pattern)
-  return [...g.scanSync({ cwd: ROOT, absolute: true })]
+  // Normalize separators to `/` so the forward-slash regexes below match on
+  // Windows, where Bun.Glob emits backslash paths. Without this the manifest
+  // is generated with empty component names locally but correct ones on CI.
+  return [...g.scanSync({ cwd: ROOT, absolute: true })].map((p) =>
+    p.replaceAll('\\', '/')
+  )
 }
 
 function isClientFile(filePath: string): boolean {


### PR DESCRIPTION
## Problem

`Bun.Glob.scanSync` emits **backslash-separated** paths on Windows (e.g. `...\components\ui\accordion\index.tsx`), but every section generator in `generate-manifest.ts` matches those paths against **forward-slash** regexes, e.g.:

```ts
file.match(/components\/([^/]+\/[^/]+)\/index\.tsx$/)
```

On Windows those regexes never match, so component/hook/util names come out **empty** (`|  | @/components/ui/ | ... |`). The bug is invisible until a contributor runs `bun run generate:manifest` on Windows and commits the result: CI (Linux) then regenerates the manifest with the *correct* names and `bun run manifest:check` fails with a diff like:

```
- |  | `@/components/ui/` | Client |
+ | Accordion | `@/components/ui/accordion` | Client |
```

## Fix

Normalize separators to `/` once, in the `glob()` helper, so all the downstream forward-slash regexes match on every platform:

```ts
return [...g.scanSync({ cwd: ROOT, absolute: true })].map((p) =>
  p.replaceAll('\', '/')
)
```

## Impact

- On Linux/macOS the output is byte-identical — `COMPONENTS.md` is unchanged, so CI stays green.
- On Windows `bun run generate:manifest` now produces the correct names, matching CI.

Single-file, low-risk change. No `COMPONENTS.md` regeneration needed (current committed manifest already has the correct names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
