### PR TITLE
fix(ui,shopify): runtime correctness bugs (validator lookup, accordion context, login rate-limit)

### DIFF
--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -83,7 +83,7 @@ Quick-reference for every component, hook, and utility in the Satus starter kit.
 
 | Export | Signature |
 |--------|-----------|
-| runFormAction | `({ rateLimitPrefix, schema, formData, rateLimitMessage = 'rate_limit_exceeded_', run, }: RunFormActionOptions<T>) => Promise<FormState>` |
+| runFormAction | `({ rateLimitPrefix, schema, formData, rateLimitMessage = 'rate_limit_exceeded_', rateLimiter = rateLimiters.standard, run, }: RunFormActionOptions<T>) => Promise<FormState>` |
 
 ### Math (`@/utils/math`)
 

--- a/components/ui/accordion/index.tsx
+++ b/components/ui/accordion/index.tsx
@@ -61,7 +61,8 @@ const AccordionsGroupContext = createContext<{
   inGroup: boolean
 }>({
   currentId: undefined,
-  setCurrentId: () => {},
+  // no-op outside a Group; real setter is provided by Group below
+  setCurrentId: () => undefined,
   inGroup: false,
 })
 const AccordionContext = createContext({} as { isOpen: boolean; id: string })

--- a/components/ui/accordion/index.tsx
+++ b/components/ui/accordion/index.tsx
@@ -55,12 +55,15 @@ import s from './accordion.module.css'
  * ```
  */
 
-const AccordionsGroupContext = createContext(
-  {} as {
-    currentId: string | undefined
-    setCurrentId: Dispatch<SetStateAction<string | undefined>>
-  }
-)
+const AccordionsGroupContext = createContext<{
+  currentId: string | undefined
+  setCurrentId: Dispatch<SetStateAction<string | undefined>>
+  inGroup: boolean
+}>({
+  currentId: undefined,
+  setCurrentId: () => {},
+  inGroup: false,
+})
 const AccordionContext = createContext({} as { isOpen: boolean; id: string })
 
 function useAccordionsGroupContext() {
@@ -79,7 +82,9 @@ function Group({ children }: PropsWithChildren) {
   const [currentId, setCurrentId] = useState<string | undefined>()
 
   return (
-    <AccordionsGroupContext.Provider value={{ currentId, setCurrentId }}>
+    <AccordionsGroupContext.Provider
+      value={{ currentId, setCurrentId, inGroup: true }}
+    >
       {children}
     </AccordionsGroupContext.Provider>
   )
@@ -113,10 +118,10 @@ type RootProps = {
  */
 function Root({ children, className, ref, defaultOpen = false }: RootProps) {
   const id = useId()
-  const { currentId, setCurrentId } = useAccordionsGroupContext()
+  const { currentId, setCurrentId, inGroup } = useAccordionsGroupContext()
 
   // If in a group, use group state; otherwise use local state
-  const hasGroup = setCurrentId !== undefined
+  const hasGroup = inGroup
   const [localOpen, setLocalOpen] = useState(defaultOpen)
 
   const isOpen = hasGroup ? currentId === id : localOpen

--- a/components/ui/form/hook.test.ts
+++ b/components/ui/form/hook.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for form hook validator resolution (issue #230).
+ *
+ * Verifies that validators are looked up by element.name first,
+ * then element.id, then element.type — so a field where name !== id
+ * still applies a name-keyed validator correctly.
+ *
+ * Run with: bun test components/ui/form/hook.test.ts
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { resolveValidator } from './hook'
+
+const noop = () => true
+
+describe('resolveValidator — name takes priority over id and type', () => {
+  test('resolves by name when name matches a registered validator', () => {
+    const validatorMap = { email: noop }
+    // name="email", id="contact-email", type="text"
+    const resolved = resolveValidator(validatorMap, {
+      name: 'email',
+      id: 'contact-email',
+      type: 'text',
+    })
+    expect(resolved).toBe(noop)
+  })
+
+  test('name-keyed validator fires even when id differs from name', () => {
+    const emailValidator = (v: string) => v.includes('@')
+    const validatorMap = { email: emailValidator }
+
+    const resolved = resolveValidator(validatorMap, {
+      name: 'email',
+      id: 'contact-email', // different from name
+      type: 'text',
+    })
+
+    expect(resolved).toBeDefined()
+    expect(resolved?.('user@example.com')).toBe(true)
+    expect(resolved?.('notanemail')).toBe(false)
+  })
+
+  test('falls back to id when name has no matching validator', () => {
+    const validatorMap = { 'contact-email': noop }
+    const resolved = resolveValidator(validatorMap, {
+      name: 'email', // no match
+      id: 'contact-email', // match
+      type: 'text',
+    })
+    expect(resolved).toBe(noop)
+  })
+
+  test('falls back to type when neither name nor id matches', () => {
+    const validatorMap = { email: noop }
+    const resolved = resolveValidator(validatorMap, {
+      name: 'username', // no match
+      id: 'user-id', // no match
+      type: 'email', // match
+    })
+    expect(resolved).toBe(noop)
+  })
+
+  test('returns undefined when no validator matches at any level', () => {
+    const validatorMap = { email: noop }
+    const resolved = resolveValidator(validatorMap, {
+      name: 'username',
+      id: 'user-input',
+      type: 'text',
+    })
+    expect(resolved).toBeUndefined()
+  })
+
+  test('name wins over id even when both are registered', () => {
+    const nameValidator = () => true
+    const idValidator = () => false
+    const validatorMap = {
+      email: nameValidator,
+      'contact-email': idValidator,
+    }
+    const resolved = resolveValidator(validatorMap, {
+      name: 'email',
+      id: 'contact-email',
+      type: 'text',
+    })
+    // name-keyed validator (alwaysTrue) must win over id-keyed (alwaysFalse)
+    expect(resolved).toBe(nameValidator)
+    expect(resolved?.('anything')).toBe(true)
+  })
+
+  test('empty name string does not accidentally match empty-string key', () => {
+    // element.name is '' for unnamed elements — should not match a real key
+    const validatorMap = { email: noop }
+    const resolved = resolveValidator(validatorMap, {
+      name: '',
+      id: '',
+      type: 'text',
+    })
+    expect(resolved).toBeUndefined()
+  })
+})

--- a/components/ui/form/hook.test.ts
+++ b/components/ui/form/hook.test.ts
@@ -87,14 +87,17 @@ describe('resolveValidator — name takes priority over id and type', () => {
     expect(resolved?.('anything')).toBe(true)
   })
 
-  test('empty name string does not accidentally match empty-string key', () => {
-    // element.name is '' for unnamed elements — should not match a real key
-    const validatorMap = { email: noop }
+  test('empty name string does not accidentally match an empty-string key', () => {
+    // element.name is '' for unnamed elements. Even if the map happens to hold
+    // an '' key, an unnamed element must skip the name lookup entirely.
+    const emptyKeyValidator = () => true
+    const validatorMap = { '': emptyKeyValidator, text: noop }
     const resolved = resolveValidator(validatorMap, {
       name: '',
       id: '',
       type: 'text',
     })
-    expect(resolved).toBeUndefined()
+    // must fall through to the type validator, not match the '' key
+    expect(resolved).toBe(noop)
   })
 })

--- a/components/ui/form/hook.ts
+++ b/components/ui/form/hook.ts
@@ -90,7 +90,11 @@ export function useForm<T = unknown>({
 
     const elementType =
       element instanceof HTMLInputElement ? element.type : 'textarea'
-    const validator = validators[element.id] || validators[elementType]
+    const validator = resolveValidator(validators, {
+      name: element.name,
+      id: element.id,
+      type: elementType,
+    })
 
     const isRequired = element.required
     let isValidValue: boolean
@@ -167,4 +171,21 @@ const validators: Record<string, (value: string) => boolean> = {
 // Allow extending validators
 export function addValidator(id: string, fn: (value: string) => boolean) {
   validators[id] = fn
+}
+
+/**
+ * Pure helper: resolves the best matching validator for a given element.
+ * Exported for testing and custom form integrations.
+ *
+ * Priority: name → id → elementType
+ */
+export function resolveValidator(
+  validatorMap: Record<string, (value: string) => boolean>,
+  element: { name: string; id: string; type: string }
+): ((value: string) => boolean) | undefined {
+  return (
+    validatorMap[element.name] ||
+    validatorMap[element.id] ||
+    validatorMap[element.type]
+  )
 }

--- a/components/ui/form/hook.ts
+++ b/components/ui/form/hook.ts
@@ -183,9 +183,7 @@ export function resolveValidator(
   validatorMap: Record<string, (value: string) => boolean>,
   element: { name: string; id: string; type: string }
 ): ((value: string) => boolean) | undefined {
-  return (
-    validatorMap[element.name] ||
-    validatorMap[element.id] ||
-    validatorMap[element.type]
-  )
+  const byName = element.name ? validatorMap[element.name] : undefined
+  const byId = element.id ? validatorMap[element.id] : undefined
+  return byName || byId || validatorMap[element.type]
 }

--- a/components/ui/form/hook.ts
+++ b/components/ui/form/hook.ts
@@ -185,5 +185,5 @@ export function resolveValidator(
 ): ((value: string) => boolean) | undefined {
   const byName = element.name ? validatorMap[element.name] : undefined
   const byId = element.id ? validatorMap[element.id] : undefined
-  return byName || byId || validatorMap[element.type]
+  return byName ?? byId ?? validatorMap[element.type]
 }

--- a/lib/integrations/shopify/README.md
+++ b/lib/integrations/shopify/README.md
@@ -54,7 +54,7 @@ const product = await getProduct('product-handle')
 
 All Shopify server actions validate input with Zod schemas:
 - **Cart actions** (`addItem`, `updateItemQuantity`, `removeItem`): validate variant IDs, quantity bounds (1-99), rate limiting. `updateItemQuantity` and `removeItem` take the client-held `lineId` (the cart line's id) to patch that line directly. All three return `CartActionResult` — `{ ok: true }` on success, `{ ok: false; error: string }` on failure.
-- **Customer actions** (`LoginCustomerAction`, `CreateCustomerAction`): validate email format, password length, rate limiting via `runFormAction`. `LoginCustomerAction` additionally pre-checks a strict rate limit (5 req/min) before the form-action helper runs.
+- **Customer actions** (`LoginCustomerAction`, `CreateCustomerAction`): validate email format, password length, rate limiting via `runFormAction`. `LoginCustomerAction` passes the strict limiter (5 req/min) to `runFormAction` to throttle brute-force attempts.
 - **Error handling**: Cart actions use `CartActionResult`; customer actions return `FormState` objects; there is no `Error` instance wrapping
 
 Env vars are validated via `shopifyEnvSchema` in the integration registry.

--- a/lib/integrations/shopify/customer/actions.ts
+++ b/lib/integrations/shopify/customer/actions.ts
@@ -1,14 +1,10 @@
 'use server'
 
-import { cookies, headers } from 'next/headers'
+import { cookies } from 'next/headers'
 import { z } from 'zod'
 import type { FormState } from '@/components/ui/form/types'
 import { runFormAction } from '@/lib/utils/form-action'
-import {
-  getIPFromHeaders,
-  rateLimit,
-  rateLimiters,
-} from '@/lib/utils/rate-limit'
+import { rateLimiters } from '@/lib/utils/rate-limit'
 import { emailSchema } from '@/utils/validation'
 import { shopifyFetch } from '../index'
 import {
@@ -37,23 +33,12 @@ export async function LoginCustomerAction(
   _prevState: FormState | null,
   formData: FormData
 ): Promise<FormState> {
-  // Login uses strict rate limiting (5 req/min) to prevent brute-force attacks.
-  // runFormAction applies standard limiting, so we pre-check strict here.
-  const headersList = await headers()
-  const ip = getIPFromHeaders(headersList)
-  const rateLimitResult = rateLimit(`login:${ip}`, rateLimiters.strict)
-
-  if (!rateLimitResult.success) {
-    return {
-      status: 429,
-      message: `Too many login attempts. Please try again in ${rateLimitResult.resetIn} seconds.`,
-    }
-  }
-
   return runFormAction({
     rateLimitPrefix: 'login-form',
     schema: loginSchema,
     formData,
+    rateLimiter: rateLimiters.strict,
+    rateLimitMessage: 'Too many login attempts. Please try again later.',
     run: async ({ email, password }) => {
       try {
         const res = await shopifyFetch<{

--- a/lib/utils/form-action.ts
+++ b/lib/utils/form-action.ts
@@ -3,6 +3,7 @@ import type { z } from 'zod'
 import type { FormState } from '@/components/ui/form/types'
 import {
   getIPFromHeaders,
+  type RateLimitConfig,
   rateLimit,
   rateLimiters,
 } from '@/lib/utils/rate-limit'
@@ -20,6 +21,11 @@ interface RunFormActionOptions<T> {
    * Defaults to `'rate_limit_exceeded_'`.
    */
   rateLimitMessage?: string
+  /**
+   * Rate limiter config. Defaults to the standard limiter (20 req/min).
+   * Pass `rateLimiters.strict` for sensitive endpoints like login.
+   */
+  rateLimiter?: RateLimitConfig
   /** Business logic to run after validation succeeds. */
   run: (input: T) => Promise<FormState>
 }
@@ -27,7 +33,7 @@ interface RunFormActionOptions<T> {
 /**
  * Shared server-action helper that handles:
  * 1. IP extraction from `x-forwarded-for`
- * 2. Rate limiting (standard limiter, 20 req/min)
+ * 2. Rate limiting (configurable; defaults to standard limiter, 20 req/min)
  * 3. Zod schema validation via `parseFormData`
  * 4. Delegation to the provided `run` callback
  *
@@ -40,15 +46,13 @@ export async function runFormAction<T>({
   schema,
   formData,
   rateLimitMessage = 'rate_limit_exceeded_',
+  rateLimiter = rateLimiters.standard,
   run,
 }: RunFormActionOptions<T>): Promise<FormState> {
   const headersList = await headers()
   const ip = getIPFromHeaders(headersList)
 
-  const rateLimitResult = rateLimit(
-    `${rateLimitPrefix}:${ip}`,
-    rateLimiters.standard
-  )
+  const rateLimitResult = rateLimit(`${rateLimitPrefix}:${ip}`, rateLimiter)
 
   if (!rateLimitResult.success) {
     return {


### PR DESCRIPTION
## What this does

Fixes three latent bugs the 2026-06-22 audit found in runtime code — none throw today, but each is a trap waiting for the wrong input.

- **Forms** (#230): a custom validator added for a field by its `name` silently never ran when the field's `id` differed from its `name`. Validators now resolve by `name` first (then `id`, then input type), so `addValidator('email', …)` actually fires on `<input name="email" id="contact-email">`.
- **Accordion** (#231): the group context default was a cast `{}` — a type lie where `setCurrentId` was actually `undefined` at runtime. Any call outside a `<Group>` would have thrown `undefined is not a function`. Replaced with a real default + an explicit `inGroup` flag.
- **Shopify login** (#232): every login ran *two* rate limiters in series (strict 5/min, then a redundant standard 20/min). Login now passes the strict limiter through the shared `runFormAction` helper and limits exactly once.

## Summary

- `components/ui/form/hook.ts` — extract `resolveValidator(map, {name,id,type})` (name→id→type), use it in `validate()`; unit tests in `hook.test.ts` lock the `name !== id` case.
- `components/ui/accordion/index.tsx` — context default `{ currentId: undefined, setCurrentId: () => undefined, inGroup: false }`; `Group` sets `inGroup: true`; `Root` guards on `inGroup` instead of `setCurrentId !== undefined`.
- `lib/utils/form-action.ts` — `runFormAction` gains optional `rateLimiter` (defaults to `rateLimiters.standard`).
- `lib/integrations/shopify/customer/actions.ts` — drop the manual strict pre-check, pass `rateLimiter: rateLimiters.strict`; README line corrected.

## Test Plan
- [x] `bun run build && bun run check` green (337 tests pass)
- [x] `bun run manifest:check` up to date
- [x] Codex cross-check on the diff before merge

Closes #230, #231, #232.


---

## Codex cross-review

Ran `codex exec` (codex-cli 0.141.0) directly on the real branch diff (`git diff origin/main...HEAD`).

**Verdict: no correctness, behavior, or security regressions.** All three fixes matched intent — validator priority `name → id → type`, accordion `inGroup` guard preserves standalone vs grouped behavior, login rate-limited once via the strict limiter through the shared helper.

**One finding, resolved:** the empty-name test asserted more than the code guaranteed (an `''` map key could match an unnamed field). Hardened `resolveValidator` to skip empty `name`/`id` lookups so unnamed fields fall through to the type validator; strengthened the test to exercise an explicit `''` key.

_(Note: the first-pass `codex-verifier` agent returned a hallucinated transcript reviewing code not in this repo; it was discarded and Codex re-run directly on the real diff.)_
