### PR TITLE
perf(webgl): FlowmapProvider mounts only the requested sims

### DIFF
--- a/lib/webgl/components/flowmap-provider/index.tsx
+++ b/lib/webgl/components/flowmap-provider/index.tsx
@@ -30,9 +30,10 @@ type FlowmapContextType = {
   flowmap: Flowmap | null
 }
 
-export const FlowmapContext = createContext<FlowmapContextType>(
-  {} as FlowmapContextType
-)
+export const FlowmapContext = createContext<FlowmapContextType>({
+  fluid: null,
+  flowmap: null,
+})
 
 /**
  * Retrieves the active GPU simulation instance from context.
@@ -66,33 +67,75 @@ export function useFlowmap(type: 'fluid' | 'flowmap' = 'flowmap') {
   return flowmap
 }
 
+function FluidSimInner({ children }: { children: React.ReactNode }) {
+  const fluid = useFluidSim()
+  const parent = use(FlowmapContext)
+  return (
+    <FlowmapContext.Provider value={{ ...parent, fluid }}>
+      {children}
+    </FlowmapContext.Provider>
+  )
+}
+
+function FlowmapSimInner({ children }: { children: React.ReactNode }) {
+  const flowmap = useFlowmapSim()
+  const parent = use(FlowmapContext)
+  return (
+    <FlowmapContext.Provider value={{ ...parent, flowmap }}>
+      {children}
+    </FlowmapContext.Provider>
+  )
+}
+
 /**
- * Initializes and provides both the fluid and flowmap GPU simulations
- * via React context.
+ * Initializes and provides GPU simulations via React context.
  *
  * **Must be placed inside the R3F `<Canvas>` tree** because the underlying
  * hooks (`useFluidSim`, `useFlowmapSim`) depend on the Three.js WebGL
  * renderer and the R3F frame loop.
  *
  * @param props.children - R3F elements that need access to the simulations.
+ * @param props.simTypes - Which simulations to mount. Defaults to both
+ *   `['fluid', 'flowmap']` for back-compat. Pass a subset to skip the
+ *   other sim's GPU pass and window listeners entirely — e.g.
+ *   `simTypes={['flowmap']}` never runs `useFluidSim`.
  * @returns A context provider wrapping the children.
  *
  * @example
  * ```tsx
+ * // Both sims (default — back-compat)
  * <Canvas>
  *   <FlowmapProvider>
  *     <DistortedPlane />
  *   </FlowmapProvider>
  * </Canvas>
+ *
+ * // Flowmap only — skips the fluid GPU pass
+ * <Canvas>
+ *   <FlowmapProvider simTypes={['flowmap']}>
+ *     <DistortedPlane />
+ *   </FlowmapProvider>
+ * </Canvas>
  * ```
  */
-export function FlowmapProvider({ children }: { children: React.ReactNode }) {
-  const fluid = useFluidSim()
-  const flowmap = useFlowmapSim()
-
+export function FlowmapProvider({
+  children,
+  simTypes = ['fluid', 'flowmap'],
+}: {
+  children: React.ReactNode
+  /** Which simulations to mount. Default: both, for back-compat. */
+  simTypes?: ('fluid' | 'flowmap')[]
+}) {
+  let tree = children
+  if (simTypes.includes('flowmap')) {
+    tree = <FlowmapSimInner>{tree}</FlowmapSimInner>
+  }
+  if (simTypes.includes('fluid')) {
+    tree = <FluidSimInner>{tree}</FluidSimInner>
+  }
   return (
-    <FlowmapContext.Provider value={{ fluid, flowmap }}>
-      {children}
+    <FlowmapContext.Provider value={{ fluid: null, flowmap: null }}>
+      {tree}
     </FlowmapContext.Provider>
   )
 }


### PR DESCRIPTION
## What this does

`FlowmapProvider` always spun up **both** GPU simulations — the Navier-Stokes fluid sim and the velocity-field flowmap sim — on every mount, even on a page that only reads one of them via `useFlowmap(...)`. That's two GPU passes and two sets of window pointer listeners running for no reason.

It now takes an optional `simTypes` prop. Pass `simTypes={['flowmap']}` and the fluid sim is never instantiated — its GPU work and listeners simply don't exist. Default stays both, so existing usage is unchanged.

## Summary

- `lib/webgl/components/flowmap-provider/index.tsx`:
  - `FlowmapProvider` gains `simTypes?: ('fluid' | 'flowmap')[]` (default `['fluid', 'flowmap']`).
  - Two private inner components `FluidSimInner` / `FlowmapSimInner`, each calling exactly one sim hook and spreading the parent context to override only its slice. Conditional **mounting** (not conditional hook calls) keeps the rules of hooks intact.
  - Resource ownership stays tied to mount/unmount — an unmounted inner never creates its sim, so `.destroy()`/listener-teardown semantics are preserved (honors `webgl-gpu-resource-effect-ownership`).
  - Replaces the `{} as FlowmapContextType` cast default with a real `{ fluid: null, flowmap: null }`, so `useFlowmap('fluid')` correctly returns `null` when the fluid sim isn't mounted.

## Test Plan
- [x] `bun run build && bun run check` green (337 tests)
- [x] `bun run manifest:check` up to date
- [x] Hooks rules respected (each sim hook called unconditionally inside its own component)

---

## Codex cross-review

Ran `codex exec` (codex-cli 0.141.0) on the real branch diff. **No findings.** Confirmed: rules of hooks intact (only mounting is conditional); `simTypes={['flowmap']}` never runs `useFluidSim` and `useFlowmap('fluid')` returns `null`; nesting + parent-spread preserves both slices when both mount; resource ownership stays bound to mount/unmount.

Closes #242.
