### PR TITLE
chore: DRY & dead-code cleanup + invert validation→components boundary (#241, #237)

### DIFF
--- a/components/ui/form/types.ts
+++ b/components/ui/form/types.ts
@@ -1,12 +1,8 @@
 import type { ComponentPropsWithoutRef, ReactNode } from 'react'
+import type { FormState } from '@/lib/types/form'
 
-// Form state returned by server actions
-export type FormState<T = unknown> = {
-  status: number
-  message: string
-  data?: T
-  fieldErrors?: Record<string, string>
-}
+// Re-export so existing component-layer imports keep working
+export type { FormState }
 
 // Server action type
 export type FormAction<T = unknown> = (

--- a/lib/integrations/hubspot/action.ts
+++ b/lib/integrations/hubspot/action.ts
@@ -26,7 +26,7 @@
 'use server'
 
 import { z } from 'zod'
-import type { FormState } from '@/components/ui/form/types'
+import type { FormState } from '@/lib/types/form'
 import { runFormAction } from '@/lib/utils/form-action'
 import { fetchWithTimeout } from '@/utils/fetch'
 import { emailSchema } from '@/utils/validation'

--- a/lib/integrations/mailchimp/action.ts
+++ b/lib/integrations/mailchimp/action.ts
@@ -1,9 +1,9 @@
 'use server'
 
 import { z } from 'zod'
-import type { FormState } from '@/components/ui/form/types'
 import type { TurnstileValidationResult } from '@/lib/integrations/turnstile'
 import { validateFormWithTurnstile } from '@/lib/integrations/turnstile'
+import type { FormState } from '@/lib/types/form'
 import { runFormAction } from '@/lib/utils/form-action'
 import { emailSchema } from '@/utils/validation'
 import {
@@ -49,7 +49,11 @@ export async function mailchimpContactAction(
     schema: contactSchema,
     formData,
     run: async (input) => {
-      const result = await addContactToMailchimp(input)
+      const result = await addContactToMailchimp({
+        name: input.name,
+        email: input.email,
+        note: `Contact form submission - Subject: ${input.subject}\n\nMessage: ${input.message}`,
+      })
       if (!result.success) {
         return {
           status: 500,

--- a/lib/integrations/mailchimp/mailchimp-client.ts
+++ b/lib/integrations/mailchimp/mailchimp-client.ts
@@ -12,8 +12,7 @@ export interface MailchimpConfig {
 export interface ContactData {
   name: string
   email: string
-  subject: string
-  message: string
+  note?: string
 }
 
 export interface SubscriptionData {
@@ -205,18 +204,18 @@ export async function addContactToMailchimp(
       console.error('Mailchimp contact tag error (non-fatal):', err)
     }
 
-    try {
-      await makeMailchimpRequest(
-        `/lists/${audienceId}/members/${upsert.memberId}/notes`,
-        {
-          method: 'POST',
-          body: JSON.stringify({
-            note: `Contact form submission - Subject: ${contactData.subject}\n\nMessage: ${contactData.message}`,
-          }),
-        }
-      )
-    } catch (err) {
-      console.error('Mailchimp contact note error (non-fatal):', err)
+    if (contactData.note) {
+      try {
+        await makeMailchimpRequest(
+          `/lists/${audienceId}/members/${upsert.memberId}/notes`,
+          {
+            method: 'POST',
+            body: JSON.stringify({ note: contactData.note }),
+          }
+        )
+      } catch (err) {
+        console.error('Mailchimp contact note error (non-fatal):', err)
+      }
     }
 
     return { success: true }

--- a/lib/integrations/shopify/cart/actions.ts
+++ b/lib/integrations/shopify/cart/actions.ts
@@ -58,6 +58,33 @@ async function runCartAction(
   return run()
 }
 
+/**
+ * Resolve the Shopify cart line ID for a given merchandise item.
+ *
+ * Fast path: returns `{ lineId }` directly when the caller already has it,
+ * skipping the extra `getCart` round-trip.
+ * Fallback: fetches the cart and finds the line by `merchandiseId`.
+ *
+ * Returns `{ error }` when the cart cannot be fetched or the item is not found.
+ */
+async function resolveLineId(
+  cartId: string,
+  lineId: string | undefined,
+  merchandiseId: string
+): Promise<{ lineId: string } | { error: string }> {
+  if (lineId) return { lineId }
+
+  const cart = await getCart(cartId)
+  if (!cart) return { error: 'Error fetching cart' }
+
+  const lineItem = cart.lines.find(
+    (line) => line.merchandise.id === merchandiseId
+  )
+  return lineItem?.id
+    ? { lineId: lineItem.id }
+    : { error: 'Item not found in cart' }
+}
+
 export async function removeItem(
   _prevState: unknown,
   merchandiseId: string,
@@ -76,31 +103,15 @@ export async function removeItem(
     }
 
     try {
-      // Fast path: caller supplies lineId directly — skip the extra getCart round-trip.
-      if (lineId) {
-        await removeFromCart(cartId, [lineId])
-        revalidateTag(TAGS.cart, {})
-        return { ok: true }
+      const resolved = await resolveLineId(cartId, lineId, merchandiseId)
+
+      if ('error' in resolved) {
+        return { ok: false, error: resolved.error }
       }
 
-      // Fallback: resolve lineId from a fresh cart fetch (e.g. callers without lineId).
-      const cart = await getCart(cartId)
-
-      if (!cart) {
-        return { ok: false, error: 'Error fetching cart' }
-      }
-
-      const lineItem = cart.lines.find(
-        (line) => line.merchandise.id === merchandiseId
-      )
-
-      if (lineItem?.id) {
-        await removeFromCart(cartId, [lineItem.id])
-        revalidateTag(TAGS.cart, {})
-        return { ok: true }
-      }
-
-      return { ok: false, error: 'Item not found in cart' }
+      await removeFromCart(cartId, [resolved.lineId])
+      revalidateTag(TAGS.cart, {})
+      return { ok: true }
     } catch (_e) {
       return { ok: false, error: 'Error removing item from cart' }
     }
@@ -185,34 +196,14 @@ export async function updateItemQuantity(
     const { merchandiseId, quantity, lineId } = parsed.data
 
     try {
-      // Fast path: caller supplies lineId directly — skip the extra getCart round-trip.
-      if (lineId) {
-        await updateCart(cartId, [{ id: lineId, merchandiseId, quantity }])
-        revalidateTag(TAGS.cart, {})
-        return { ok: true }
-      }
+      const resolved = await resolveLineId(cartId, lineId, merchandiseId)
 
-      // Fallback: resolve lineId from a fresh cart fetch (e.g. callers without lineId).
-      const cart = await getCart(cartId)
-
-      if (!cart) {
-        return { ok: false, error: 'Error fetching cart' }
-      }
-
-      const lineItem = cart.lines.find(
-        (line) => line.merchandise.id === merchandiseId
-      )
-
-      if (!lineItem?.id) {
-        return { ok: false, error: 'Item not found in cart' }
+      if ('error' in resolved) {
+        return { ok: false, error: resolved.error }
       }
 
       await updateCart(cartId, [
-        {
-          id: lineItem.id,
-          merchandiseId,
-          quantity,
-        },
+        { id: resolved.lineId, merchandiseId, quantity },
       ])
       revalidateTag(TAGS.cart, {})
       return { ok: true }

--- a/lib/integrations/shopify/cart/optimistic-utils.ts
+++ b/lib/integrations/shopify/cart/optimistic-utils.ts
@@ -3,7 +3,6 @@ import type {
   Product,
   ProductVariant,
 } from '@/integrations/shopify/types'
-import { isEmptyArray } from '@/utils/strings'
 
 type CartLine = Pick<
   Cart['lines'][number],
@@ -67,7 +66,7 @@ function updateItem(state: Cart, action: UpdateItemAction): Cart {
     return updated ? [updated] : []
   })
 
-  if (isEmptyArray(updatedLines)) {
+  if (updatedLines.length === 0) {
     return {
       ...state,
       lines: [],

--- a/lib/integrations/shopify/customer/actions.ts
+++ b/lib/integrations/shopify/customer/actions.ts
@@ -2,7 +2,7 @@
 
 import { cookies } from 'next/headers'
 import { z } from 'zod'
-import type { FormState } from '@/components/ui/form/types'
+import type { FormState } from '@/lib/types/form'
 import { runFormAction } from '@/lib/utils/form-action'
 import { rateLimiters } from '@/lib/utils/rate-limit'
 import { emailSchema } from '@/utils/validation'

--- a/lib/scripts/utils.ts
+++ b/lib/scripts/utils.ts
@@ -105,26 +105,6 @@ export const createDir = async (path: string): Promise<void> => {
  */
 export const bunExecutable = process.execPath
 
-/**
- * Current platform
- */
-export const platform = process.platform
-
-/**
- * Check if running on Windows
- */
-export const isWindows = platform === 'win32'
-
-/**
- * Check if running on macOS
- */
-export const isMacOS = platform === 'darwin'
-
-/**
- * Check if running on Linux
- */
-export const isLinux = platform === 'linux'
-
 // ============================================================================
 // CLI Argument Utilities
 // ============================================================================
@@ -186,7 +166,7 @@ export const getFlagValue = (
  */
 export const copyToClipboard = async (text: string): Promise<boolean> => {
   try {
-    if (isMacOS) {
+    if (process.platform === 'darwin') {
       const proc = Bun.spawn(['pbcopy'], { stdin: 'pipe' })
       proc.stdin.write(text)
       proc.stdin.end()
@@ -194,7 +174,7 @@ export const copyToClipboard = async (text: string): Promise<boolean> => {
       return proc.exitCode === 0
     }
 
-    if (isLinux) {
+    if (process.platform === 'linux') {
       // Try xclip first, then xsel
       for (const cmd of [
         ['xclip', '-selection', 'clipboard'],
@@ -213,7 +193,7 @@ export const copyToClipboard = async (text: string): Promise<boolean> => {
       return false
     }
 
-    if (isWindows) {
+    if (process.platform === 'win32') {
       const proc = Bun.spawn(['clip'], { stdin: 'pipe' })
       proc.stdin.write(text)
       proc.stdin.end()

--- a/lib/types/form.ts
+++ b/lib/types/form.ts
@@ -1,0 +1,9 @@
+// Form state returned by server actions.
+// Lives here (lib/) so lib-level utilities can import it without reaching
+// upward into components/ (which would invert the dependency layer).
+export type FormState<T = unknown> = {
+  status: number
+  message: string
+  data?: T
+  fieldErrors?: Record<string, string>
+}

--- a/lib/utils/form-action.ts
+++ b/lib/utils/form-action.ts
@@ -1,6 +1,6 @@
 import { headers } from 'next/headers'
 import type { z } from 'zod'
-import type { FormState } from '@/components/ui/form/types'
+import type { FormState } from '@/lib/types/form'
 import {
   getIPFromHeaders,
   type RateLimitConfig,

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import type { FormState } from '@/components/ui/form/types'
+import type { FormState } from '@/lib/types/form'
 
 // ---------------------------------------------------------------------------
 // Shared field schemas


### PR DESCRIPTION
## What this does

Behavior-preserving cleanups that keep the starter an exemplary baseline (people copy these patterns), plus one layer-boundary fix. Nothing here changes runtime behavior — it's pedagogy and hygiene.

- **Dead code**: drop the unused `platform`/`isWindows`/`isMacOS`/`isLinux` re-exports from `lib/scripts/utils.ts`; inline `process.platform` where it's actually used.
- **Cross-domain import**: `optimistic-utils.ts` used a `isEmptyArray()` helper from the strings module for `updatedLines` — now just `updatedLines.length === 0`.
- **Leaked logic**: the Mailchimp *contact-form* note copy was hard-coded inside the general Mailchimp client; it now lives in the calling action, and the client takes an optional `note?`.
- **Dedup**: `updateItemQuantity` and `removeItem` shared ~20 lines of lineId resolution — extracted to `resolveLineId()`.
- **Boundary (#237)**: `lib/utils/validation.ts` imported `FormState` *up* from `components/ui/form` — an inverted layer. `FormState` now lives in `lib/types/form.ts`; the component file re-exports it, so nothing downstream changed.

## Deferred (with reasons)

- **#241.3 — remove `getClientIP`**: not actually dead. It has two production callers (`proxy.ts`, `app/api/revalidate/route.ts`) using `getClientIP(request)` as a Request-level convenience over `getIPFromHeaders(request.headers)`. The issue's "no callers" premise was inaccurate, so it's left in place.
- **#241.5 — `usePointerVelocity` dedup**: the fluid and flowmap pointer paths are *not* near-identical — fluid uses raw deltas (`×5`, no `dt`) with an abs-movement guard + `addSplat`; flowmap uses dt-clamped *normalized* velocity (`delta/dt`) plus a `moved` flag. A first extraction attempt also reset the persistent pointer ref across effect re-runs (caught by the Codex pass). Unifying these safely needs more care than a behavior-preserving PR should carry, so it's deferred rather than ship drift in a GPU-input path.

## Test Plan
- [x] `bun run build && bun run check` green (337 tests)
- [x] `bun run manifest:check` up to date

---

## Codex cross-review

Two `codex exec` passes (codex-cli 0.141.0). The first, on the full draft, caught a **real behavior drift** in the pointer-velocity dedup (the extracted hook reset pointer history on every effect re-run, where the originals persisted it in a ref) — which is why that item was reverted. The second pass, on the final diff, returned **no findings**: confirmed `copyToClipboard` branches identically, `isEmptyArray`→`length===0` equivalent, the Mailchimp action still sends the exact same note string, `resolveLineId` preserves the fast path/fallback/error strings, and the `FormState` move keeps every importer working. Verified the final diff contains no webgl/pointer changes.

Closes #237. Addresses #241 (5 of 7 items shipped; 2 deferred above).
