### PR TITLE
refactor(scripts): split AST-op types + extract bundle-installer (pure reorg)

### DIFF
--- a/lib/scripts/ast-operation-types.ts
+++ b/lib/scripts/ast-operation-types.ts
@@ -1,0 +1,310 @@
+/**
+ * AST-operation type system shared by `ast-transforms.ts` and `integration-bundles.ts`.
+ *
+ * Contains only exported interface/type declarations — zero runtime code.
+ */
+
+/** Remove a top-level import declaration by its module specifier. */
+export interface RemoveImportOp {
+  kind: 'removeImport'
+  /** The module specifier string to match exactly, e.g. '@/webgl/components/canvas' */
+  specifier: string
+}
+
+/** Remove a `const NAME = …` variable statement by name (any scope depth). */
+export interface RemoveVariableStatementOp {
+  kind: 'removeVariableStatement'
+  /** The variable name to remove, e.g. 'LazyWebGLCanvas' */
+  name: string
+}
+
+/**
+ * Remove a bare call-expression statement by its callee name, e.g. the whole
+ * `useTheatre(sheet, 'fluid simulation', { … })` statement. Matches at any
+ * scope depth; removes every occurrence in the file.
+ */
+export interface RemoveCallStatementOp {
+  kind: 'removeCallStatement'
+  /** The called identifier, e.g. 'useTheatre' */
+  callee: string
+}
+
+/**
+ * Remove a single argument (by its source text) from every call to `callee`,
+ * e.g. drop `SheetContext` from `useContextBridge(TransformContext, SheetContext)`
+ * so the remaining `useContextBridge(TransformContext)` stops depending on the
+ * stripped Theatre.js module. No-op when the argument is already absent.
+ */
+export interface RemoveCallArgumentOp {
+  kind: 'removeCallArgument'
+  /** The called identifier, e.g. 'useContextBridge' */
+  callee: string
+  /** The argument's source text to remove, e.g. 'SheetContext' */
+  argument: string
+}
+
+/**
+ * Remove (or unwrap) a JSX element by its tag name.
+ *
+ * - `attribute` — optional {name, value} pair that must match to disambiguate
+ *   elements sharing the same tag (e.g. OrchestraToggle with id="webgl").
+ * - `unwrap` — when true, keep the element's children and remove only the
+ *   opening / closing tags (e.g. strip <Canvas> but keep its content).
+ */
+export interface RemoveJsxElementOp {
+  kind: 'removeJsxElement'
+  /** JSX tag name, e.g. 'LazyWebGLCanvas', 'Canvas', 'OrchestraToggle' */
+  tagName: string
+  /** Optional attribute to match for disambiguation */
+  attribute?: { name: string; value: string }
+  /** When true, keep children and remove only the tags */
+  unwrap?: boolean
+}
+
+/** Remove a property (with its leading JSDoc) from a named interface. */
+export interface RemoveInterfacePropertyOp {
+  kind: 'removeInterfaceProperty'
+  /** Interface name, e.g. 'WrapperProps' */
+  interfaceName: string
+  /** Property name, e.g. 'webgl' */
+  propertyName: string
+}
+
+/**
+ * Remove a named JSX attribute from all JSX elements with a given tag name.
+ * Targets both self-closing and open/close elements.
+ *
+ * @example Remove `webgl` prop from every `<Wrapper webgl …>` usage:
+ * `{ kind: 'removeJsxAttribute', tagName: 'Wrapper', attributeName: 'webgl' }`
+ */
+export interface RemoveJsxAttributeOp {
+  kind: 'removeJsxAttribute'
+  /** Tag name of the element whose attribute to remove, e.g. 'Wrapper' */
+  tagName: string
+  /** Attribute name to remove, e.g. 'webgl' */
+  attributeName: string
+}
+
+/**
+ * Remove a named binding from a destructured variable declaration.
+ *
+ * Targets `const { …, name, … } = expr` statements at any scope depth.
+ * Rebuilt from the remaining elements, preserving defaults and rest elements.
+ *
+ * @example Remove `studio` from `const { stats, grid, studio } = useOrchestra()`
+ * `{ kind: 'removeDestructuredBinding', variableName: 'studio', declarationPattern: 'useOrchestra' }`
+ */
+export interface RemoveDestructuredBindingOp {
+  kind: 'removeDestructuredBinding'
+  /** The binding name to remove, e.g. 'studio' */
+  bindingName: string
+  /**
+   * Substring of the initializer expression text used to narrow the target
+   * declaration (e.g. 'useOrchestra'). Prevents accidentally modifying
+   * unrelated destructurings that happen to bind the same name.
+   */
+  initializerContains: string
+}
+
+/** Remove a named parameter from a function's destructured props argument. */
+export interface RemoveFunctionParameterOp {
+  kind: 'removeFunctionParameter'
+  /** Exported function name, e.g. 'Wrapper' */
+  functionName: string
+  /** Parameter name as it appears in the destructured binding, e.g. 'webgl' */
+  parameterName: string
+}
+
+/**
+ * Replace the entire JSDoc block on a named function with a provided string.
+ * Used when multiple partial-text edits to the JSDoc would be brittle; a full
+ * replacement is simpler and guarantees the result is well-formed.
+ */
+export interface ReplaceJsDocOp {
+  kind: 'replaceJsDoc'
+  /** Name of the function whose JSDoc to replace */
+  functionName: string
+  /** The replacement JSDoc text (must include /** … * /) */
+  replacement: string
+}
+
+/**
+ * Remove an object element from an array property nested inside a named
+ * variable declaration.  Designed for `images.remotePatterns` in next.config.ts.
+ *
+ * Matches an array element that is an object literal containing a property
+ * whose name and string value both match the given `matchProperty`.
+ */
+export interface RemoveArrayObjectElementOp {
+  kind: 'removeArrayObjectElement'
+  /**
+   * Dot-separated path from the variable declaration down to the array
+   * property, e.g. `'images.remotePatterns'`.
+   */
+  propertyPath: string
+  /** The variable name that holds the object, e.g. `'nextConfig'`. */
+  variableName: string
+  /** Property name + value that must be present on the target object element. */
+  matchProperty: { name: string; value: string }
+}
+
+/**
+ * Remove a string-literal element from an array property nested inside a named
+ * variable declaration.  Designed for `experimental.optimizePackageImports`.
+ */
+export interface RemoveArrayStringElementOp {
+  kind: 'removeArrayStringElement'
+  /**
+   * Dot-separated path from the variable declaration down to the array
+   * property, e.g. `'experimental.optimizePackageImports'`.
+   */
+  propertyPath: string
+  /** The variable name that holds the object, e.g. `'nextConfig'`. */
+  variableName: string
+  /** The exact string value to remove from the array. */
+  value: string
+}
+
+// ---------------------------------------------------------------------------
+// Additive operations (inverse of the removals above)
+// Every additive op is IDEMPOTENT: when the construct it would add is already
+// present, the source text is returned byte-for-byte unchanged, so applying
+// the same op twice is a no-op.
+// ---------------------------------------------------------------------------
+
+/**
+ * Add a top-level import declaration, given as full source text.
+ *
+ * If an import with the same module specifier already exists, any missing
+ * named imports are merged into it (no-op when all bindings are present).
+ * Otherwise the declaration is inserted after the last existing import, e.g.
+ * re-adding `import { Canvas } from '@/webgl/components/canvas'`.
+ */
+export interface AddImportOp {
+  kind: 'addImport'
+  /** Full import declaration text, e.g. `import { Canvas } from '@/webgl/components/canvas'` */
+  text: string
+}
+
+/**
+ * Append a string-literal element to an array property nested inside a named
+ * variable declaration.  Inverse of `removeArrayStringElement`; designed for
+ * `experimental.optimizePackageImports` in next.config.ts.
+ *
+ * No-op when an element with the same literal value already exists.
+ */
+export interface AddArrayStringElementOp {
+  kind: 'addArrayStringElement'
+  /** The variable name that holds the object, e.g. `'nextConfig'`. */
+  variableName: string
+  /**
+   * Dot-separated path from the variable declaration down to the array
+   * property, e.g. `'experimental.optimizePackageImports'`.
+   */
+  propertyPath: string
+  /** The string value to append to the array. */
+  value: string
+}
+
+/**
+ * Append an object-literal element to an array property nested inside a named
+ * variable declaration.  Inverse of `removeArrayObjectElement`; designed for
+ * `images.remotePatterns` in next.config.ts.
+ *
+ * No-op when an element already matches `matchProperty` (same matching
+ * semantics as `removeArrayObjectElement`, including quoted-key
+ * normalization).
+ */
+export interface AddArrayObjectElementOp {
+  kind: 'addArrayObjectElement'
+  /** The variable name that holds the object, e.g. `'nextConfig'`. */
+  variableName: string
+  /**
+   * Dot-separated path from the variable declaration down to the array
+   * property, e.g. `'images.remotePatterns'`.
+   */
+  propertyPath: string
+  /** The object literal to append, as source text, e.g. `{ protocol: 'https', hostname: 'cdn.sanity.io' }` */
+  objectText: string
+  /** Property name + value identifying an already-present matching element. */
+  matchProperty: { name: string; value: string }
+}
+
+/**
+ * Insert a full variable statement, e.g. re-adding
+ * `const LazyWebGLCanvas = dynamic(…)` to lib/features/index.tsx.
+ *
+ * No-op when a variable named `name` already exists anywhere in the file
+ * (any scope depth, mirroring `removeVariableStatement`).
+ */
+export interface AddVariableStatementOp {
+  kind: 'addVariableStatement'
+  /** The declared variable name used for the idempotency check, e.g. 'LazyWebGLCanvas' */
+  name: string
+  /** Full statement text to insert, e.g. `const LazyWebGLCanvas = dynamic(() => …)` */
+  text: string
+  /**
+   * When true or omitted, insert after the last import declaration.
+   * When false, append at the end of the file.
+   */
+  afterImports?: boolean
+}
+
+/**
+ * Append a JSX child as the last child of the first element whose opening tag
+ * matches `parentTagName`, e.g. re-adding `<Canvas root />` inside <Wrapper>.
+ *
+ * Parent selection: among same-tag candidates, an element that already
+ * contains a direct child with tag `childTagName` wins, so re-added elements
+ * land next to their siblings (e.g. an OrchestraToggle row). The special
+ * value `parentTagName: 'Fragment'` falls back to the first JSX fragment
+ * (`<>…</>`) when no `<Fragment>` element matches.
+ *
+ * No-op when any JSX element (or self-closing element) with tag
+ * `childTagName` already exists anywhere in the file — narrowed to elements
+ * whose attribute matches when `childAttribute` is provided.
+ */
+export interface AddJsxChildOp {
+  kind: 'addJsxChild'
+  /**
+   * Tag name of the parent element to append into, e.g. 'Wrapper'.
+   * 'Fragment' targets the first JSX fragment when no element matches.
+   */
+  parentTagName: string
+  /** The JSX child to append, as source text, e.g. `<Canvas root />` */
+  childText: string
+  /** Tag name of the child, used for the idempotency check, e.g. 'Canvas' */
+  childTagName: string
+  /**
+   * Optional attribute narrowing the idempotency check: only an existing
+   * `childTagName` element whose attribute matches blocks insertion, so
+   * `<OrchestraToggle id="webgl">` can be re-added next to other toggles.
+   */
+  childAttribute?: { name: string; value: string }
+}
+
+export type AstOperation =
+  | RemoveImportOp
+  | RemoveVariableStatementOp
+  | RemoveCallStatementOp
+  | RemoveCallArgumentOp
+  | RemoveJsxElementOp
+  | RemoveJsxAttributeOp
+  | RemoveDestructuredBindingOp
+  | RemoveInterfacePropertyOp
+  | RemoveFunctionParameterOp
+  | ReplaceJsDocOp
+  | RemoveArrayObjectElementOp
+  | RemoveArrayStringElementOp
+  | AddImportOp
+  | AddArrayStringElementOp
+  | AddArrayObjectElementOp
+  | AddVariableStatementOp
+  | AddJsxChildOp
+
+export interface CodeTransform {
+  /** Path to the file to transform (relative to project root) */
+  file: string
+  /** Typed AST operations to apply */
+  ops: AstOperation[]
+}

--- a/lib/scripts/ast-transforms.test.ts
+++ b/lib/scripts/ast-transforms.test.ts
@@ -14,8 +14,8 @@
  */
 
 import { describe, expect, it } from 'bun:test'
+import type { AstOperation } from './ast-operation-types'
 import { applyOpsToText } from './ast-transforms'
-import type { AstOperation } from './integration-bundles'
 
 /** Number of times `needle` occurs in `haystack`. */
 function count(haystack: string, needle: string): number {

--- a/lib/scripts/ast-transforms.ts
+++ b/lib/scripts/ast-transforms.ts
@@ -39,7 +39,7 @@ import type {
   RemoveJsxElementOp,
   RemoveVariableStatementOp,
   ReplaceJsDocOp,
-} from './integration-bundles'
+} from './ast-operation-types'
 import { resolvePath } from './utils'
 
 // ---------------------------------------------------------------------------

--- a/lib/scripts/bundle-installer.ts
+++ b/lib/scripts/bundle-installer.ts
@@ -1,0 +1,416 @@
+/**
+ * Bundle installation primitives and shared sequences.
+ *
+ * Extracted from `satus.ts` so that both `satus.ts` and `setup-project.ts`
+ * can import from a neutral module rather than `setup-project.ts` depending
+ * on the CLI executable `satus.ts`.
+ */
+
+import { mkdir } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import * as p from '@clack/prompts'
+import { applyCodeTransforms, applyOpsToText } from './ast-transforms'
+import {
+  type CodeTransform,
+  getIntegrationEntries,
+  type IntegrationBundle,
+} from './integration-bundles'
+import {
+  listPayloadFiles,
+  type PayloadPackageJson,
+  type PayloadSource,
+  payloadPathExists,
+  readPayloadFile,
+} from './payload-source'
+import { pathExists, resolvePath } from './utils'
+
+// ---------------------------------------------------------------------------
+// Install steps (moved from satus.ts)
+// ---------------------------------------------------------------------------
+
+/** A bundle counts as installed when its first folder (or file) exists. */
+export function bundleProbePath(bundle: IntegrationBundle): string | undefined {
+  return bundle.folders[0] ?? bundle.files[0]
+}
+
+export const isInstalled = async (
+  bundle: IntegrationBundle
+): Promise<boolean> => {
+  const probe = bundleProbePath(bundle)
+  if (!probe) return false
+  return pathExists(resolvePath(probe))
+}
+
+/**
+ * Copy the bundle's `folders` and `files` from the payload source into the
+ * project. Existing files are kept (unless --force); missing ones are always
+ * copied. Fails loudly when the payload lacks a declared folder or file.
+ */
+export const copyBundleFiles = async (
+  source: PayloadSource,
+  bundle: IntegrationBundle,
+  options: { dryRun: boolean; force: boolean }
+): Promise<{ copied: number; skipped: number }> => {
+  const relFiles: string[] = []
+
+  for (const folder of bundle.folders) {
+    relFiles.push(...(await listPayloadFiles(source, folder)))
+  }
+  for (const file of bundle.files) {
+    if (!(await payloadPathExists(source, file))) {
+      throw new Error(`Payload source (${source.label}) is missing ${file}`)
+    }
+    relFiles.push(file)
+  }
+
+  let copied = 0
+  let skipped = 0
+
+  for (const rel of relFiles) {
+    const dest = resolvePath(rel)
+    if ((await pathExists(dest)) && !options.force) {
+      skipped++
+      continue
+    }
+    if (!options.dryRun) {
+      await mkdir(dirname(dest), { recursive: true })
+      await Bun.write(dest, Bun.file(join(source.root, rel)))
+    }
+    copied++
+  }
+
+  return { copied, skipped }
+}
+
+/**
+ * Copy the bundle's integration-owned `overwriteFiles` wholesale from the
+ * payload source. A local file is only overwritten when it matches either
+ * the payload version (already wired — no-op) or the expected lean state
+ * (the payload version with this bundle's removal codeTransforms applied).
+ * Anything else means local modifications — skip with a warning unless
+ * --force.
+ */
+export const applyOverwriteFiles = async (
+  source: PayloadSource,
+  bundle: IntegrationBundle,
+  options: { dryRun: boolean; force: boolean }
+): Promise<{ written: string[]; skipped: string[] }> => {
+  const written: string[] = []
+  const skipped: string[] = []
+
+  for (const rel of bundle.overwriteFiles ?? []) {
+    const payloadText = await readPayloadFile(source, rel)
+    const dest = resolvePath(rel)
+
+    if (!(await pathExists(dest))) {
+      if (!options.dryRun) {
+        await mkdir(dirname(dest), { recursive: true })
+        await Bun.write(dest, payloadText)
+      }
+      written.push(rel)
+      continue
+    }
+
+    const localText = await Bun.file(dest).text()
+    if (localText === payloadText) continue // already wired
+
+    const removalOps =
+      bundle.codeTransforms.find((t) => t.file === rel)?.ops ?? []
+    const expectedLean = applyOpsToText(payloadText, removalOps)
+
+    if (localText === expectedLean || options.force) {
+      if (!options.dryRun) {
+        await Bun.write(dest, payloadText)
+      }
+      written.push(rel)
+    } else {
+      skipped.push(rel)
+    }
+  }
+
+  return { written, skipped }
+}
+
+const sortRecord = (record: Record<string, string>): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(record).sort(([a], [b]) => a.localeCompare(b))
+  )
+
+/**
+ * Add the bundle's dependencies to the local package.json, pinning each to
+ * the version declared by the payload source's package.json. Dependencies
+ * already present locally keep their existing pin.
+ */
+export const addDependencies = async (
+  bundle: IntegrationBundle,
+  payloadPkg: PayloadPackageJson,
+  options: { dryRun: boolean }
+): Promise<{ added: string[]; missing: string[] }> => {
+  const pkgPath = resolvePath('package.json')
+  const pkg = (await Bun.file(pkgPath).json()) as {
+    dependencies?: Record<string, string>
+    devDependencies?: Record<string, string>
+    [key: string]: unknown
+  }
+
+  const added: string[] = []
+  const missing: string[] = []
+
+  const addFrom = (
+    names: string[],
+    target: 'dependencies' | 'devDependencies'
+  ): void => {
+    for (const name of names) {
+      const version =
+        payloadPkg.dependencies?.[name] ?? payloadPkg.devDependencies?.[name]
+      if (!version) {
+        missing.push(name)
+        continue
+      }
+      const record = pkg[target] ?? {}
+      pkg[target] = record
+      if (record[name]) continue // already present — keep the local pin
+      record[name] = version
+      added.push(`${name}@${version}`)
+    }
+  }
+
+  addFrom(bundle.dependencies, 'dependencies')
+  addFrom(bundle.devDependencies, 'devDependencies')
+
+  if (added.length > 0 && !options.dryRun) {
+    if (pkg.dependencies) pkg.dependencies = sortRecord(pkg.dependencies)
+    if (pkg.devDependencies) {
+      pkg.devDependencies = sortRecord(pkg.devDependencies)
+    }
+    await Bun.write(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`)
+  }
+
+  return { added, missing }
+}
+
+/**
+ * Restore the bundle's barrel export lines: read each pattern's line from the
+ * SOURCE repo's barrel file and insert it into the local barrel when absent
+ * (created when missing). Warns when the payload has no matching barrel/line.
+ */
+export const restoreBarrelExports = async (
+  source: PayloadSource,
+  bundle: IntegrationBundle,
+  options: { dryRun: boolean }
+): Promise<number> => {
+  let changes = 0
+
+  for (const { file, pattern } of bundle.barrelExports) {
+    if (!(await payloadPathExists(source, file))) {
+      p.log.warn(
+        `Payload source has no barrel file ${file} — skipping export restore for "${pattern}"`
+      )
+      continue
+    }
+
+    const sourceText = await readPayloadFile(source, file)
+    const line = findBarrelLine(sourceText, pattern)
+    if (!line) {
+      p.log.warn(
+        `No export line matching "${pattern}" in payload ${file} — skipping`
+      )
+      continue
+    }
+
+    const localPath = resolvePath(file)
+    const localText = (await pathExists(localPath))
+      ? await Bun.file(localPath).text()
+      : ''
+    const updated = insertBarrelLine(localText, line)
+
+    if (updated !== localText) {
+      if (!options.dryRun) {
+        await mkdir(dirname(localPath), { recursive: true })
+        await Bun.write(localPath, updated)
+      }
+      changes++
+    }
+  }
+
+  return changes
+}
+
+/** Append missing env vars as commented stubs to .env.example (created when absent). */
+export const appendEnvStubs = async (
+  envVars: string[],
+  dryRun: boolean
+): Promise<number> => {
+  if (envVars.length === 0) return 0
+
+  const envPath = resolvePath('.env.example')
+  const exists = await pathExists(envPath)
+  const content = exists ? await Bun.file(envPath).text() : ''
+
+  const missing = envVars.filter(
+    (envVar) => !new RegExp(`^#?\\s*${envVar}=`, 'm').test(content)
+  )
+  if (missing.length === 0) return 0
+
+  if (!dryRun) {
+    const base =
+      content.length === 0 || content.endsWith('\n') ? content : `${content}\n`
+    const stubs = missing.map((envVar) => `# ${envVar}=`).join('\n')
+    await Bun.write(envPath, `${base}${stubs}\n`)
+  }
+
+  return missing.length
+}
+
+// ---------------------------------------------------------------------------
+// Barrel export helpers (moved from satus.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the export line in a source barrel matching the removal `pattern`,
+ * using the same matching as setup-project's removal (quoted pattern or
+ * quoted './pattern' specifier).
+ */
+export function findBarrelLine(
+  sourceText: string,
+  pattern: string
+): string | undefined {
+  return sourceText
+    .split('\n')
+    .find(
+      (line) => line.includes(`'${pattern}'`) || line.includes(`'./${pattern}'`)
+    )
+}
+
+/**
+ * Insert a barrel export line when absent (sorted position among existing
+ * `export` lines, best-effort). Returns the text unchanged when an identical
+ * line already exists — idempotent.
+ */
+export function insertBarrelLine(localText: string, line: string): string {
+  const newLine = line.trim()
+  if (newLine.length === 0) return localText
+
+  const lines = localText.split('\n')
+  if (lines.some((existing) => existing.trim() === newLine)) return localText
+
+  const exportIndexes: number[] = []
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i]?.startsWith('export ')) exportIndexes.push(i)
+  }
+
+  if (exportIndexes.length === 0) {
+    const base =
+      localText.length === 0 || localText.endsWith('\n')
+        ? localText
+        : `${localText}\n`
+    return `${base}${newLine}\n`
+  }
+
+  const sortedAfter = exportIndexes.find(
+    (i) => (lines[i] ?? '').localeCompare(newLine) > 0
+  )
+  const lastExport = exportIndexes[exportIndexes.length - 1] ?? 0
+  const insertAt = sortedAfter ?? lastExport + 1
+  lines.splice(insertAt, 0, newLine)
+  return lines.join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Shared install sequence
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the shared per-bundle install sequence: copy files, restore overwrite
+ * files, add dependencies, restore barrel exports, append env stubs, apply
+ * additive code transforms.
+ *
+ * Returns a `details` string array (one entry per action taken) that callers
+ * can use for logging. Does not manage spinners or log directly.
+ */
+export const installBundle = async (
+  source: PayloadSource,
+  bundle: IntegrationBundle,
+  payloadPkg: PayloadPackageJson,
+  options: { dryRun: boolean; force: boolean }
+): Promise<{
+  details: string[]
+  depsAdded: string[]
+  overwriteSkipped: string[]
+  depsMissing: string[]
+}> => {
+  const details: string[] = []
+
+  const { copied, skipped } = await copyBundleFiles(source, bundle, options)
+  if (copied > 0) details.push(`${copied} files copied`)
+  if (skipped > 0) details.push(`${skipped} existing files kept`)
+
+  const overwrite = await applyOverwriteFiles(source, bundle, options)
+  if (overwrite.written.length > 0) {
+    details.push(`${overwrite.written.length} integration-owned files restored`)
+  }
+
+  const deps = await addDependencies(bundle, payloadPkg, options)
+  if (deps.added.length > 0) {
+    details.push(`${deps.added.length} dependencies pinned`)
+  }
+
+  const barrelChanges = await restoreBarrelExports(source, bundle, options)
+  if (barrelChanges > 0) {
+    details.push(`${barrelChanges} barrel exports restored`)
+  }
+
+  const envChanges = await appendEnvStubs(bundle.envVars, options.dryRun)
+  if (envChanges > 0) details.push(`${envChanges} env stubs appended`)
+
+  const transformChanges = await applyCodeTransforms(
+    bundle.addTransforms ?? [],
+    options.dryRun
+  )
+  if (transformChanges > 0) {
+    details.push(`${transformChanges} files re-wired`)
+  }
+
+  return {
+    details,
+    depsAdded: deps.added,
+    overwriteSkipped: overwrite.skipped,
+    depsMissing: deps.missing,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared strip block (de-duplicated from satus.ts and setup-project.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip absent-integration wiring from freshly copied files.
+ *
+ * For every integration NOT in `installedOrAdded` AND not currently installed
+ * on disk, apply its subtractive `codeTransforms`. These ops are no-ops on
+ * files already in the lean state, so calling this after an install is safe.
+ *
+ * @param installedOrAdded - Set (or array) of integration ids that are being
+ *   added / were already added in this run and should NOT be stripped.
+ * @param dryRun - When true, count changes but do not write files.
+ * @returns The number of files that were actually changed.
+ */
+export const stripAbsentIntegrationWiring = async (
+  installedOrAdded: Set<string> | string[],
+  dryRun: boolean
+): Promise<number> => {
+  const skipSet =
+    installedOrAdded instanceof Set
+      ? installedOrAdded
+      : new Set(installedOrAdded)
+
+  const stripTransforms: CodeTransform[] = []
+  for (const [id, bundle] of getIntegrationEntries()) {
+    if (skipSet.has(id)) continue
+    if (await isInstalled(bundle)) continue
+    stripTransforms.push(...bundle.codeTransforms)
+  }
+
+  if (stripTransforms.length === 0) return 0
+  return applyCodeTransforms(stripTransforms, dryRun)
+}

--- a/lib/scripts/integration-bundles.ts
+++ b/lib/scripts/integration-bundles.ts
@@ -10,323 +10,37 @@
  */
 
 import type { RemovableId } from '@/integrations/registry'
+import type { CodeTransform } from './ast-operation-types'
+
+// Re-export the AST-operation type system so existing importers that pull
+// these types from './integration-bundles' continue to compile unchanged.
+export type {
+  AddArrayObjectElementOp,
+  AddArrayStringElementOp,
+  AddImportOp,
+  AddJsxChildOp,
+  AddVariableStatementOp,
+  AstOperation,
+  CodeTransform,
+  RemoveArrayObjectElementOp,
+  RemoveArrayStringElementOp,
+  RemoveCallArgumentOp,
+  RemoveCallStatementOp,
+  RemoveDestructuredBindingOp,
+  RemoveFunctionParameterOp,
+  RemoveImportOp,
+  RemoveInterfacePropertyOp,
+  RemoveJsxAttributeOp,
+  RemoveJsxElementOp,
+  RemoveVariableStatementOp,
+  ReplaceJsDocOp,
+} from './ast-operation-types'
 
 export interface BarrelExport {
   /** Path to the barrel export file (e.g., 'components/ui/index.ts') */
   file: string
   /** Pattern to match export lines to remove (e.g., 'sanity-image') */
   pattern: string
-}
-
-// ---------------------------------------------------------------------------
-// Typed AST operation union
-// Each variant is resilient to whitespace / formatting changes because it
-// targets named constructs (imports, variables, JSX tags) rather than text.
-// ---------------------------------------------------------------------------
-
-/** Remove a top-level import declaration by its module specifier. */
-export interface RemoveImportOp {
-  kind: 'removeImport'
-  /** The module specifier string to match exactly, e.g. '@/webgl/components/canvas' */
-  specifier: string
-}
-
-/** Remove a `const NAME = …` variable statement by name (any scope depth). */
-export interface RemoveVariableStatementOp {
-  kind: 'removeVariableStatement'
-  /** The variable name to remove, e.g. 'LazyWebGLCanvas' */
-  name: string
-}
-
-/**
- * Remove a bare call-expression statement by its callee name, e.g. the whole
- * `useTheatre(sheet, 'fluid simulation', { … })` statement. Matches at any
- * scope depth; removes every occurrence in the file.
- */
-export interface RemoveCallStatementOp {
-  kind: 'removeCallStatement'
-  /** The called identifier, e.g. 'useTheatre' */
-  callee: string
-}
-
-/**
- * Remove a single argument (by its source text) from every call to `callee`,
- * e.g. drop `SheetContext` from `useContextBridge(TransformContext, SheetContext)`
- * so the remaining `useContextBridge(TransformContext)` stops depending on the
- * stripped Theatre.js module. No-op when the argument is already absent.
- */
-export interface RemoveCallArgumentOp {
-  kind: 'removeCallArgument'
-  /** The called identifier, e.g. 'useContextBridge' */
-  callee: string
-  /** The argument's source text to remove, e.g. 'SheetContext' */
-  argument: string
-}
-
-/**
- * Remove (or unwrap) a JSX element by its tag name.
- *
- * - `attribute` — optional {name, value} pair that must match to disambiguate
- *   elements sharing the same tag (e.g. OrchestraToggle with id="webgl").
- * - `unwrap` — when true, keep the element's children and remove only the
- *   opening / closing tags (e.g. strip <Canvas> but keep its content).
- */
-export interface RemoveJsxElementOp {
-  kind: 'removeJsxElement'
-  /** JSX tag name, e.g. 'LazyWebGLCanvas', 'Canvas', 'OrchestraToggle' */
-  tagName: string
-  /** Optional attribute to match for disambiguation */
-  attribute?: { name: string; value: string }
-  /** When true, keep children and remove only the tags */
-  unwrap?: boolean
-}
-
-/** Remove a property (with its leading JSDoc) from a named interface. */
-export interface RemoveInterfacePropertyOp {
-  kind: 'removeInterfaceProperty'
-  /** Interface name, e.g. 'WrapperProps' */
-  interfaceName: string
-  /** Property name, e.g. 'webgl' */
-  propertyName: string
-}
-
-/**
- * Remove a named JSX attribute from all JSX elements with a given tag name.
- * Targets both self-closing and open/close elements.
- *
- * @example Remove `webgl` prop from every `<Wrapper webgl …>` usage:
- * `{ kind: 'removeJsxAttribute', tagName: 'Wrapper', attributeName: 'webgl' }`
- */
-export interface RemoveJsxAttributeOp {
-  kind: 'removeJsxAttribute'
-  /** Tag name of the element whose attribute to remove, e.g. 'Wrapper' */
-  tagName: string
-  /** Attribute name to remove, e.g. 'webgl' */
-  attributeName: string
-}
-
-/**
- * Remove a named binding from a destructured variable declaration.
- *
- * Targets `const { …, name, … } = expr` statements at any scope depth.
- * Rebuilt from the remaining elements, preserving defaults and rest elements.
- *
- * @example Remove `studio` from `const { stats, grid, studio } = useOrchestra()`
- * `{ kind: 'removeDestructuredBinding', variableName: 'studio', declarationPattern: 'useOrchestra' }`
- */
-export interface RemoveDestructuredBindingOp {
-  kind: 'removeDestructuredBinding'
-  /** The binding name to remove, e.g. 'studio' */
-  bindingName: string
-  /**
-   * Substring of the initializer expression text used to narrow the target
-   * declaration (e.g. 'useOrchestra'). Prevents accidentally modifying
-   * unrelated destructurings that happen to bind the same name.
-   */
-  initializerContains: string
-}
-
-/** Remove a named parameter from a function's destructured props argument. */
-export interface RemoveFunctionParameterOp {
-  kind: 'removeFunctionParameter'
-  /** Exported function name, e.g. 'Wrapper' */
-  functionName: string
-  /** Parameter name as it appears in the destructured binding, e.g. 'webgl' */
-  parameterName: string
-}
-
-/**
- * Replace the entire JSDoc block on a named function with a provided string.
- * Used when multiple partial-text edits to the JSDoc would be brittle; a full
- * replacement is simpler and guarantees the result is well-formed.
- */
-export interface ReplaceJsDocOp {
-  kind: 'replaceJsDoc'
-  /** Name of the function whose JSDoc to replace */
-  functionName: string
-  /** The replacement JSDoc text (must include /** … * /) */
-  replacement: string
-}
-
-/**
- * Remove an object element from an array property nested inside a named
- * variable declaration.  Designed for `images.remotePatterns` in next.config.ts.
- *
- * Matches an array element that is an object literal containing a property
- * whose name and string value both match the given `matchProperty`.
- */
-export interface RemoveArrayObjectElementOp {
-  kind: 'removeArrayObjectElement'
-  /**
-   * Dot-separated path from the variable declaration down to the array
-   * property, e.g. `'images.remotePatterns'`.
-   */
-  propertyPath: string
-  /** The variable name that holds the object, e.g. `'nextConfig'`. */
-  variableName: string
-  /** Property name + value that must be present on the target object element. */
-  matchProperty: { name: string; value: string }
-}
-
-/**
- * Remove a string-literal element from an array property nested inside a named
- * variable declaration.  Designed for `experimental.optimizePackageImports`.
- */
-export interface RemoveArrayStringElementOp {
-  kind: 'removeArrayStringElement'
-  /**
-   * Dot-separated path from the variable declaration down to the array
-   * property, e.g. `'experimental.optimizePackageImports'`.
-   */
-  propertyPath: string
-  /** The variable name that holds the object, e.g. `'nextConfig'`. */
-  variableName: string
-  /** The exact string value to remove from the array. */
-  value: string
-}
-
-// ---------------------------------------------------------------------------
-// Additive operations (inverse of the removals above)
-// Every additive op is IDEMPOTENT: when the construct it would add is already
-// present, the source text is returned byte-for-byte unchanged, so applying
-// the same op twice is a no-op.
-// ---------------------------------------------------------------------------
-
-/**
- * Add a top-level import declaration, given as full source text.
- *
- * If an import with the same module specifier already exists, any missing
- * named imports are merged into it (no-op when all bindings are present).
- * Otherwise the declaration is inserted after the last existing import, e.g.
- * re-adding `import { Canvas } from '@/webgl/components/canvas'`.
- */
-export interface AddImportOp {
-  kind: 'addImport'
-  /** Full import declaration text, e.g. `import { Canvas } from '@/webgl/components/canvas'` */
-  text: string
-}
-
-/**
- * Append a string-literal element to an array property nested inside a named
- * variable declaration.  Inverse of `removeArrayStringElement`; designed for
- * `experimental.optimizePackageImports` in next.config.ts.
- *
- * No-op when an element with the same literal value already exists.
- */
-export interface AddArrayStringElementOp {
-  kind: 'addArrayStringElement'
-  /** The variable name that holds the object, e.g. `'nextConfig'`. */
-  variableName: string
-  /**
-   * Dot-separated path from the variable declaration down to the array
-   * property, e.g. `'experimental.optimizePackageImports'`.
-   */
-  propertyPath: string
-  /** The string value to append to the array. */
-  value: string
-}
-
-/**
- * Append an object-literal element to an array property nested inside a named
- * variable declaration.  Inverse of `removeArrayObjectElement`; designed for
- * `images.remotePatterns` in next.config.ts.
- *
- * No-op when an element already matches `matchProperty` (same matching
- * semantics as `removeArrayObjectElement`, including quoted-key
- * normalization).
- */
-export interface AddArrayObjectElementOp {
-  kind: 'addArrayObjectElement'
-  /** The variable name that holds the object, e.g. `'nextConfig'`. */
-  variableName: string
-  /**
-   * Dot-separated path from the variable declaration down to the array
-   * property, e.g. `'images.remotePatterns'`.
-   */
-  propertyPath: string
-  /** The object literal to append, as source text, e.g. `{ protocol: 'https', hostname: 'cdn.sanity.io' }` */
-  objectText: string
-  /** Property name + value identifying an already-present matching element. */
-  matchProperty: { name: string; value: string }
-}
-
-/**
- * Insert a full variable statement, e.g. re-adding
- * `const LazyWebGLCanvas = dynamic(…)` to lib/features/index.tsx.
- *
- * No-op when a variable named `name` already exists anywhere in the file
- * (any scope depth, mirroring `removeVariableStatement`).
- */
-export interface AddVariableStatementOp {
-  kind: 'addVariableStatement'
-  /** The declared variable name used for the idempotency check, e.g. 'LazyWebGLCanvas' */
-  name: string
-  /** Full statement text to insert, e.g. `const LazyWebGLCanvas = dynamic(() => …)` */
-  text: string
-  /**
-   * When true or omitted, insert after the last import declaration.
-   * When false, append at the end of the file.
-   */
-  afterImports?: boolean
-}
-
-/**
- * Append a JSX child as the last child of the first element whose opening tag
- * matches `parentTagName`, e.g. re-adding `<Canvas root />` inside <Wrapper>.
- *
- * Parent selection: among same-tag candidates, an element that already
- * contains a direct child with tag `childTagName` wins, so re-added elements
- * land next to their siblings (e.g. an OrchestraToggle row). The special
- * value `parentTagName: 'Fragment'` falls back to the first JSX fragment
- * (`<>…</>`) when no `<Fragment>` element matches.
- *
- * No-op when any JSX element (or self-closing element) with tag
- * `childTagName` already exists anywhere in the file — narrowed to elements
- * whose attribute matches when `childAttribute` is provided.
- */
-export interface AddJsxChildOp {
-  kind: 'addJsxChild'
-  /**
-   * Tag name of the parent element to append into, e.g. 'Wrapper'.
-   * 'Fragment' targets the first JSX fragment when no element matches.
-   */
-  parentTagName: string
-  /** The JSX child to append, as source text, e.g. `<Canvas root />` */
-  childText: string
-  /** Tag name of the child, used for the idempotency check, e.g. 'Canvas' */
-  childTagName: string
-  /**
-   * Optional attribute narrowing the idempotency check: only an existing
-   * `childTagName` element whose attribute matches blocks insertion, so
-   * `<OrchestraToggle id="webgl">` can be re-added next to other toggles.
-   */
-  childAttribute?: { name: string; value: string }
-}
-
-export type AstOperation =
-  | RemoveImportOp
-  | RemoveVariableStatementOp
-  | RemoveCallStatementOp
-  | RemoveCallArgumentOp
-  | RemoveJsxElementOp
-  | RemoveJsxAttributeOp
-  | RemoveDestructuredBindingOp
-  | RemoveInterfacePropertyOp
-  | RemoveFunctionParameterOp
-  | ReplaceJsDocOp
-  | RemoveArrayObjectElementOp
-  | RemoveArrayStringElementOp
-  | AddImportOp
-  | AddArrayStringElementOp
-  | AddArrayObjectElementOp
-  | AddVariableStatementOp
-  | AddJsxChildOp
-
-export interface CodeTransform {
-  /** Path to the file to transform (relative to project root) */
-  file: string
-  /** Typed AST operations to apply */
-  ops: AstOperation[]
 }
 
 export interface IntegrationBundle {

--- a/lib/scripts/satus.test.ts
+++ b/lib/scripts/satus.test.ts
@@ -9,14 +9,13 @@
  */
 
 import { describe, expect, it } from 'bun:test'
-import { INTEGRATION_BUNDLES } from './integration-bundles'
 import {
   bundleProbePath,
   findBarrelLine,
   insertBarrelLine,
-  parseAddArgs,
-  resolveAddSet,
-} from './satus'
+} from './bundle-installer'
+import { INTEGRATION_BUNDLES } from './integration-bundles'
+import { parseAddArgs, resolveAddSet } from './satus'
 
 // ---------------------------------------------------------------------------
 // parseAddArgs

--- a/lib/scripts/satus.ts
+++ b/lib/scripts/satus.ts
@@ -16,28 +16,23 @@
  * non-interactively outside a TTY), so the CLI is drivable in CI.
  */
 
-import { mkdir } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
 import * as p from '@clack/prompts'
 import type { RemovableId } from '@/integrations/registry'
-import { applyCodeTransforms, applyOpsToText } from './ast-transforms'
 import {
-  type CodeTransform,
+  installBundle,
+  isInstalled,
+  stripAbsentIntegrationWiring,
+} from './bundle-installer'
+import {
   getIntegrationEntries,
   INTEGRATION_BUNDLES,
   type IntegrationBundle,
 } from './integration-bundles'
 import {
-  listPayloadFiles,
-  type PayloadPackageJson,
-  type PayloadSource,
-  payloadPathExists,
-  readPayloadFile,
   readPayloadPackageJson,
   readPinnedRef,
   resolvePayloadSource,
 } from './payload-source'
-import { pathExists, resolvePath } from './utils'
 
 // ---------------------------------------------------------------------------
 // CLI argument parsing (exported for unit tests)
@@ -161,298 +156,6 @@ export function resolveAddSet(requested: string[]): {
   return { order, implied }
 }
 
-/** A bundle counts as installed when its first folder (or file) exists. */
-export function bundleProbePath(bundle: IntegrationBundle): string | undefined {
-  return bundle.folders[0] ?? bundle.files[0]
-}
-
-// ---------------------------------------------------------------------------
-// Barrel export restoration (exported for unit tests)
-// ---------------------------------------------------------------------------
-
-/**
- * Find the export line in a source barrel matching the removal `pattern`,
- * using the same matching as setup-project's removal (quoted pattern or
- * quoted './pattern' specifier).
- */
-export function findBarrelLine(
-  sourceText: string,
-  pattern: string
-): string | undefined {
-  return sourceText
-    .split('\n')
-    .find(
-      (line) => line.includes(`'${pattern}'`) || line.includes(`'./${pattern}'`)
-    )
-}
-
-/**
- * Insert a barrel export line when absent (sorted position among existing
- * `export` lines, best-effort). Returns the text unchanged when an identical
- * line already exists — idempotent.
- */
-export function insertBarrelLine(localText: string, line: string): string {
-  const newLine = line.trim()
-  if (newLine.length === 0) return localText
-
-  const lines = localText.split('\n')
-  if (lines.some((existing) => existing.trim() === newLine)) return localText
-
-  const exportIndexes: number[] = []
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i]?.startsWith('export ')) exportIndexes.push(i)
-  }
-
-  if (exportIndexes.length === 0) {
-    const base =
-      localText.length === 0 || localText.endsWith('\n')
-        ? localText
-        : `${localText}\n`
-    return `${base}${newLine}\n`
-  }
-
-  const sortedAfter = exportIndexes.find(
-    (i) => (lines[i] ?? '').localeCompare(newLine) > 0
-  )
-  const lastExport = exportIndexes[exportIndexes.length - 1] ?? 0
-  const insertAt = sortedAfter ?? lastExport + 1
-  lines.splice(insertAt, 0, newLine)
-  return lines.join('\n')
-}
-
-// ---------------------------------------------------------------------------
-// Install steps
-// ---------------------------------------------------------------------------
-
-export const isInstalled = async (
-  bundle: IntegrationBundle
-): Promise<boolean> => {
-  const probe = bundleProbePath(bundle)
-  if (!probe) return false
-  return pathExists(resolvePath(probe))
-}
-
-/**
- * Copy the bundle's `folders` and `files` from the payload source into the
- * project. Existing files are kept (unless --force); missing ones are always
- * copied. Fails loudly when the payload lacks a declared folder or file.
- */
-export const copyBundleFiles = async (
-  source: PayloadSource,
-  bundle: IntegrationBundle,
-  options: { dryRun: boolean; force: boolean }
-): Promise<{ copied: number; skipped: number }> => {
-  const relFiles: string[] = []
-
-  for (const folder of bundle.folders) {
-    relFiles.push(...(await listPayloadFiles(source, folder)))
-  }
-  for (const file of bundle.files) {
-    if (!(await payloadPathExists(source, file))) {
-      throw new Error(`Payload source (${source.label}) is missing ${file}`)
-    }
-    relFiles.push(file)
-  }
-
-  let copied = 0
-  let skipped = 0
-
-  for (const rel of relFiles) {
-    const dest = resolvePath(rel)
-    if ((await pathExists(dest)) && !options.force) {
-      skipped++
-      continue
-    }
-    if (!options.dryRun) {
-      await mkdir(dirname(dest), { recursive: true })
-      await Bun.write(dest, Bun.file(join(source.root, rel)))
-    }
-    copied++
-  }
-
-  return { copied, skipped }
-}
-
-/**
- * Copy the bundle's integration-owned `overwriteFiles` wholesale from the
- * payload source. A local file is only overwritten when it matches either
- * the payload version (already wired — no-op) or the expected lean state
- * (the payload version with this bundle's removal codeTransforms applied).
- * Anything else means local modifications — skip with a warning unless
- * --force.
- */
-export const applyOverwriteFiles = async (
-  source: PayloadSource,
-  bundle: IntegrationBundle,
-  options: { dryRun: boolean; force: boolean }
-): Promise<{ written: string[]; skipped: string[] }> => {
-  const written: string[] = []
-  const skipped: string[] = []
-
-  for (const rel of bundle.overwriteFiles ?? []) {
-    const payloadText = await readPayloadFile(source, rel)
-    const dest = resolvePath(rel)
-
-    if (!(await pathExists(dest))) {
-      if (!options.dryRun) {
-        await mkdir(dirname(dest), { recursive: true })
-        await Bun.write(dest, payloadText)
-      }
-      written.push(rel)
-      continue
-    }
-
-    const localText = await Bun.file(dest).text()
-    if (localText === payloadText) continue // already wired
-
-    const removalOps =
-      bundle.codeTransforms.find((t) => t.file === rel)?.ops ?? []
-    const expectedLean = applyOpsToText(payloadText, removalOps)
-
-    if (localText === expectedLean || options.force) {
-      if (!options.dryRun) {
-        await Bun.write(dest, payloadText)
-      }
-      written.push(rel)
-    } else {
-      skipped.push(rel)
-    }
-  }
-
-  return { written, skipped }
-}
-
-const sortRecord = (record: Record<string, string>): Record<string, string> =>
-  Object.fromEntries(
-    Object.entries(record).sort(([a], [b]) => a.localeCompare(b))
-  )
-
-/**
- * Add the bundle's dependencies to the local package.json, pinning each to
- * the version declared by the payload source's package.json. Dependencies
- * already present locally keep their existing pin.
- */
-export const addDependencies = async (
-  bundle: IntegrationBundle,
-  payloadPkg: PayloadPackageJson,
-  options: { dryRun: boolean }
-): Promise<{ added: string[]; missing: string[] }> => {
-  const pkgPath = resolvePath('package.json')
-  const pkg = (await Bun.file(pkgPath).json()) as {
-    dependencies?: Record<string, string>
-    devDependencies?: Record<string, string>
-    [key: string]: unknown
-  }
-
-  const added: string[] = []
-  const missing: string[] = []
-
-  const addFrom = (
-    names: string[],
-    target: 'dependencies' | 'devDependencies'
-  ): void => {
-    for (const name of names) {
-      const version =
-        payloadPkg.dependencies?.[name] ?? payloadPkg.devDependencies?.[name]
-      if (!version) {
-        missing.push(name)
-        continue
-      }
-      const record = pkg[target] ?? {}
-      pkg[target] = record
-      if (record[name]) continue // already present — keep the local pin
-      record[name] = version
-      added.push(`${name}@${version}`)
-    }
-  }
-
-  addFrom(bundle.dependencies, 'dependencies')
-  addFrom(bundle.devDependencies, 'devDependencies')
-
-  if (added.length > 0 && !options.dryRun) {
-    if (pkg.dependencies) pkg.dependencies = sortRecord(pkg.dependencies)
-    if (pkg.devDependencies) {
-      pkg.devDependencies = sortRecord(pkg.devDependencies)
-    }
-    await Bun.write(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`)
-  }
-
-  return { added, missing }
-}
-
-/**
- * Restore the bundle's barrel export lines: read each pattern's line from the
- * SOURCE repo's barrel file and insert it into the local barrel when absent
- * (created when missing). Warns when the payload has no matching barrel/line.
- */
-export const restoreBarrelExports = async (
-  source: PayloadSource,
-  bundle: IntegrationBundle,
-  options: { dryRun: boolean }
-): Promise<number> => {
-  let changes = 0
-
-  for (const { file, pattern } of bundle.barrelExports) {
-    if (!(await payloadPathExists(source, file))) {
-      p.log.warn(
-        `Payload source has no barrel file ${file} — skipping export restore for "${pattern}"`
-      )
-      continue
-    }
-
-    const sourceText = await readPayloadFile(source, file)
-    const line = findBarrelLine(sourceText, pattern)
-    if (!line) {
-      p.log.warn(
-        `No export line matching "${pattern}" in payload ${file} — skipping`
-      )
-      continue
-    }
-
-    const localPath = resolvePath(file)
-    const localText = (await pathExists(localPath))
-      ? await Bun.file(localPath).text()
-      : ''
-    const updated = insertBarrelLine(localText, line)
-
-    if (updated !== localText) {
-      if (!options.dryRun) {
-        await mkdir(dirname(localPath), { recursive: true })
-        await Bun.write(localPath, updated)
-      }
-      changes++
-    }
-  }
-
-  return changes
-}
-
-/** Append missing env vars as commented stubs to .env.example (created when absent). */
-export const appendEnvStubs = async (
-  envVars: string[],
-  dryRun: boolean
-): Promise<number> => {
-  if (envVars.length === 0) return 0
-
-  const envPath = resolvePath('.env.example')
-  const exists = await pathExists(envPath)
-  const content = exists ? await Bun.file(envPath).text() : ''
-
-  const missing = envVars.filter(
-    (envVar) => !new RegExp(`^#?\\s*${envVar}=`, 'm').test(content)
-  )
-  if (missing.length === 0) return 0
-
-  if (!dryRun) {
-    const base =
-      content.length === 0 || content.endsWith('\n') ? content : `${content}\n`
-    const stubs = missing.map((envVar) => `# ${envVar}=`).join('\n')
-    await Bun.write(envPath, `${base}${stubs}\n`)
-  }
-
-  return missing.length
-}
-
 // ---------------------------------------------------------------------------
 // Commands
 // ---------------------------------------------------------------------------
@@ -539,7 +242,7 @@ const runAdd = async (plugins: string[], flags: AddFlags): Promise<void> => {
   })
   p.log.step(`Payload source: ${source.label}`)
 
-  let depsAdded = 0
+  let totalDepsAdded = 0
 
   try {
     const payloadPkg = await readPayloadPackageJson(source)
@@ -547,58 +250,28 @@ const runAdd = async (plugins: string[], flags: AddFlags): Promise<void> => {
 
     for (const { bundle } of toInstall) {
       s.start(`Adding ${bundle.name}...`)
-      const details: string[] = []
 
-      const { copied, skipped } = await copyBundleFiles(source, bundle, flags)
-      if (copied > 0) details.push(`${copied} files copied`)
-      if (skipped > 0) details.push(`${skipped} existing files kept`)
-
-      const overwrite = await applyOverwriteFiles(source, bundle, flags)
-      if (overwrite.written.length > 0) {
-        details.push(
-          `${overwrite.written.length} integration-owned files restored`
-        )
-      }
-
-      const deps = await addDependencies(bundle, payloadPkg, flags)
-      depsAdded += deps.added.length
-      if (deps.added.length > 0) {
-        details.push(`${deps.added.length} dependencies pinned`)
-      }
-
-      const barrelChanges = await restoreBarrelExports(source, bundle, flags)
-      if (barrelChanges > 0) {
-        details.push(`${barrelChanges} barrel exports restored`)
-      }
-
-      const envChanges = await appendEnvStubs(bundle.envVars, flags.dryRun)
-      if (envChanges > 0) details.push(`${envChanges} env stubs appended`)
-
-      const transformChanges = await applyCodeTransforms(
-        bundle.addTransforms ?? [],
-        flags.dryRun
-      )
-      if (transformChanges > 0) {
-        details.push(`${transformChanges} files re-wired`)
-      }
+      const { details, depsAdded, overwriteSkipped, depsMissing } =
+        await installBundle(source, bundle, payloadPkg, flags)
+      totalDepsAdded += depsAdded.length
 
       const verb = flags.dryRun ? 'Would add' : 'Added'
       const detail = details.length > 0 ? ` (${details.join(', ')})` : ''
       s.stop(`${verb} ${bundle.name}${detail}`)
 
-      for (const rel of overwrite.skipped) {
+      for (const rel of overwriteSkipped) {
         p.log.warn(
           `${rel} is locally modified — skipped. Re-run with --force to overwrite.`
         )
       }
-      for (const dep of deps.missing) {
+      for (const dep of depsMissing) {
         p.log.warn(
           `"${dep}" is not in the payload package.json — install it manually.`
         )
       }
 
-      if (deps.added.length > 0) {
-        p.log.message(`  Pinned: ${deps.added.join(', ')}`)
+      if (depsAdded.length > 0) {
+        p.log.message(`  Pinned: ${depsAdded.join(', ')}`)
       }
     }
 
@@ -607,22 +280,14 @@ const runAdd = async (plugins: string[], flags: AddFlags): Promise<void> => {
     // hooks. Reuse the subtractive codeTransforms of each bundle that is
     // neither installed nor part of this add, so absent integrations stay
     // absent. These ops are no-ops on files already in the lean state.
-    const stripTransforms: CodeTransform[] = []
-    for (const [id, bundle] of getIntegrationEntries()) {
-      if (order.includes(id)) continue
-      if (await isInstalled(bundle)) continue
-      stripTransforms.push(...bundle.codeTransforms)
-    }
-    if (stripTransforms.length > 0) {
-      const stripped = await applyCodeTransforms(stripTransforms, flags.dryRun)
-      if (stripped > 0) {
-        p.log.step(
-          `Stripped absent-integration wiring from ${stripped} copied files`
-        )
-      }
+    const stripped = await stripAbsentIntegrationWiring(order, flags.dryRun)
+    if (stripped > 0) {
+      p.log.step(
+        `Stripped absent-integration wiring from ${stripped} copied files`
+      )
     }
 
-    if (depsAdded > 0 && !flags.dryRun) {
+    if (totalDepsAdded > 0 && !flags.dryRun) {
       if (flags.skipInstall) {
         p.log.step('Skipped bun install (--skip-install) — run it manually')
       } else {

--- a/lib/scripts/setup-project.ts
+++ b/lib/scripts/setup-project.ts
@@ -31,22 +31,21 @@ import { join } from 'node:path'
 import * as p from '@clack/prompts'
 import type { RemovableId } from '@/integrations/registry'
 import { applyCodeTransforms } from './ast-transforms'
-import { cancelGuard } from './generate-shared'
-import {
-  type CodeTransform,
-  getIntegrationEntries,
-  getIntegrationNames,
-  INTEGRATION_BUNDLES,
-} from './integration-bundles'
-import type { PayloadPackageJson, PayloadSource } from './payload-source'
 import {
   addDependencies,
   appendEnvStubs,
   applyOverwriteFiles,
   copyBundleFiles,
-  isInstalled,
   restoreBarrelExports,
-} from './satus'
+  stripAbsentIntegrationWiring,
+} from './bundle-installer'
+import { cancelGuard } from './generate-shared'
+import {
+  type CodeTransform,
+  getIntegrationNames,
+  INTEGRATION_BUNDLES,
+} from './integration-bundles'
+import type { PayloadPackageJson, PayloadSource } from './payload-source'
 import {
   getFlagValue,
   parseCliFlags,
@@ -595,20 +594,14 @@ const setupAddIntegrations = async (
   // Strip absent-integration wiring from freshly copied files.
   // e.g. keeping webgl without theatre must remove theatre wiring from the
   // copied fluid/flowmap hooks.  These ops are no-ops on already-lean files.
-  const stripTransforms: CodeTransform[] = []
-  for (const [id, bundle] of getIntegrationEntries()) {
-    if (addedIntegrationIds.has(id)) continue
-    if (await isInstalled(bundle)) continue
-    stripTransforms.push(...bundle.codeTransforms)
-  }
-
-  if (stripTransforms.length > 0) {
-    const stripped = await applyCodeTransforms(stripTransforms, dryRun)
-    if (stripped > 0) {
-      p.log.step(
-        `Stripped absent-integration wiring from ${stripped} copied files`
-      )
-    }
+  const stripped = await stripAbsentIntegrationWiring(
+    addedIntegrationIds,
+    dryRun
+  )
+  if (stripped > 0) {
+    p.log.step(
+      `Stripped absent-integration wiring from ${stripped} copied files`
+    )
   }
 }
 


### PR DESCRIPTION
## What this does

Pure reorganization of the scaffolding tooling internals (`lib/scripts/`) — no behavior change. The goal is purely to make the next person's life easier; the diff should read as "code moved, nothing else."

Two things were entangled and are now separated:

1. **AST-operation types** lived inside `integration-bundles.ts` (the bundle *data* file), which `ast-transforms.ts` then imported back from — a circular-import smell. The ~19 operation types now live in their own `ast-operation-types.ts` (types only, zero runtime). `integration-bundles.ts` re-exports them so nothing external breaks.
2. **Install logic** was half in the executable `satus.ts` and half mirrored in `setup-project.ts`, with a "strip absent-integration wiring" block duplicated near-verbatim between them. It's now one `bundle-installer.ts` (`installBundle` + `stripAbsentIntegrationWiring`, each defined once). `satus.ts` keeps only CLI arg-parsing / list / add orchestration.

## Summary

- New `lib/scripts/ast-operation-types.ts` — the AST-op type system; `ast-transforms.ts` imports from here; `integration-bundles.ts` re-exports for back-compat.
- New `lib/scripts/bundle-installer.ts` — shared `installBundle()` + the single `stripAbsentIntegrationWiring()`; install primitives moved here from `satus.ts`.
- `satus.ts` −373 lines, `integration-bundles.ts` −336 lines; `setup-project.ts` imports install primitives from `bundle-installer.ts` (no longer from the executable `satus.ts`).
- Honors `scaffolder-integration-logic-lives-in-starter` — integration knowledge stays in the starter; this is organization only.

## Test Plan
- [x] `bun run test:setup` (35 pass) — install/strip/self-prune behavior intact
- [x] `bun run build && bun run check` green (337 tests)
- [x] `bun run manifest:check` up to date

---

## Codex cross-review

Ran `codex exec` (codex-cli 0.141.0) on the full diff (incl. new files), tasked specifically with finding silent behavior drift during the move.

**Verdict: faithful move.** Confirmed install-sequence ordering, awaits, dry-run/force handling, returned detail data, dependency counting, and the strip logic all match the original call sites; the type extraction is complete and the re-exports cover every moved type plus `AstOperation`/`CodeTransform`.

**One finding, declined with rationale:** Codex noted `satus.ts` no longer re-exports the installer helpers (`isInstalled`, `copyBundleFiles`, …), so a hypothetical external `import … from './satus'` would break. This is intended, not a regression — `satus.ts` is a CLI entry script (run as `bun satus.ts`), not a published module API; relocating those helpers into `bundle-installer.ts` is the explicit point of the refactor. All internal importers were repointed, and the full typecheck + 337 tests pass, proving nothing is broken.

Closes #236.
