### PR TITLE
fix(webgl): stop full-screen canvas from intercepting DOM clicks

### DIFF
--- a/lib/webgl/components/canvas/webgl.tsx
+++ b/lib/webgl/components/canvas/webgl.tsx
@@ -55,7 +55,10 @@ export function WebGLCanvas({
         eventSource={document.documentElement}
         eventPrefix="client"
         resize={{ scroll: false, debounce: 500 }}
-        style={{ pointerEvents: 'all' }}
+        // Keep the fixed, full-screen canvas from swallowing DOM clicks. r3f
+        // still gets pointer events via `eventSource={document.documentElement}`,
+        // so 3D raycasting works while the DOM underneath stays interactive.
+        style={{ pointerEvents: 'none' }}
       >
         <SheetProvider id="webgl">
           <OrthographicCamera


### PR DESCRIPTION
## What this does

The WebGL canvas mounts full-screen and fixed over the entire page. On any project built on Satus, that canvas was sitting on top of the DOM and swallowing clicks — so buttons, links, and form submits silently did nothing. The handler never fired because the canvas ate the event first.

This makes the canvas transparent to clicks by default, so the DOM underneath stays interactive. 3D interaction is unaffected.

## Summary

- `lib/webgl/components/canvas/webgl.tsx`: the r3f `<Canvas>` carried an inline `style={{ pointerEvents: 'all' }}` that overrode the `.webgl` wrapper's `pointer-events: none`. Changed it to `'none'`.
- Safe because the canvas takes its events from the document, not itself: `eventSource={document.documentElement}`. r3f attaches its pointer listeners to `document.documentElement`, so raycasting/hover on 3D objects keep working even with the canvas element set to `pointer-events: none`. This is the canonical r3f "WebGL behind interactive DOM" setup.
- If a specific scene needs direct pointer capture (e.g. dragging a mesh), opt in on that surface rather than re-enabling `all` globally on the canvas.

## Test Plan

- [x] `biome check` clean
- [x] `tsc --noEmit` clean (pre-commit)
- [ ] Manual: a button/form rendered over the canvas now receives clicks
- [ ] Manual: existing 3D pointer interactions (hover/click on meshes) still fire