### PR TITLE
refactor: nuclear-review cleanup — turnstile fail-closed, cart dedup, dead-code removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@ latest tag; security fixes land on the latest release (see `SECURITY.md`).
 - Dependabot PRs now auto-sync `bun.lock` via a `pull_request_target` workflow, so they pass the frozen-lockfile install in CI. (#190)
 - Consolidated root docs: folded `BOUNDARIES.md` into `ARCHITECTURE.md` and
   refreshed the doc maps in `README.md` and `AGENTS.md` (#177).
+- Shopify cart actions (`removeItem`/`addItem`/`updateItemQuantity`) share a
+  `runCartAction` helper for the IP + standard rate-limit prelude instead of
+  inlining it three times; behavior is unchanged.
+- `ast-transforms` op handlers route the ts-morph
+  create/getFullText/removeSourceFile lifecycle through one `withSourceFile`
+  helper with guaranteed cleanup — behavior-preserving, ~60 fewer lines.
 
 ### Removed
 
@@ -83,9 +89,17 @@ latest tag; security fixes land on the latest release (see `SECURITY.md`).
 - Hardened HubSpot form HTML stripping into a complete `stripHtmlTags` parser
   (a character scan, not regex), resolving the CodeQL
   `js/incomplete-multi-character-sanitization` alert (#179, #180).
+- Turnstile siteverify responses are validated with a Zod schema and fail
+  closed — an unexpected response shape now returns a failed verification
+  instead of reading an unchecked `as`-cast `success`.
 
 ### Removed
 
+- Dead and duplicate internal surface: unused `batch`/`measure` exports from
+  `lib/utils/raf.ts` (only `mutate` is consumed), the duplicated
+  `ShaderMaterial<K>`/`DoubleRenderTarget` webgl types (hoisted once into
+  `lib/webgl/utils`), and the flat `Select*`/`Menu*`/`Tabs*` part exports that
+  had zero importers (the compound `Select`/`Menu`/`Tabs` APIs are unchanged).
 - Hand-rolled `components/ui/dropdown/` — superseded by the accessible Base UI `Select`. (#202, #205)
 - `lib/utils/animation.ts` re-exports of `clamp` / `lerp` / `mapRange` / `modulo` / `truncate` — import these from `@/utils/math` instead. (#198)
 - In-repo marketing homepage — the `app/(marketing)` landing sections (hero, features, value-props, getting-started, presets) and marketing-only WebGL effects (`animated-gradient`, `liquid-drip`, `split-text`). Satus is a starter kit; its marketing lives at oss.darkroom.engineering/satus. (#188)

--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -110,9 +110,7 @@ Quick-reference for every component, hook, and utility in the Satus starter kit.
 
 | Export | Signature |
 |--------|-----------|
-| measure | `(fn: () => T) => Promise<T>` |
 | mutate | `(fn: () => T) => Promise<T>` |
-| batch | `(reads: { [K in keyof T]: () => T[K] }, write: (results: T) => void) => Promise<void>` |
 
 ### Rate-limit (`@/utils/rate-limit`)
 

--- a/components/ui/menu/index.tsx
+++ b/components/ui/menu/index.tsx
@@ -136,26 +136,7 @@ const CheckboxItemIndicator = BaseMenu.CheckboxItemIndicator
 // Submenu support
 const SubmenuTrigger = BaseMenu.SubmenuTrigger
 
-export {
-  Arrow,
-  CheckboxItem,
-  CheckboxItemIndicator,
-  Group,
-  GroupLabel,
-  Item,
-  Popup,
-  Portal,
-  Positioner,
-  RadioGroup,
-  RadioItem,
-  RadioItemIndicator,
-  Root,
-  Separator,
-  SubmenuTrigger,
-  Trigger,
-}
-
-// Also export as namespace for compound component pattern
+// Export as namespace for compound component pattern
 export const Menu = {
   Root,
   Trigger,

--- a/components/ui/select/index.tsx
+++ b/components/ui/select/index.tsx
@@ -239,21 +239,4 @@ Select.GroupLabel = GroupLabel
 Select.Separator = Separator
 Select.Arrow = Arrow
 
-// Also export compound components individually
-export {
-  Arrow as SelectArrow,
-  Group as SelectGroup,
-  GroupLabel as SelectGroupLabel,
-  Icon as SelectIcon,
-  Item as SelectItem,
-  ItemIndicator as SelectItemIndicator,
-  ItemText as SelectItemText,
-  Popup as SelectPopup,
-  Portal as SelectPortal,
-  Positioner as SelectPositioner,
-  Root as SelectRoot,
-  Select,
-  Separator as SelectSeparator,
-  Trigger as SelectTrigger,
-  Value as SelectValue,
-}
+export { Select }

--- a/components/ui/tabs/index.tsx
+++ b/components/ui/tabs/index.tsx
@@ -89,11 +89,3 @@ export const Tabs = {
   Indicator,
   Panel,
 }
-
-export {
-  Indicator as TabsIndicator,
-  List as TabsList,
-  Panel as TabsPanel,
-  Root as TabsRoot,
-  Tab as TabsTab,
-}

--- a/lib/integrations/shopify/cart/actions.ts
+++ b/lib/integrations/shopify/cart/actions.ts
@@ -32,6 +32,32 @@ const updateQuantitySchema = z.object({
   lineId: z.string().optional(),
 })
 
+/**
+ * Shared prelude for cart server actions: extracts the client IP, applies the
+ * standard rate limiter, and delegates to the provided `run` callback.
+ *
+ * Returns the rate-limit error result directly when the limit is exceeded, so
+ * callers never need to repeat the IP + rateLimit boilerplate.
+ *
+ * @param rateLimitPrefix - Rate-limit key prefix (e.g. "cart-add"). The client IP is appended.
+ * @param run - The action body to invoke after the prelude passes.
+ */
+async function runCartAction(
+  rateLimitPrefix: string,
+  run: () => Promise<CartActionResult>
+): Promise<CartActionResult> {
+  const headersList = await headers()
+  const ip = getIPFromHeaders(headersList)
+  const rateLimitResult = rateLimit(
+    `${rateLimitPrefix}:${ip}`,
+    rateLimiters.standard
+  )
+  if (!rateLimitResult.success) {
+    return { ok: false, error: 'Too many requests. Please try again later.' }
+  }
+  return run()
+}
+
 export async function removeItem(
   _prevState: unknown,
   merchandiseId: string,
@@ -44,96 +70,89 @@ export async function removeItem(
     return { ok: false, error: 'Missing cart ID' }
   }
 
-  const headersList = await headers()
-  const ip = getIPFromHeaders(headersList)
-  const rateLimitResult = rateLimit(`cart-remove:${ip}`, rateLimiters.standard)
-  if (!rateLimitResult.success) {
-    return { ok: false, error: 'Too many requests. Please try again later.' }
-  }
-
-  if (!merchandiseId) {
-    return { ok: false, error: 'Merchandise ID is required' }
-  }
-
-  try {
-    // Fast path: caller supplies lineId directly — skip the extra getCart round-trip.
-    if (lineId) {
-      await removeFromCart(cartId, [lineId])
-      revalidateTag(TAGS.cart, {})
-      return { ok: true }
+  return runCartAction('cart-remove', async () => {
+    if (!merchandiseId) {
+      return { ok: false, error: 'Merchandise ID is required' }
     }
 
-    // Fallback: resolve lineId from a fresh cart fetch (e.g. callers without lineId).
-    const cart = await getCart(cartId)
+    try {
+      // Fast path: caller supplies lineId directly — skip the extra getCart round-trip.
+      if (lineId) {
+        await removeFromCart(cartId, [lineId])
+        revalidateTag(TAGS.cart, {})
+        return { ok: true }
+      }
 
-    if (!cart) {
-      return { ok: false, error: 'Error fetching cart' }
+      // Fallback: resolve lineId from a fresh cart fetch (e.g. callers without lineId).
+      const cart = await getCart(cartId)
+
+      if (!cart) {
+        return { ok: false, error: 'Error fetching cart' }
+      }
+
+      const lineItem = cart.lines.find(
+        (line) => line.merchandise.id === merchandiseId
+      )
+
+      if (lineItem?.id) {
+        await removeFromCart(cartId, [lineItem.id])
+        revalidateTag(TAGS.cart, {})
+        return { ok: true }
+      }
+
+      return { ok: false, error: 'Item not found in cart' }
+    } catch (_e) {
+      return { ok: false, error: 'Error removing item from cart' }
     }
-
-    const lineItem = cart.lines.find(
-      (line) => line.merchandise.id === merchandiseId
-    )
-
-    if (lineItem?.id) {
-      await removeFromCart(cartId, [lineItem.id])
-      revalidateTag(TAGS.cart, {})
-      return { ok: true }
-    }
-
-    return { ok: false, error: 'Item not found in cart' }
-  } catch (_e) {
-    return { ok: false, error: 'Error removing item from cart' }
-  }
+  })
 }
 
 export async function addItem(
   _prevState: unknown,
   { variantId, quantity = 1 }: AddItemPayload
 ): Promise<CartActionResult> {
-  const headersList = await headers()
-  const ip = getIPFromHeaders(headersList)
-  const rateLimitResult = rateLimit(`cart-add:${ip}`, rateLimiters.standard)
-  if (!rateLimitResult.success) {
-    return { ok: false, error: 'Too many requests. Please try again later.' }
-  }
-
-  // Validate input before creating a cart, so an invalid request doesn't leave
-  // an orphaned cart + cookie behind.
-  const parsed = addItemSchema.safeParse({ variantId, quantity })
-  if (!parsed.success) {
-    return {
-      ok: false,
-      error: parsed.error.issues[0]?.message ?? 'Invalid input',
+  return runCartAction('cart-add', async () => {
+    // Validate input before creating a cart, so an invalid request doesn't leave
+    // an orphaned cart + cookie behind.
+    const parsed = addItemSchema.safeParse({ variantId, quantity })
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: parsed.error.issues[0]?.message ?? 'Invalid input',
+      }
     }
-  }
 
-  const _cookies = await cookies()
-  let cartId = _cookies.get('cartId')?.value
+    const _cookies = await cookies()
+    let cartId = _cookies.get('cartId')?.value
 
-  // This is here because cookie can only be set server side
-  // and useFormState executes the addItem action in the server
-  if (!cartId) {
-    const cart = await createCart()
-    cartId = cart.id
-    _cookies.set('cartId', cartId, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: 60 * 60 * 24 * 30, // 30 days
-      path: '/',
-    })
-  }
+    // This is here because cookie can only be set server side
+    // and useFormState executes the addItem action in the server
+    if (!cartId) {
+      const cart = await createCart()
+      cartId = cart.id
+      _cookies.set('cartId', cartId, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        maxAge: 60 * 60 * 24 * 30, // 30 days
+        path: '/',
+      })
+    }
 
-  try {
-    await addToCart(cartId, [
-      { merchandiseId: parsed.data.variantId, quantity: parsed.data.quantity },
-    ])
-    revalidateTag(TAGS.cart, {})
+    try {
+      await addToCart(cartId, [
+        {
+          merchandiseId: parsed.data.variantId,
+          quantity: parsed.data.quantity,
+        },
+      ])
+      revalidateTag(TAGS.cart, {})
 
-    return { ok: true }
-  } catch (_e) {
-    return { ok: false, error: 'Error adding item to cart' }
-  }
+      return { ok: true }
+    } catch (_e) {
+      return { ok: false, error: 'Error adding item to cart' }
+    }
+  })
 }
 
 export async function updateItemQuantity(
@@ -154,58 +173,53 @@ export async function updateItemQuantity(
     return { ok: false, error: 'Missing cart ID' }
   }
 
-  const headersList = await headers()
-  const ip = getIPFromHeaders(headersList)
-  const rateLimitResult = rateLimit(`cart-update:${ip}`, rateLimiters.standard)
-  if (!rateLimitResult.success) {
-    return { ok: false, error: 'Too many requests. Please try again later.' }
-  }
-
-  const parsed = updateQuantitySchema.safeParse(payload)
-  if (!parsed.success) {
-    return {
-      ok: false,
-      error: parsed.error.issues[0]?.message ?? 'Invalid input',
+  return runCartAction('cart-update', async () => {
+    const parsed = updateQuantitySchema.safeParse(payload)
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: parsed.error.issues[0]?.message ?? 'Invalid input',
+      }
     }
-  }
 
-  const { merchandiseId, quantity, lineId } = parsed.data
+    const { merchandiseId, quantity, lineId } = parsed.data
 
-  try {
-    // Fast path: caller supplies lineId directly — skip the extra getCart round-trip.
-    if (lineId) {
-      await updateCart(cartId, [{ id: lineId, merchandiseId, quantity }])
+    try {
+      // Fast path: caller supplies lineId directly — skip the extra getCart round-trip.
+      if (lineId) {
+        await updateCart(cartId, [{ id: lineId, merchandiseId, quantity }])
+        revalidateTag(TAGS.cart, {})
+        return { ok: true }
+      }
+
+      // Fallback: resolve lineId from a fresh cart fetch (e.g. callers without lineId).
+      const cart = await getCart(cartId)
+
+      if (!cart) {
+        return { ok: false, error: 'Error fetching cart' }
+      }
+
+      const lineItem = cart.lines.find(
+        (line) => line.merchandise.id === merchandiseId
+      )
+
+      if (!lineItem?.id) {
+        return { ok: false, error: 'Item not found in cart' }
+      }
+
+      await updateCart(cartId, [
+        {
+          id: lineItem.id,
+          merchandiseId,
+          quantity,
+        },
+      ])
       revalidateTag(TAGS.cart, {})
       return { ok: true }
+    } catch (_e) {
+      return { ok: false, error: 'Error updating item quantity' }
     }
-
-    // Fallback: resolve lineId from a fresh cart fetch (e.g. callers without lineId).
-    const cart = await getCart(cartId)
-
-    if (!cart) {
-      return { ok: false, error: 'Error fetching cart' }
-    }
-
-    const lineItem = cart.lines.find(
-      (line) => line.merchandise.id === merchandiseId
-    )
-
-    if (!lineItem?.id) {
-      return { ok: false, error: 'Item not found in cart' }
-    }
-
-    await updateCart(cartId, [
-      {
-        id: lineItem.id,
-        merchandiseId,
-        quantity,
-      },
-    ])
-    revalidateTag(TAGS.cart, {})
-    return { ok: true }
-  } catch (_e) {
-    return { ok: false, error: 'Error updating item quantity' }
-  }
+  })
 }
 
 export async function fetchCart(): Promise<Cart | undefined> {

--- a/lib/integrations/turnstile/index.ts
+++ b/lib/integrations/turnstile/index.ts
@@ -6,7 +6,13 @@
  * - Perfect for terminal aesthetics
  */
 
+import { z } from 'zod'
 import { fetchWithTimeout } from '@/utils/fetch'
+
+const siteverifySchema = z.object({
+  success: z.boolean(),
+  'error-codes': z.array(z.string()).optional(),
+})
 
 export interface TurnstileValidationResult {
   isValid: boolean
@@ -61,12 +67,15 @@ export async function validateTurnstile(
       }
     }
 
-    const data = (await response.json()) as {
-      success: boolean
-      'error-codes'?: string[]
+    const parsed = siteverifySchema.safeParse(await response.json())
+
+    // Fail closed: if the response shape is unexpected, treat as failure.
+    if (!parsed.success) {
+      console.error('Turnstile siteverify response has unexpected shape')
+      return { isValid: false, errors: ['security_verification_failed_'] }
     }
 
-    if (data.success) {
+    if (parsed.data.success) {
       return { isValid: true, errors: [] }
     }
     return {

--- a/lib/scripts/ast-transforms.ts
+++ b/lib/scripts/ast-transforms.ts
@@ -146,6 +146,29 @@ function insertIndexAfterImports(sf: SourceFile): number {
   return index
 }
 
+/**
+ * Owns the create / getFullText / removeSourceFile lifecycle for a single
+ * in-memory source file. `fn` receives the SourceFile, mutates it, and returns
+ * either `undefined` (proceed with `sf.getFullText()`) or a string (short-
+ * circuit early — returned verbatim, bypassing getFullText). The source file is
+ * always removed in `finally` regardless of how `fn` exits.
+ */
+function withSourceFile(
+  project: Project,
+  sourceText: string,
+  fn: (sf: SourceFile) => string | undefined,
+  fileName = '__tmp__.tsx'
+): string {
+  const sf = project.createSourceFile(fileName, sourceText, { overwrite: true })
+  try {
+    const earlyResult = fn(sf)
+    if (typeof earlyResult === 'string') return earlyResult
+    return sf.getFullText()
+  } finally {
+    project.removeSourceFile(sf)
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Individual operation handlers
 // Each handler receives source text, applies one op, returns new source text.
@@ -159,18 +182,14 @@ function applyRemoveImport(
   sourceText: string,
   op: RemoveImportOp
 ): string {
-  const sf = project.createSourceFile('__tmp__.tsx', sourceText)
-
-  for (const decl of sf.getImportDeclarations()) {
-    if (decl.getModuleSpecifierValue() === op.specifier) {
-      decl.remove()
-      break
+  return withSourceFile(project, sourceText, (sf) => {
+    for (const decl of sf.getImportDeclarations()) {
+      if (decl.getModuleSpecifierValue() === op.specifier) {
+        decl.remove()
+        break
+      }
     }
-  }
-
-  const result = sf.getFullText()
-  project.removeSourceFile(sf)
-  return result
+  })
 }
 
 function applyRemoveVariableStatement(
@@ -178,23 +197,18 @@ function applyRemoveVariableStatement(
   sourceText: string,
   op: RemoveVariableStatementOp
 ): string {
-  const sf = project.createSourceFile('__tmp__.tsx', sourceText)
-  let result = sourceText
-
-  // Descendant scan so function-scoped consts are found, not just top-level.
-  for (const stmt of sf.getDescendantsOfKind(SyntaxKind.VariableStatement)) {
-    for (const decl of stmt.getDeclarations()) {
-      if (decl.getName() === op.name) {
-        stmt.remove()
-        result = sf.getFullText()
-        break
+  return withSourceFile(project, sourceText, (sf) => {
+    // Descendant scan so function-scoped consts are found, not just top-level.
+    for (const stmt of sf.getDescendantsOfKind(SyntaxKind.VariableStatement)) {
+      for (const decl of stmt.getDeclarations()) {
+        if (decl.getName() === op.name) {
+          stmt.remove()
+          return undefined // proceed with sf.getFullText()
+        }
       }
     }
-    if (result !== sourceText) break
-  }
-
-  project.removeSourceFile(sf)
-  return result
+    return sourceText // no match — return original unchanged
+  })
 }
 
 /**
@@ -207,26 +221,22 @@ function applyRemoveCallStatement(
   sourceText: string,
   op: RemoveCallStatementOp
 ): string {
-  const sf = project.createSourceFile('__tmp__.tsx', sourceText)
+  return withSourceFile(project, sourceText, (sf) => {
+    // Text removal invalidates collected nodes, so re-resolve after each pass.
+    while (true) {
+      const stmt = sf
+        .getDescendantsOfKind(SyntaxKind.ExpressionStatement)
+        .find((s) => {
+          const call = s.getExpression().asKind(SyntaxKind.CallExpression)
+          return call?.getExpression().getText() === op.callee
+        })
+      if (!stmt) break
 
-  // Text removal invalidates collected nodes, so re-resolve after each pass.
-  while (true) {
-    const stmt = sf
-      .getDescendantsOfKind(SyntaxKind.ExpressionStatement)
-      .find((s) => {
-        const call = s.getExpression().asKind(SyntaxKind.CallExpression)
-        return call?.getExpression().getText() === op.callee
-      })
-    if (!stmt) break
-
-    // Full start spans the leading trivia (blank line + comments) so the
-    // statement's own comment block is removed with it.
-    sf.removeText(stmt.getFullStart(), stmt.getEnd())
-  }
-
-  const result = sf.getFullText()
-  project.removeSourceFile(sf)
-  return result
+      // Full start spans the leading trivia (blank line + comments) so the
+      // statement's own comment block is removed with it.
+      sf.removeText(stmt.getFullStart(), stmt.getEnd())
+    }
+  })
 }
 
 function applyRemoveCallArgument(
@@ -234,26 +244,22 @@ function applyRemoveCallArgument(
   sourceText: string,
   op: RemoveCallArgumentOp
 ): string {
-  const sf = project.createSourceFile('__tmp__.tsx', sourceText)
-
-  // removeArgument invalidates the node list, so re-resolve after each removal.
-  while (true) {
-    let removed = false
-    for (const call of sf.getDescendantsOfKind(SyntaxKind.CallExpression)) {
-      if (call.getExpression().getText() !== op.callee) continue
-      const arg = call.getArguments().find((a) => a.getText() === op.argument)
-      if (arg) {
-        call.removeArgument(arg)
-        removed = true
-        break
+  return withSourceFile(project, sourceText, (sf) => {
+    // removeArgument invalidates the node list, so re-resolve after each removal.
+    while (true) {
+      let removed = false
+      for (const call of sf.getDescendantsOfKind(SyntaxKind.CallExpression)) {
+        if (call.getExpression().getText() !== op.callee) continue
+        const arg = call.getArguments().find((a) => a.getText() === op.argument)
+        if (arg) {
+          call.removeArgument(arg)
+          removed = true
+          break
+        }
       }
+      if (!removed) break
     }
-    if (!removed) break
-  }
-
-  const result = sf.getFullText()
-  project.removeSourceFile(sf)
-  return result
+  })
 }
 
 /**
@@ -273,111 +279,107 @@ function applyRemoveJsxElement(
   sourceText: string,
   op: RemoveJsxElementOp
 ): string {
-  const sf = project.createSourceFile('__tmp__.tsx', sourceText)
+  return withSourceFile(project, sourceText, (sf) => {
+    const selfClosingMatches = sf
+      .getDescendantsOfKind(SyntaxKind.JsxSelfClosingElement)
+      .filter((el) => selfClosingMatchesOp(el, op))
+      .map((n) => ({ pos: n.getPos(), kind: 'self' as const, node: n }))
 
-  const selfClosingMatches = sf
-    .getDescendantsOfKind(SyntaxKind.JsxSelfClosingElement)
-    .filter((el) => selfClosingMatchesOp(el, op))
-    .map((n) => ({ pos: n.getPos(), kind: 'self' as const, node: n }))
+    const openElementMatches = sf
+      .getDescendantsOfKind(SyntaxKind.JsxElement)
+      .filter((el) => openElementMatchesOp(el, op))
+      .map((n) => ({ pos: n.getPos(), kind: 'open' as const, node: n }))
 
-  const openElementMatches = sf
-    .getDescendantsOfKind(SyntaxKind.JsxElement)
-    .filter((el) => openElementMatchesOp(el, op))
-    .map((n) => ({ pos: n.getPos(), kind: 'open' as const, node: n }))
+    // Process in reverse source order so removals don't shift earlier positions.
+    const allMatches = [...selfClosingMatches, ...openElementMatches].sort(
+      (a, b) => b.pos - a.pos
+    )
 
-  // Process in reverse source order so removals don't shift earlier positions.
-  const allMatches = [...selfClosingMatches, ...openElementMatches].sort(
-    (a, b) => b.pos - a.pos
-  )
+    for (const match of allMatches) {
+      if (match.kind === 'self') {
+        const node = match.node
 
-  for (const match of allMatches) {
-    if (match.kind === 'self') {
-      const node = match.node
-
-      // Walk up the full ancestor chain to find the enclosing JsxExpression.
-      // This handles `{<Foo />}` (direct), `{cond && <Foo />}` (one level of
-      // binary expression), and deeper nesting like
-      // `{a && b && (<Wrapper><Foo /></Wrapper>)}` where Foo is several
-      // levels inside a JsxElement that itself is inside the JsxExpression.
-      // We do NOT stop at JsxElement boundaries here because the element being
-      // removed may be a leaf inside a wrapper (e.g. `<Suspense><Foo/></Suspense>`)
-      // that is itself inside the target JsxExpression.
-      let enclosingJsxExpr: Node | undefined
-      let cursor: Node | undefined = node.getParent()
-      while (cursor) {
-        if (cursor.getKind() === SyntaxKind.JsxExpression) {
-          enclosingJsxExpr = cursor
-          break
+        // Walk up the full ancestor chain to find the enclosing JsxExpression.
+        // This handles `{<Foo />}` (direct), `{cond && <Foo />}` (one level of
+        // binary expression), and deeper nesting like
+        // `{a && b && (<Wrapper><Foo /></Wrapper>)}` where Foo is several
+        // levels inside a JsxElement that itself is inside the JsxExpression.
+        // We do NOT stop at JsxElement boundaries here because the element being
+        // removed may be a leaf inside a wrapper (e.g. `<Suspense><Foo/></Suspense>`)
+        // that is itself inside the target JsxExpression.
+        let enclosingJsxExpr: Node | undefined
+        let cursor: Node | undefined = node.getParent()
+        while (cursor) {
+          if (cursor.getKind() === SyntaxKind.JsxExpression) {
+            enclosingJsxExpr = cursor
+            break
+          }
+          // Stop at JSX fragments — they delimit independent rendering scopes
+          if (cursor.getKind() === SyntaxKind.JsxFragment) {
+            break
+          }
+          cursor = cursor.getParent()
         }
-        // Stop at JSX fragments — they delimit independent rendering scopes
-        if (cursor.getKind() === SyntaxKind.JsxFragment) {
-          break
-        }
-        cursor = cursor.getParent()
-      }
 
-      if (enclosingJsxExpr) {
-        // Also remove any immediately preceding JSX comment sibling.
-        const container = enclosingJsxExpr.getParent()
-        if (container) {
-          const siblings = container.getChildren()
-          const idx = siblings.indexOf(enclosingJsxExpr)
-          if (idx > 0) {
-            const prev = siblings[idx - 1]
-            if (
-              prev &&
-              prev.getKind() === SyntaxKind.JsxExpression &&
-              prev.getText().trim().startsWith('{/*')
-            ) {
-              prev.replaceWithText('')
+        if (enclosingJsxExpr) {
+          // Also remove any immediately preceding JSX comment sibling.
+          const container = enclosingJsxExpr.getParent()
+          if (container) {
+            const siblings = container.getChildren()
+            const idx = siblings.indexOf(enclosingJsxExpr)
+            if (idx > 0) {
+              const prev = siblings[idx - 1]
+              if (
+                prev &&
+                prev.getKind() === SyntaxKind.JsxExpression &&
+                prev.getText().trim().startsWith('{/*')
+              ) {
+                prev.replaceWithText('')
+              }
             }
           }
-        }
-        enclosingJsxExpr.replaceWithText('')
-      } else {
-        node.replaceWithText('')
-      }
-    } else {
-      // JsxElement (open+close pair)
-      const node = match.node
-      if (op.unwrap) {
-        // Keep children, strip opening/closing tags.
-        const childText = node
-          .getJsxChildren()
-          .map((c) => c.getText())
-          .join('')
-        node.replaceWithText(childText)
-      } else {
-        // Remove entirely — walk up to find the enclosing JsxExpression so
-        // that `{cond && <Elem>…</Elem>}` is removed whole, not just the tags.
-        let enclosingExpr: Node | undefined
-        let cur: Node | undefined = node.getParent()
-        while (cur) {
-          if (cur.getKind() === SyntaxKind.JsxExpression) {
-            enclosingExpr = cur
-            break
-          }
-          // Stop if we reach another JSX element boundary (don't escape siblings)
-          if (
-            cur.getKind() === SyntaxKind.JsxElement ||
-            cur.getKind() === SyntaxKind.JsxFragment
-          ) {
-            break
-          }
-          cur = cur.getParent()
-        }
-        if (enclosingExpr) {
-          enclosingExpr.replaceWithText('')
+          enclosingJsxExpr.replaceWithText('')
         } else {
           node.replaceWithText('')
         }
+      } else {
+        // JsxElement (open+close pair)
+        const node = match.node
+        if (op.unwrap) {
+          // Keep children, strip opening/closing tags.
+          const childText = node
+            .getJsxChildren()
+            .map((c) => c.getText())
+            .join('')
+          node.replaceWithText(childText)
+        } else {
+          // Remove entirely — walk up to find the enclosing JsxExpression so
+          // that `{cond && <Elem>…</Elem>}` is removed whole, not just the tags.
+          let enclosingExpr: Node | undefined
+          let cur: Node | undefined = node.getParent()
+          while (cur) {
+            if (cur.getKind() === SyntaxKind.JsxExpression) {
+              enclosingExpr = cur
+              break
+            }
+            // Stop if we reach another JSX element boundary (don't escape siblings)
+            if (
+              cur.getKind() === SyntaxKind.JsxElement ||
+              cur.getKind() === SyntaxKind.JsxFragment
+            ) {
+              break
+            }
+            cur = cur.getParent()
+          }
+          if (enclosingExpr) {
+            enclosingExpr.replaceWithText('')
+          } else {
+            node.replaceWithText('')
+          }
+        }
       }
     }
-  }
-
-  const result = sf.getFullText()
-  project.removeSourceFile(sf)
-  return result
+  })
 }
 
 /**
@@ -391,40 +393,36 @@ function applyRemoveJsxAttribute(
   sourceText: string,
   op: RemoveJsxAttributeOp
 ): string {
-  const sf = project.createSourceFile('__tmp__.tsx', sourceText)
+  return withSourceFile(project, sourceText, (sf) => {
+    // Collect attribute nodes from self-closing elements
+    const selfClosingAttrs = sf
+      .getDescendantsOfKind(SyntaxKind.JsxSelfClosingElement)
+      .filter((el) => el.getTagNameNode().getText() === op.tagName)
+      .flatMap((el) => {
+        const attr = el.getAttribute(op.attributeName)
+        return attr ? [attr] : []
+      })
 
-  // Collect attribute nodes from self-closing elements
-  const selfClosingAttrs = sf
-    .getDescendantsOfKind(SyntaxKind.JsxSelfClosingElement)
-    .filter((el) => el.getTagNameNode().getText() === op.tagName)
-    .flatMap((el) => {
-      const attr = el.getAttribute(op.attributeName)
-      return attr ? [attr] : []
-    })
+    // Collect attribute nodes from open/close elements
+    const openElementAttrs = sf
+      .getDescendantsOfKind(SyntaxKind.JsxElement)
+      .filter(
+        (el) => el.getOpeningElement().getTagNameNode().getText() === op.tagName
+      )
+      .flatMap((el) => {
+        const attr = el.getOpeningElement().getAttribute(op.attributeName)
+        return attr ? [attr] : []
+      })
 
-  // Collect attribute nodes from open/close elements
-  const openElementAttrs = sf
-    .getDescendantsOfKind(SyntaxKind.JsxElement)
-    .filter(
-      (el) => el.getOpeningElement().getTagNameNode().getText() === op.tagName
+    // Process in reverse source order to keep positions stable
+    const allAttrs = [...selfClosingAttrs, ...openElementAttrs].sort(
+      (a, b) => b.getPos() - a.getPos()
     )
-    .flatMap((el) => {
-      const attr = el.getOpeningElement().getAttribute(op.attributeName)
-      return attr ? [attr] : []
-    })
 
-  // Process in reverse source order to keep positions stable
-  const allAttrs = [...selfClosingAttrs, ...openElementAttrs].sort(
-    (a, b) => b.getPos() - a.getPos()
-  )
-
-  for (const attr of allAttrs) {
-    attr.remove()
-  }
-
-  const result = sf.getFullText()
-  project.removeSourceFile(sf)
-  return result
+    for (const attr of allAttrs) {
+      attr.remove()
+    }
+  })
 }
 
 function applyRemoveInterfaceProperty(
@@ -432,24 +430,16 @@ function applyRemoveInterfaceProperty(
   sourceText: string,
   op: RemoveInterfacePropertyOp
 ): string {
-  const sf = project.createSourceFile('__tmp__.tsx', sourceText)
+  return withSourceFile(project, sourceText, (sf) => {
+    const iface = sf.getInterface(op.interfaceName)
+    if (!iface) return sourceText
 
-  const iface = sf.getInterface(op.interfaceName)
-  if (!iface) {
-    project.removeSourceFile(sf)
-    return sourceText
-  }
+    const prop = iface.getProperty(op.propertyName)
+    if (!prop) return sourceText
 
-  const prop = iface.getProperty(op.propertyName)
-  if (!prop) {
-    project.removeSourceFile(sf)
-    return sourceText
-  }
-
-  prop.remove()
-  const result = sf.getFullText()
-  project.removeSourceFile(sf)
-  return result
+    prop.remove()
+    return undefined // proceed with sf.getFullText()
+  })
 }
 
 function applyRemoveFunctionParameter(
@@ -457,44 +447,31 @@ function applyRemoveFunctionParameter(
   sourceText: string,
   op: RemoveFunctionParameterOp
 ): string {
-  const sf = project.createSourceFile('__tmp__.tsx', sourceText)
+  return withSourceFile(project, sourceText, (sf) => {
+    const fn = sf.getFunction(op.functionName)
+    if (!fn) return sourceText
 
-  const fn = sf.getFunction(op.functionName)
-  if (!fn) {
-    project.removeSourceFile(sf)
-    return sourceText
-  }
+    // Props are destructured in the first parameter's object binding pattern.
+    const param = fn.getParameters()[0]
+    if (!param) return sourceText
 
-  // Props are destructured in the first parameter's object binding pattern.
-  const param = fn.getParameters()[0]
-  if (!param) {
-    project.removeSourceFile(sf)
-    return sourceText
-  }
+    const binding = param.getNameNode()
+    if (binding.getKind() !== SyntaxKind.ObjectBindingPattern) return sourceText
 
-  const binding = param.getNameNode()
-  if (binding.getKind() !== SyntaxKind.ObjectBindingPattern) {
-    project.removeSourceFile(sf)
-    return sourceText
-  }
+    const pattern = binding.asKindOrThrow(SyntaxKind.ObjectBindingPattern)
+    const elements = pattern.getElements()
+    const target = elements.find((el) => el.getName() === op.parameterName)
+    if (!target) return sourceText
 
-  const pattern = binding.asKindOrThrow(SyntaxKind.ObjectBindingPattern)
-  const elements = pattern.getElements()
-  const target = elements.find((el) => el.getName() === op.parameterName)
-  if (!target) {
-    project.removeSourceFile(sf)
-    return sourceText
-  }
-
-  // BindingElement has no `.remove()`; rebuild the binding pattern text from the
-  // remaining elements (each element's text preserves its default value, and a
-  // rest element like `...props` is kept verbatim).
-  const kept = elements.filter((el) => el !== target).map((el) => el.getText())
-  pattern.replaceWithText(`{ ${kept.join(', ')} }`)
-
-  const result = sf.getFullText()
-  project.removeSourceFile(sf)
-  return result
+    // BindingElement has no `.remove()`; rebuild the binding pattern text from the
+    // remaining elements (each element's text preserves its default value, and a
+    // rest element like `...props` is kept verbatim).
+    const kept = elements
+      .filter((el) => el !== target)
+      .map((el) => el.getText())
+    pattern.replaceWithText(`{ ${kept.join(', ')} }`)
+    return undefined // proceed with sf.getFullText()
+  })
 }
 
 /**
@@ -511,35 +488,32 @@ function applyRemoveDestructuredBinding(
   sourceText: string,
   op: RemoveDestructuredBindingOp
 ): string {
-  const sf = project.createSourceFile('__tmp__.tsx', sourceText)
+  return withSourceFile(project, sourceText, (sf) => {
+    for (const stmt of sf.getDescendantsOfKind(SyntaxKind.VariableStatement)) {
+      for (const decl of stmt.getDeclarations()) {
+        const nameNode = decl.getNameNode()
+        if (nameNode.getKind() !== SyntaxKind.ObjectBindingPattern) continue
 
-  for (const stmt of sf.getDescendantsOfKind(SyntaxKind.VariableStatement)) {
-    for (const decl of stmt.getDeclarations()) {
-      const nameNode = decl.getNameNode()
-      if (nameNode.getKind() !== SyntaxKind.ObjectBindingPattern) continue
+        const pattern = nameNode.asKindOrThrow(SyntaxKind.ObjectBindingPattern)
+        const elements = pattern.getElements()
+        const target = elements.find((el) => el.getName() === op.bindingName)
+        if (!target) continue
 
-      const pattern = nameNode.asKindOrThrow(SyntaxKind.ObjectBindingPattern)
-      const elements = pattern.getElements()
-      const target = elements.find((el) => el.getName() === op.bindingName)
-      if (!target) continue
+        // Narrow by initializer text to avoid modifying unrelated destructurings.
+        const initText = decl.getInitializer()?.getText() ?? ''
+        if (!initText.includes(op.initializerContains)) continue
 
-      // Narrow by initializer text to avoid modifying unrelated destructurings.
-      const initText = decl.getInitializer()?.getText() ?? ''
-      if (!initText.includes(op.initializerContains)) continue
+        const kept = elements
+          .filter((el) => el !== target)
+          .map((el) => el.getText())
+        pattern.replaceWithText(`{ ${kept.join(', ')} }`)
 
-      const kept = elements
-        .filter((el) => el !== target)
-        .map((el) => el.getText())
-      pattern.replaceWithText(`{ ${kept.join(', ')} }`)
-
-      const result = sf.getFullText()
-      project.removeSourceFile(sf)
-      return result
+        return undefined // proceed with sf.getFullText()
+      }
     }
-  }
 
-  project.removeSourceFile(sf)
-  return sourceText
+    return sourceText // no match — return original unchanged
+  })
 }
 
 function applyReplaceJsDoc(
@@ -547,33 +521,22 @@ function applyReplaceJsDoc(
   sourceText: string,
   op: ReplaceJsDocOp
 ): string {
-  const sf = project.createSourceFile('__tmp__.tsx', sourceText)
+  return withSourceFile(project, sourceText, (sf) => {
+    const fn = sf.getFunction(op.functionName)
+    if (!fn) return sourceText
 
-  const fn = sf.getFunction(op.functionName)
-  if (!fn) {
-    project.removeSourceFile(sf)
-    return sourceText
-  }
+    const docs = fn.getJsDocs()
+    if (docs.length === 0) return sourceText
 
-  const docs = fn.getJsDocs()
-  if (docs.length === 0) {
-    project.removeSourceFile(sf)
-    return sourceText
-  }
+    // Replace the first (and typically only) JSDoc block.
+    // We pass the full /** … */ text directly to replaceWithText; ts-morph
+    // treats JSDoc nodes as replaceable text ranges.
+    const firstDoc = docs[0]
+    if (!firstDoc) return sourceText
 
-  // Replace the first (and typically only) JSDoc block.
-  // We pass the full /** … */ text directly to replaceWithText; ts-morph
-  // treats JSDoc nodes as replaceable text ranges.
-  const firstDoc = docs[0]
-  if (!firstDoc) {
-    project.removeSourceFile(sf)
-    return sourceText
-  }
-
-  firstDoc.replaceWithText(op.replacement)
-  const result = sf.getFullText()
-  project.removeSourceFile(sf)
-  return result
+    firstDoc.replaceWithText(op.replacement)
+    return undefined // proceed with sf.getFullText()
+  })
 }
 
 /**
@@ -727,45 +690,43 @@ function applyAddImport(
   const defaultImport = opDecl.getDefaultImport()?.getText()
   project.removeSourceFile(opSf)
 
-  const sf = project.createSourceFile('__tmp__.tsx', sourceText)
-  const existing = sf
-    .getImportDeclarations()
-    .find((d) => d.getModuleSpecifierValue() === specifier)
+  return withSourceFile(project, sourceText, (sf) => {
+    const existing = sf
+      .getImportDeclarations()
+      .find((d) => d.getModuleSpecifierValue() === specifier)
 
-  if (existing) {
-    let changed = false
+    if (existing) {
+      let changed = false
 
-    // A namespace import (`import * as X`) cannot carry named/default
-    // bindings; the module is already imported, so treat as present.
-    if (!existing.getNamespaceImport()) {
-      if (defaultImport && !existing.getDefaultImport()) {
-        existing.setDefaultImport(defaultImport)
-        changed = true
-      }
+      // A namespace import (`import * as X`) cannot carry named/default
+      // bindings; the module is already imported, so treat as present.
+      if (!existing.getNamespaceImport()) {
+        if (defaultImport && !existing.getDefaultImport()) {
+          existing.setDefaultImport(defaultImport)
+          changed = true
+        }
 
-      // Merge missing named imports, compared by imported name so aliased
-      // re-imports of the same binding don't duplicate.
-      const existingNames = new Set(
-        existing.getNamedImports().map((n) => n.getName())
-      )
-      const missing = namedImports.filter((n) => !existingNames.has(n.name))
-      if (missing.length > 0) {
-        existing.addNamedImports(
-          missing.map((n) => (n.alias ? `${n.name} as ${n.alias}` : n.name))
+        // Merge missing named imports, compared by imported name so aliased
+        // re-imports of the same binding don't duplicate.
+        const existingNames = new Set(
+          existing.getNamedImports().map((n) => n.getName())
         )
-        changed = true
+        const missing = namedImports.filter((n) => !existingNames.has(n.name))
+        if (missing.length > 0) {
+          existing.addNamedImports(
+            missing.map((n) => (n.alias ? `${n.name} as ${n.alias}` : n.name))
+          )
+          changed = true
+        }
       }
+
+      if (!changed) return sourceText
+      return undefined // proceed with sf.getFullText()
     }
 
-    const result = changed ? sf.getFullText() : sourceText
-    project.removeSourceFile(sf)
-    return result
-  }
-
-  sf.insertStatements(insertIndexAfterImports(sf), op.text)
-  const result = sf.getFullText()
-  project.removeSourceFile(sf)
-  return result
+    sf.insertStatements(insertIndexAfterImports(sf), op.text)
+    return undefined // proceed with sf.getFullText()
+  })
 }
 
 /**
@@ -866,25 +827,19 @@ function applyAddVariableStatement(
   sourceText: string,
   op: AddVariableStatementOp
 ): string {
-  const sf = project.createSourceFile('__tmp__.tsx', sourceText)
+  return withSourceFile(project, sourceText, (sf) => {
+    const exists = sf
+      .getDescendantsOfKind(SyntaxKind.VariableDeclaration)
+      .some((d) => d.getName() === op.name)
+    if (exists) return sourceText
 
-  const exists = sf
-    .getDescendantsOfKind(SyntaxKind.VariableDeclaration)
-    .some((d) => d.getName() === op.name)
-  if (exists) {
-    project.removeSourceFile(sf)
-    return sourceText
-  }
-
-  if (op.afterImports === false) {
-    sf.addStatements(op.text)
-  } else {
-    sf.insertStatements(insertIndexAfterImports(sf), op.text)
-  }
-
-  const result = sf.getFullText()
-  project.removeSourceFile(sf)
-  return result
+    if (op.afterImports === false) {
+      sf.addStatements(op.text)
+    } else {
+      sf.insertStatements(insertIndexAfterImports(sf), op.text)
+    }
+    return undefined // proceed with sf.getFullText()
+  })
 }
 
 /** JSX child kinds considered when matching an existing child's indentation. */
@@ -937,105 +892,96 @@ function applyAddJsxChild(
   sourceText: string,
   op: AddJsxChildOp
 ): string {
-  const sf = project.createSourceFile('__tmp__.tsx', sourceText)
-
-  const childMatches = (
-    tagName: string,
-    getAttribute: (name: string) => JsxAttributeLike | undefined
-  ): boolean => {
-    if (tagName !== op.childTagName) return false
-    if (!op.childAttribute) return true
-    return (
-      jsxAttrStringValue(getAttribute(op.childAttribute.name)) ===
-      op.childAttribute.value
-    )
-  }
-
-  const childExists =
-    sf
-      .getDescendantsOfKind(SyntaxKind.JsxSelfClosingElement)
-      .some((el) =>
-        childMatches(el.getTagNameNode().getText(), (name) =>
-          el.getAttribute(name)
-        )
-      ) ||
-    sf
-      .getDescendantsOfKind(SyntaxKind.JsxElement)
-      .some((el) =>
-        childMatches(
-          el.getOpeningElement().getTagNameNode().getText(),
-          (name) => el.getOpeningElement().getAttribute(name)
-        )
+  return withSourceFile(project, sourceText, (sf) => {
+    const childMatches = (
+      tagName: string,
+      getAttribute: (name: string) => JsxAttributeLike | undefined
+    ): boolean => {
+      if (tagName !== op.childTagName) return false
+      if (!op.childAttribute) return true
+      return (
+        jsxAttrStringValue(getAttribute(op.childAttribute.name)) ===
+        op.childAttribute.value
       )
-  if (childExists) {
-    project.removeSourceFile(sf)
-    return sourceText
-  }
+    }
 
-  // True when `el` has a direct JSX child whose tag matches the op's child.
-  const hasSameTagChild = (el: JsxElement | JsxFragment): boolean =>
-    el.getJsxChildren().some((child) => {
-      if (child.getKind() === SyntaxKind.JsxSelfClosingElement) {
-        return (
-          child
-            .asKindOrThrow(SyntaxKind.JsxSelfClosingElement)
-            .getTagNameNode()
-            .getText() === op.childTagName
+    const childExists =
+      sf
+        .getDescendantsOfKind(SyntaxKind.JsxSelfClosingElement)
+        .some((el) =>
+          childMatches(el.getTagNameNode().getText(), (name) =>
+            el.getAttribute(name)
+          )
+        ) ||
+      sf
+        .getDescendantsOfKind(SyntaxKind.JsxElement)
+        .some((el) =>
+          childMatches(
+            el.getOpeningElement().getTagNameNode().getText(),
+            (name) => el.getOpeningElement().getAttribute(name)
+          )
         )
-      }
-      if (child.getKind() === SyntaxKind.JsxElement) {
-        return (
-          child
-            .asKindOrThrow(SyntaxKind.JsxElement)
-            .getOpeningElement()
-            .getTagNameNode()
-            .getText() === op.childTagName
-        )
-      }
-      return false
-    })
+    if (childExists) return sourceText
 
-  const candidates = sf
-    .getDescendantsOfKind(SyntaxKind.JsxElement)
-    .filter(
-      (el) =>
-        el.getOpeningElement().getTagNameNode().getText() === op.parentTagName
-    )
+    // True when `el` has a direct JSX child whose tag matches the op's child.
+    const hasSameTagChild = (el: JsxElement | JsxFragment): boolean =>
+      el.getJsxChildren().some((child) => {
+        if (child.getKind() === SyntaxKind.JsxSelfClosingElement) {
+          return (
+            child
+              .asKindOrThrow(SyntaxKind.JsxSelfClosingElement)
+              .getTagNameNode()
+              .getText() === op.childTagName
+          )
+        }
+        if (child.getKind() === SyntaxKind.JsxElement) {
+          return (
+            child
+              .asKindOrThrow(SyntaxKind.JsxElement)
+              .getOpeningElement()
+              .getTagNameNode()
+              .getText() === op.childTagName
+          )
+        }
+        return false
+      })
 
-  let parent: JsxElement | JsxFragment | undefined =
-    candidates.find(hasSameTagChild) ?? candidates[0]
+    const candidates = sf
+      .getDescendantsOfKind(SyntaxKind.JsxElement)
+      .filter(
+        (el) =>
+          el.getOpeningElement().getTagNameNode().getText() === op.parentTagName
+      )
 
-  if (!parent && op.parentTagName === 'Fragment') {
-    const fragments = sf.getDescendantsOfKind(SyntaxKind.JsxFragment)
-    parent = fragments.find(hasSameTagChild) ?? fragments[0]
-  }
+    let parent: JsxElement | JsxFragment | undefined =
+      candidates.find(hasSameTagChild) ?? candidates[0]
 
-  if (!parent) {
-    project.removeSourceFile(sf)
-    return sourceText
-  }
+    if (!parent && op.parentTagName === 'Fragment') {
+      const fragments = sf.getDescendantsOfKind(SyntaxKind.JsxFragment)
+      parent = fragments.find(hasSameTagChild) ?? fragments[0]
+    }
 
-  const closing =
-    parent.getKind() === SyntaxKind.JsxFragment
-      ? parent.asKindOrThrow(SyntaxKind.JsxFragment).getClosingFragment()
-      : parent.asKindOrThrow(SyntaxKind.JsxElement).getClosingElement()
-  const closingStart = closing.getStart()
-  const lineStart = sourceText.lastIndexOf('\n', closingStart - 1) + 1
-  const closingLinePrefix = sourceText.slice(lineStart, closingStart)
+    if (!parent) return sourceText
 
-  if (/^[ \t]*$/.test(closingLinePrefix)) {
-    // Closing tag on its own line — give the child its own indented line.
-    const childIndent =
-      lastJsxChildIndent(parent, sourceText) ?? `${closingLinePrefix}  `
-    sf.insertText(lineStart, `${childIndent}${op.childText}\n`)
-  } else {
-    // Single-line parent (e.g. `<main>{children}</main>`) — insert inline.
-    sf.insertText(closingStart, op.childText)
-  }
+    const closing =
+      parent.getKind() === SyntaxKind.JsxFragment
+        ? parent.asKindOrThrow(SyntaxKind.JsxFragment).getClosingFragment()
+        : parent.asKindOrThrow(SyntaxKind.JsxElement).getClosingElement()
+    const closingStart = closing.getStart()
+    const lineStart = sourceText.lastIndexOf('\n', closingStart - 1) + 1
+    const closingLinePrefix = sourceText.slice(lineStart, closingStart)
 
-  const result = sf.getFullText()
-  project.removeSourceFile(sf)
-  return result
+    if (/^[ \t]*$/.test(closingLinePrefix)) {
+      // Closing tag on its own line — give the child its own indented line.
+      const childIndent =
+        lastJsxChildIndent(parent, sourceText) ?? `${closingLinePrefix}  `
+      sf.insertText(lineStart, `${childIndent}${op.childText}\n`)
+    } else {
+      // Single-line parent (e.g. `<main>{children}</main>`) — insert inline.
+      sf.insertText(closingStart, op.childText)
+    }
+    return undefined // proceed with sf.getFullText()
+  })
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/utils/raf.ts
+++ b/lib/utils/raf.ts
@@ -1,47 +1,13 @@
 /**
  * RAF Queue - Request Animation Frame Batching
  *
- * Batches DOM reads and writes to prevent layout thrashing.
+ * Batches DOM writes to prevent layout thrashing.
  * Uses Tempus for frame synchronization.
- *
- * ## The Problem: Layout Thrashing
- *
- * When you interleave DOM reads and writes, the browser must recalculate
- * layout multiple times per frame:
- *
- * ```ts
- * // ❌ BAD: Causes layout thrashing
- * element1.style.width = '100px'  // Write → triggers layout
- * const height = element2.offsetHeight  // Read → forces layout recalc
- * element3.style.height = height + 'px' // Write → triggers layout again
- * ```
- *
- * ## The Solution: Batch Operations
- *
- * ```ts
- * // ✅ GOOD: Batch reads, then batch writes
- * import { measure, mutate } from '@/utils/raf'
- *
- * // All reads happen first
- * const height = await measure(() => element.offsetHeight)
- *
- * // Then all writes
- * await mutate(() => {
- *   element.style.height = height + 'px'
- * })
- * ```
  *
  * @example
  * ```ts
- * import { measure, mutate } from '@/utils/raf'
+ * import { mutate } from '@/utils/raf'
  *
- * // Read multiple values
- * const [width, height] = await Promise.all([
- *   measure(() => element.offsetWidth),
- *   measure(() => element.offsetHeight),
- * ])
- *
- * // Write multiple values
  * await mutate(() => {
  *   element.style.transform = `translate(${width}px, ${height}px)`
  * })
@@ -50,47 +16,17 @@
 
 import Tempus from 'tempus'
 
-// Internal queues
-const readQueue: Array<() => unknown> = []
+// Internal write queue
 const writeQueue: Array<() => unknown> = []
 
-// Process queues each frame via Tempus
+// Process queue each frame via Tempus
 Tempus.add(
   () => {
-    // Process all reads first (measurements)
-    for (const fn of readQueue) fn()
-    readQueue.length = 0
-
-    // Then process all writes (mutations)
     for (const fn of writeQueue) fn()
     writeQueue.length = 0
   },
   { priority: 1000 }
 )
-
-/**
- * Queue a DOM measurement (read operation).
- *
- * Use this for any operation that reads layout properties:
- * - `offsetWidth`, `offsetHeight`
- * - `getBoundingClientRect()`
- * - `getComputedStyle()`
- * - `scrollTop`, `scrollLeft`
- *
- * @param fn - Function that performs the read
- * @returns Promise resolving to the read value
- *
- * @example
- * ```ts
- * const rect = await measure(() => element.getBoundingClientRect())
- * const scroll = await measure(() => window.scrollY)
- * ```
- */
-export function measure<T>(fn: () => T): Promise<T> {
-  return new Promise((resolve) => {
-    readQueue.push(() => resolve(fn()))
-  })
-}
 
 /**
  * Queue a DOM mutation (write operation).
@@ -116,34 +52,4 @@ export function mutate<T>(fn: () => T): Promise<T> {
   return new Promise((resolve) => {
     writeQueue.push(() => resolve(fn()))
   })
-}
-
-/**
- * Batch multiple reads and writes efficiently.
- *
- * @param reads - Functions that read from DOM
- * @param writes - Functions that write to DOM (receives read results)
- *
- * @example
- * ```ts
- * await batch(
- *   // Reads
- *   [
- *     () => el1.offsetWidth,
- *     () => el2.offsetHeight,
- *   ],
- *   // Writes (receives read results)
- *   ([width, height]) => {
- *     el3.style.width = width + 'px'
- *     el3.style.height = height + 'px'
- *   }
- * )
- * ```
- */
-export async function batch<T extends unknown[]>(
-  reads: { [K in keyof T]: () => T[K] },
-  write: (results: T) => void
-): Promise<void> {
-  const results = (await Promise.all(reads.map((fn) => measure(fn)))) as T
-  await mutate(() => write(results))
 }

--- a/lib/webgl/utils/flowmaps/flowmap-sim.ts
+++ b/lib/webgl/utils/flowmaps/flowmap-sim.ts
@@ -8,7 +8,6 @@ import {
   type BufferGeometry,
   GLSL3,
   HalfFloatType,
-  type IUniform,
   Mesh,
   NoBlending,
   OrthographicCamera,
@@ -17,14 +16,12 @@ import {
   Vector2,
   type WebGLRenderer,
 } from 'three'
-import { getDoubleRenderTarget, getFullscreenTriangle } from '@/lib/webgl/utils'
-
-type DoubleRenderTarget = ReturnType<typeof getDoubleRenderTarget>
-
-/** A RawShaderMaterial whose uniform keys are known (so accesses aren't `| undefined`). */
-type ShaderMaterial<K extends string> = RawShaderMaterial & {
-  uniforms: Record<K, IUniform>
-}
+import {
+  type DoubleRenderTarget,
+  getDoubleRenderTarget,
+  getFullscreenTriangle,
+  type ShaderMaterial,
+} from '@/lib/webgl/utils'
 
 export interface FlowmapOptions {
   size?: number

--- a/lib/webgl/utils/fluid/fluid-sim.ts
+++ b/lib/webgl/utils/fluid/fluid-sim.ts
@@ -10,7 +10,6 @@ import {
   Color,
   GLSL3,
   HalfFloatType,
-  type IUniform,
   Mesh,
   NearestFilter,
   NoBlending,
@@ -23,16 +22,14 @@ import {
   type WebGLRenderer,
   WebGLRenderTarget,
 } from 'three'
-import { getDoubleRenderTarget, getFullscreenTriangle } from '@/lib/webgl/utils'
-
-type DoubleRenderTarget = ReturnType<typeof getDoubleRenderTarget>
+import {
+  type DoubleRenderTarget,
+  getDoubleRenderTarget,
+  getFullscreenTriangle,
+  type ShaderMaterial,
+} from '@/lib/webgl/utils'
 
 type Splat = { x: number; y: number; dx: number; dy: number }
-
-/** A RawShaderMaterial whose uniform keys are known (so accesses aren't `| undefined`). */
-type ShaderMaterial<K extends string> = RawShaderMaterial & {
-  uniforms: Record<K, IUniform>
-}
 
 export interface FluidOptions {
   simRes?: number

--- a/lib/webgl/utils/index.tsx
+++ b/lib/webgl/utils/index.tsx
@@ -6,6 +6,8 @@
 import {
   BufferGeometry,
   Float32BufferAttribute,
+  type IUniform,
+  type RawShaderMaterial,
   type RenderTargetOptions,
   WebGLRenderTarget,
 } from 'three'
@@ -45,4 +47,11 @@ export function getFullscreenTriangle() {
   geometry.setAttribute('uv', new Float32BufferAttribute([0, 2, 0, 0, 2, 0], 2))
 
   return geometry
+}
+
+export type DoubleRenderTarget = ReturnType<typeof getDoubleRenderTarget>
+
+/** A RawShaderMaterial whose uniform keys are known (so accesses aren't `| undefined`). */
+export type ShaderMaterial<K extends string> = RawShaderMaterial & {
+  uniforms: Record<K, IUniform>
 }


### PR DESCRIPTION
## What this does

A maintainability pass from a whole-codebase audit. The one behavior-affecting change: Turnstile bot-verification now **fails closed** — if Cloudflare returns an unexpected response shape, the request is treated as *not verified* instead of trusting an unchecked cast. Everything else is internal cleanup that leaves runtime behavior identical: less duplicated rate-limiting in the cart, a smaller codemod engine, and removal of dead/duplicate exports.

No public API of the starter kit changes — the `Select`/`Menu`/`Tabs` compound components and all integration entry points are untouched.

## Summary

- **fix(turnstile):** validate the siteverify response with a Zod schema; on an unexpected shape, return a failed verification (fail-closed) rather than reading an `as`-cast `success`.
- **refactor(shopify):** extract `runCartAction` so `removeItem`/`addItem`/`updateItemQuantity` share one IP + standard rate-limit prelude instead of inlining it three times.
- **refactor(scripts):** route the ts-morph `createSourceFile`/`getFullText`/`removeSourceFile` lifecycle in `ast-transforms` through one `withSourceFile` helper with guaranteed cleanup (~60 fewer lines, behavior-preserving).
- **chore:** remove unused `batch`/`measure` from `lib/utils/raf.ts`, hoist the duplicated `ShaderMaterial<K>`/`DoubleRenderTarget` webgl types into `lib/webgl/utils`, and drop the flat `Select*`/`Menu*`/`Tabs*` part exports that had zero importers.
- **docs:** record the above under `CHANGELOG.md` `[Unreleased]`.

### Deliberately out of scope
The audit's largest finding — restructuring the snapshot/strip→re-add setup architecture — was **not** touched: the wrapper Canvas mount and webgl→theatre AST stripping are intentional (team-knowledge `webgl-gpu-resource-effect-ownership`), and the self-pruning machinery is a cross-repo contract with create-darkroom. That's a design decision for a separate discussion, not a cleanup.

## Test Plan
- [x] `bun run check` green (biome + tsgo + `bun test`: 330 pass / 0 fail)
- [x] ast-transforms codemod tests unchanged; setup/satus e2e (self-prune typecheck) pass
- [ ] Confirm Turnstile happy-path still verifies in a deployed preview