### PR TITLE
fix(scripts): guarantee AST source-file cleanup + atomic package.json writes

### DIFF
--- a/lib/scripts/ast-transforms.ts
+++ b/lib/scripts/ast-transforms.ts
@@ -543,31 +543,31 @@ function applyReplaceJsDoc(
  * Resolve a dot-separated property path from an object-expression node,
  * returning the deepest PropertyAccessExpression value node or undefined.
  *
- * e.g. `resolvePropertyPath(objExpr, 'images.remotePatterns')` returns the
- * node for the `remotePatterns` array initialiser.
+ * Operates on a caller-owned SourceFile — the caller is responsible for the
+ * file's lifetime (open before, remove in `finally` via `withSourceFile`).
+ *
+ * e.g. `resolvePropertyPath(sf, 'nextConfig', 'images.remotePatterns')` returns
+ * the node for the `remotePatterns` array initialiser.
  */
 function resolvePropertyPath(
-  project: Project,
-  sourceText: string,
+  sf: SourceFile,
   variableName: string,
   propertyPath: string
-): { sf: SourceFile; node: Node | undefined } {
-  const sf = project.createSourceFile('__tmp__.ts', sourceText)
-
+): Node | undefined {
   const varDecl = sf
     .getVariableDeclarations()
     .find((v) => v.getName() === variableName)
-  if (!varDecl) return { sf, node: undefined }
+  if (!varDecl) return undefined
 
   const init = varDecl.getInitializer()
   if (!init || init.getKind() !== SyntaxKind.ObjectLiteralExpression)
-    return { sf, node: undefined }
+    return undefined
 
   const parts = propertyPath.split('.')
   let current: Node = init
   for (const part of parts) {
     if (current.getKind() !== SyntaxKind.ObjectLiteralExpression) {
-      return { sf, node: undefined }
+      return undefined
     }
     const obj = current.asKindOrThrow(SyntaxKind.ObjectLiteralExpression)
     const prop = obj
@@ -577,12 +577,12 @@ function resolvePropertyPath(
           p.getKind() === SyntaxKind.PropertyAssignment &&
           p.asKindOrThrow(SyntaxKind.PropertyAssignment).getName() === part
       )
-    if (!prop) return { sf, node: undefined }
+    if (!prop) return undefined
     const pa = prop.asKindOrThrow(SyntaxKind.PropertyAssignment)
     current = pa.getInitializer() ?? pa
   }
 
-  return { sf, node: current }
+  return current
 }
 
 function applyRemoveArrayObjectElement(
@@ -590,32 +590,25 @@ function applyRemoveArrayObjectElement(
   sourceText: string,
   op: RemoveArrayObjectElementOp
 ): string {
-  const { sf, node } = resolvePropertyPath(
-    project,
-    sourceText,
-    op.variableName,
-    op.propertyPath
-  )
+  return withSourceFile(project, sourceText, (sf) => {
+    const node = resolvePropertyPath(sf, op.variableName, op.propertyPath)
 
-  if (!node || node.getKind() !== SyntaxKind.ArrayLiteralExpression) {
-    project.removeSourceFile(sf)
-    return sourceText
-  }
+    if (!node || node.getKind() !== SyntaxKind.ArrayLiteralExpression) {
+      return sourceText
+    }
 
-  const arr = node.asKindOrThrow(SyntaxKind.ArrayLiteralExpression)
-  const elements = arr.getElements()
+    const arr = node.asKindOrThrow(SyntaxKind.ArrayLiteralExpression)
+    const elements = arr.getElements()
 
-  for (const el of elements) {
-    if (!objectElementMatches(el, op.matchProperty)) continue
+    for (const el of elements) {
+      if (!objectElementMatches(el, op.matchProperty)) continue
 
-    // Found the matching element — remove it from the array
-    arr.removeElement(el)
-    break
-  }
-
-  const result = sf.getFullText()
-  project.removeSourceFile(sf)
-  return result
+      // Found the matching element — remove it from the array
+      arr.removeElement(el)
+      break
+    }
+    return undefined // proceed with sf.getFullText()
+  })
 }
 
 function applyRemoveArrayStringElement(
@@ -623,34 +616,28 @@ function applyRemoveArrayStringElement(
   sourceText: string,
   op: RemoveArrayStringElementOp
 ): string {
-  const { sf, node } = resolvePropertyPath(
-    project,
-    sourceText,
-    op.variableName,
-    op.propertyPath
-  )
+  return withSourceFile(project, sourceText, (sf) => {
+    const node = resolvePropertyPath(sf, op.variableName, op.propertyPath)
 
-  if (!node || node.getKind() !== SyntaxKind.ArrayLiteralExpression) {
-    project.removeSourceFile(sf)
-    return sourceText
-  }
-
-  const arr = node.asKindOrThrow(SyntaxKind.ArrayLiteralExpression)
-  const elements = arr.getElements()
-
-  for (const el of elements) {
-    if (el.getKind() !== SyntaxKind.StringLiteral) continue
-    if (
-      el.asKindOrThrow(SyntaxKind.StringLiteral).getLiteralValue() === op.value
-    ) {
-      arr.removeElement(el)
-      break
+    if (!node || node.getKind() !== SyntaxKind.ArrayLiteralExpression) {
+      return sourceText
     }
-  }
 
-  const result = sf.getFullText()
-  project.removeSourceFile(sf)
-  return result
+    const arr = node.asKindOrThrow(SyntaxKind.ArrayLiteralExpression)
+    const elements = arr.getElements()
+
+    for (const el of elements) {
+      if (el.getKind() !== SyntaxKind.StringLiteral) continue
+      if (
+        el.asKindOrThrow(SyntaxKind.StringLiteral).getLiteralValue() ===
+        op.value
+      ) {
+        arr.removeElement(el)
+        break
+      }
+    }
+    return undefined // proceed with sf.getFullText()
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -739,41 +726,33 @@ function applyAddArrayStringElement(
   sourceText: string,
   op: AddArrayStringElementOp
 ): string {
-  const { sf, node } = resolvePropertyPath(
-    project,
-    sourceText,
-    op.variableName,
-    op.propertyPath
-  )
+  return withSourceFile(project, sourceText, (sf) => {
+    const node = resolvePropertyPath(sf, op.variableName, op.propertyPath)
 
-  if (!node || node.getKind() !== SyntaxKind.ArrayLiteralExpression) {
-    project.removeSourceFile(sf)
-    return sourceText
-  }
+    if (!node || node.getKind() !== SyntaxKind.ArrayLiteralExpression) {
+      return sourceText
+    }
 
-  const arr = node.asKindOrThrow(SyntaxKind.ArrayLiteralExpression)
-  const alreadyPresent = arr
-    .getElements()
-    .some(
-      (el) =>
-        el.getKind() === SyntaxKind.StringLiteral &&
-        el.asKindOrThrow(SyntaxKind.StringLiteral).getLiteralValue() ===
-          op.value
-    )
-  if (alreadyPresent) {
-    project.removeSourceFile(sf)
-    return sourceText
-  }
+    const arr = node.asKindOrThrow(SyntaxKind.ArrayLiteralExpression)
+    const alreadyPresent = arr
+      .getElements()
+      .some(
+        (el) =>
+          el.getKind() === SyntaxKind.StringLiteral &&
+          el.asKindOrThrow(SyntaxKind.StringLiteral).getLiteralValue() ===
+            op.value
+      )
+    if (alreadyPresent) {
+      return sourceText
+    }
 
-  // Escape backslashes before quotes so the emitted literal round-trips.
-  const escaped = op.value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
-  arr.addElement(`'${escaped}'`, {
-    useNewLines: arr.getText().includes('\n'),
+    // Escape backslashes before quotes so the emitted literal round-trips.
+    const escaped = op.value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+    arr.addElement(`'${escaped}'`, {
+      useNewLines: arr.getText().includes('\n'),
+    })
+    return undefined // proceed with sf.getFullText()
   })
-
-  const result = sf.getFullText()
-  project.removeSourceFile(sf)
-  return result
 }
 
 /**
@@ -787,34 +766,26 @@ function applyAddArrayObjectElement(
   sourceText: string,
   op: AddArrayObjectElementOp
 ): string {
-  const { sf, node } = resolvePropertyPath(
-    project,
-    sourceText,
-    op.variableName,
-    op.propertyPath
-  )
+  return withSourceFile(project, sourceText, (sf) => {
+    const node = resolvePropertyPath(sf, op.variableName, op.propertyPath)
 
-  if (!node || node.getKind() !== SyntaxKind.ArrayLiteralExpression) {
-    project.removeSourceFile(sf)
-    return sourceText
-  }
+    if (!node || node.getKind() !== SyntaxKind.ArrayLiteralExpression) {
+      return sourceText
+    }
 
-  const arr = node.asKindOrThrow(SyntaxKind.ArrayLiteralExpression)
-  const alreadyPresent = arr
-    .getElements()
-    .some((el) => objectElementMatches(el, op.matchProperty))
-  if (alreadyPresent) {
-    project.removeSourceFile(sf)
-    return sourceText
-  }
+    const arr = node.asKindOrThrow(SyntaxKind.ArrayLiteralExpression)
+    const alreadyPresent = arr
+      .getElements()
+      .some((el) => objectElementMatches(el, op.matchProperty))
+    if (alreadyPresent) {
+      return sourceText
+    }
 
-  arr.addElement(op.objectText, {
-    useNewLines: arr.getText().includes('\n'),
+    arr.addElement(op.objectText, {
+      useNewLines: arr.getText().includes('\n'),
+    })
+    return undefined // proceed with sf.getFullText()
   })
-
-  const result = sf.getFullText()
-  project.removeSourceFile(sf)
-  return result
 }
 
 /**

--- a/lib/scripts/setup-project.ts
+++ b/lib/scripts/setup-project.ts
@@ -149,17 +149,26 @@ const replaceManualLandingPage = async (dryRun: boolean): Promise<void> => {
   }
 }
 
+// Parsed package.json shape used by the in-memory mutation helpers below.
+type PackageJson = {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  scripts?: Record<string, string>
+  satus?: Record<string, unknown>
+  [key: string]: unknown
+}
+
 /**
- * Remove dependency entries from package.json
+ * Remove dependency entries from the in-memory package.json object.
+ * Returns the lists of removed dep/devDep names (for logging).
+ * Does NOT read or write the file — caller owns I/O.
  */
-const removeDepsFromPackageJson = async (
+const removeDepsFromPackageJson = (
+  pkg: PackageJson,
   depsToRemove: string[],
   devDepsToRemove: string[],
   dryRun: boolean
-): Promise<{ deps: string[]; devDeps: string[] }> => {
-  const pkgPath = resolvePath('package.json')
-  const pkg = await Bun.file(pkgPath).json()
-
+): { deps: string[]; devDeps: string[] } => {
   const removedDeps: string[] = []
   const removedDevDeps: string[] = []
 
@@ -179,10 +188,6 @@ const removeDepsFromPackageJson = async (
       }
       removedDevDeps.push(dep)
     }
-  }
-
-  if ((removedDeps.length > 0 || removedDevDeps.length > 0) && !dryRun) {
-    await Bun.write(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`)
   }
 
   return { deps: removedDeps, devDeps: removedDevDeps }
@@ -369,8 +374,15 @@ const setupSnapshot = async (
  * Apply the UNION of ALL bundles' removals unconditionally — stripping every
  * integration to leave a lean core.  This is a re-scoping of the prior
  * "remove unkept" logic to "remove all".
+ *
+ * Accepts a pre-parsed in-memory `pkg` object and calls `removeDepsFromPackageJson`
+ * to mutate it directly — no file I/O for the package.json dep removal step.
+ * Returns removal counts for logging.
  */
-const setupLean = async (dryRun: boolean): Promise<void> => {
+const setupLean = async (
+  pkg: PackageJson,
+  dryRun: boolean
+): Promise<{ deps: number; devDeps: number }> => {
   const integrationNames = getIntegrationNames()
   const s = p.spinner()
 
@@ -440,15 +452,20 @@ const setupLean = async (dryRun: boolean): Promise<void> => {
     allBarrelExports.push(...bundle.barrelExports)
   }
 
-  // Update package.json
+  // Mutate the in-memory package.json object (no file write here)
+  let totalDeps = 0
+  let totalDevDeps = 0
   if (allDeps.length > 0 || allDevDeps.length > 0) {
     s.start('Updating package.json (removing deps)...')
-    const { deps, devDeps } = await removeDepsFromPackageJson(
+    const { deps, devDeps } = removeDepsFromPackageJson(
+      pkg,
       allDeps,
       allDevDeps,
       dryRun
     )
-    const total = deps.length + devDeps.length
+    totalDeps = deps.length
+    totalDevDeps = devDeps.length
+    const total = totalDeps + totalDevDeps
     s.stop(
       total > 0
         ? `Removed ${total} dependencies from package.json`
@@ -477,6 +494,8 @@ const setupLean = async (dryRun: boolean): Promise<void> => {
         : 'No export updates needed'
     )
   }
+
+  return { deps: totalDeps, devDeps: totalDevDeps }
 }
 
 /**
@@ -594,16 +613,10 @@ const setupAddIntegrations = async (
 }
 
 /**
- * Self-prune: delete this script's own setup machinery from the scaffolded
- * project as its last act.  Deletes:
- *   - lib/scripts/setup-project.ts (this file, last, wrapped in try/catch)
- *   - lib/scripts/setup-project.test.ts
- *   - lib/scripts/satus.test.ts
- *   - lib/scripts/satus.e2e.test.ts
- *   - lib/scripts/ast-transforms.test.ts
- *   - lib/scripts/payload-source.test.ts
- *
- * Also removes `setup:project` and `test:setup` from package.json scripts.
+ * Mutate the in-memory package.json object to remove the `setup:project` and
+ * `test:setup` script entries, and delete the setup script files from disk.
+ * Returns the list of deleted files and removed script keys (for logging).
+ * Does NOT write package.json — caller owns the single write.
  *
  * KEPT (used by tests that ship with every project):
  *   - lib/scripts/test-setup.ts (bunfig.toml preloads it for ALL bun tests)
@@ -612,7 +625,10 @@ const setupAddIntegrations = async (
  *   - lib/scripts/satus.ts and all its deps
  *   - lib/scripts/ast-transforms.ts, integration-bundles.ts, etc.
  */
-const selfPrune = async (dryRun: boolean): Promise<void> => {
+const selfPrune = async (
+  pkg: PackageJson,
+  dryRun: boolean
+): Promise<{ deleted: string[]; scriptsRemoved: string[] }> => {
   const s = p.spinner()
   s.start('Self-pruning setup machinery...')
 
@@ -635,12 +651,7 @@ const selfPrune = async (dryRun: boolean): Promise<void> => {
     }
   }
 
-  // Remove setup:project and test:setup from package.json scripts
-  const pkgPath = resolvePath('package.json')
-  const pkg = (await Bun.file(pkgPath).json()) as {
-    scripts?: Record<string, string>
-    [key: string]: unknown
-  }
+  // Mutate the in-memory package.json scripts (no file write here)
   const scriptsRemoved: string[] = []
   const scripts = pkg.scripts
   if (scripts) {
@@ -652,9 +663,6 @@ const selfPrune = async (dryRun: boolean): Promise<void> => {
           delete scripts[key]
         }
       }
-    }
-    if (scriptsRemoved.length > 0 && !dryRun) {
-      await Bun.write(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`)
     }
   }
 
@@ -682,34 +690,29 @@ const selfPrune = async (dryRun: boolean): Promise<void> => {
   } else {
     p.log.message('  Would delete lib/scripts/setup-project.ts')
   }
+
+  return { deleted, scriptsRemoved }
 }
 
 /**
- * Record the current git HEAD sha into package.json as the pinned satus ref
- * (`"satus": { "ref": … }`), used by `satus add` to fetch matching payloads.
- * Skips silently when git is unavailable — the ref is optional metadata.
+ * Read the current git HEAD sha. Returns the sha string, or undefined when
+ * git is unavailable or not a repo. The sha is later written into package.json
+ * as `"satus": { "ref": … }` by the consolidated package.json write in setup().
  */
-const recordPinnedRef = async (): Promise<void> => {
+const readGitHead = async (): Promise<string | undefined> => {
   try {
     const proc = Bun.spawn(['git', 'rev-parse', 'HEAD'], {
       stdout: 'pipe',
       stderr: 'ignore',
     })
     const exitCode = await proc.exited
-    if (exitCode !== 0) return
+    if (exitCode !== 0) return undefined
 
     const sha = (await new Response(proc.stdout).text()).trim()
-    if (!sha) return
-
-    const pkgPath = resolvePath('package.json')
-    const pkg = (await Bun.file(pkgPath).json()) as {
-      satus?: Record<string, unknown>
-      [key: string]: unknown
-    }
-    pkg.satus = { ...(pkg.satus ?? {}), ref: sha }
-    await Bun.write(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`)
+    return sha || undefined
   } catch {
     // git not installed / not a repo — the pinned ref is optional metadata
+    return undefined
   }
 }
 
@@ -717,14 +720,19 @@ const recordPinnedRef = async (): Promise<void> => {
  * Main setup orchestration (additive model):
  *
  *   1. ensureNextTypeStub
- *   2. recordPinnedRef (read git HEAD before any writes)
+ *   2. Read git HEAD sha (before any writes — metadata only)
  *   3. cleanMarketing (if flagged)
  *   4. snapshot(kept) — capture kept integration files before stripping
- *   5. setupLean — strip ALL integrations unconditionally
- *   6. setupAddIntegrations — re-add the kept set from the snapshot
- *   7. snapshot.cleanup()
- *   8. selfPrune — delete setup machinery
- *   9. bun install (unless --skip-install)
+ *   5. Read package.json ONCE into memory
+ *   6. setupLean — strip ALL integrations (mutates in-memory pkg)
+ *   7. selfPrune — delete setup files; mutate pkg scripts in-memory
+ *   8. Apply pinned git ref to in-memory pkg
+ *   9. Write package.json ONCE (atomic for steps 6–8; before bun install
+ *      so the installer sees the final dep list and lockfile stays consistent)
+ *  10. setupAddIntegrations — re-add the kept set from the snapshot
+ *  11. snapshot.cleanup()
+ *  12. bun install (unless --skip-install); runs after the write so it reads
+ *      the already-finalized package.json and only updates the lockfile
  */
 const setup = async (options: SetupOptions): Promise<void> => {
   const { dryRun, keepIntegrations, cleanMarketing, skipInstall } = options
@@ -733,10 +741,8 @@ const setup = async (options: SetupOptions): Promise<void> => {
   //    immediately after setup without needing to run `bun dev` first.
   await ensureNextTypeStub(dryRun)
 
-  // 2. Record the pinned ref BEFORE any writes (reads git HEAD; metadata only).
-  if (!dryRun) {
-    await recordPinnedRef()
-  }
+  // 2. Read git HEAD before any writes (pure read, no side-effects).
+  const gitSha = dryRun ? undefined : await readGitHead()
 
   // 3. Replace the manual landing page (independent of integration removal).
   if (cleanMarketing) {
@@ -755,23 +761,44 @@ const setup = async (options: SetupOptions): Promise<void> => {
     ss.stop(`Snapshot ready (${snapshot.label})`)
   }
 
-  // 5. Strip ALL integrations unconditionally to lean core.
-  await setupLean(dryRun)
+  // 5. Read package.json ONCE into memory. All three mutators (removeDeps,
+  //    selfPrune, recordPinnedRef) operate on this object; a single write
+  //    follows at step 9. This avoids partial-mutation on mid-sequence failure
+  //    and eliminates 3+ separate read-parse-write round-trips.
+  const pkgPath = resolvePath('package.json')
+  const pkg = (await Bun.file(pkgPath).json()) as PackageJson
 
-  // 6. Re-add the kept integrations from the snapshot.
+  // 6. Strip ALL integrations unconditionally to lean core.
+  //    Mutates `pkg` for dep removal; other file changes (folders, env) happen here.
+  await setupLean(pkg, dryRun)
+
+  // 7. Self-prune: delete setup files, mutate pkg.scripts in-memory.
+  await selfPrune(pkg, dryRun)
+
+  // 8. Record the pinned satus ref in-memory (git sha read at step 2).
+  if (gitSha) {
+    pkg.satus = { ...(pkg.satus ?? {}), ref: gitSha }
+  }
+
+  // 9. Write package.json ONCE with all three mutations applied.
+  //    Must happen BEFORE bun install so the installer sees the final dep list
+  //    and updates the lockfile accordingly. bun install does not rewrite
+  //    package.json itself, so this write is not clobbered by the install step.
+  if (!dryRun) {
+    await Bun.write(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`)
+  }
+
+  // 10. Re-add the kept integrations from the snapshot.
   if (snapshot) {
     await setupAddIntegrations(keepIntegrations, snapshot, dryRun)
   }
 
-  // 7. Cleanup snapshot temp directory.
+  // 11. Cleanup snapshot temp directory.
   if (snapshot) {
     await snapshot.cleanup()
   }
 
-  // 8. Self-prune: delete setup machinery from the scaffolded project.
-  await selfPrune(dryRun)
-
-  // 9. Run bun install to update lockfile.
+  // 12. Run bun install to update lockfile.
   if (!(dryRun || skipInstall)) {
     const s = p.spinner()
     s.start('Updating lockfile...')


### PR DESCRIPTION
## What this does

Two correctness fixes in the scaffolding tooling (`lib/scripts/`) — the maintainer-facing code that self-prunes when a project is generated from this starter. Neither is user-visible; both close failure modes that only bite under errors.

- **AST transforms** (#234): the four array-element handlers leaned on `resolvePropertyPath` opening its own ts-morph source file and then trusted each handler to remove it by hand — six duplicated cleanup pairs. Any throw between open and cleanup leaked the in-memory file. `resolvePropertyPath` now takes a caller-owned `SourceFile`, and the handlers run inside `withSourceFile`, which removes the file in `finally` no matter how the body exits.
- **setup-project** (#235): `package.json` was opened/parsed/written independently by three phases plus the install step, so a mid-run failure could leave it half-mutated across 3+ write round-trips. It's now read once, mutated in memory by every phase, and written once — before `bun install`, so the installer sees the final dep list and the write isn't clobbered.

## Summary

- `lib/scripts/ast-transforms.ts` — `resolvePropertyPath(sf, …)` (was `(project, sourceText, …)`); 4 handlers wrapped in `withSourceFile`; 6 manual `removeSourceFile` calls deleted (only the one in `withSourceFile`'s `finally` remains).
- `lib/scripts/setup-project.ts` — `removeDepsFromPackageJson`/`selfPrune` mutate a passed `pkg` object; pinned-ref split into pure `readGitHead()` + inline mutation; single read (step 5) / single write (step 9, pre-install) in `setup()`, with an ordering comment.

## Test Plan
- [x] `bun run test:setup` (35 pass) — self-prune contract intact
- [x] `bun run build && bun run check` green (337 tests)
- [x] `bun run manifest:check` up to date

---

## Codex cross-review

Ran `codex exec` (codex-cli 0.141.0) on the real branch diff.

**Verdict: no correctness, behavior, resource, or security regressions.** Confirmed the `withSourceFile` callback contract is honored on every path (no-op → `sourceText` verbatim, mutation → `undefined` → `getFullText()`), the six removed `removeSourceFile` calls are all covered by the new wrapping (no leak), and the single package.json write lands before `bun install` so installer-added deps aren't clobbered while `selfPrune` still strips the setup scripts.

Closes #234, #235.
