### PR TITLE
fix: harden starter defaults — cart errors, a11y, env validation, CI hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/lighthouse-to-slack.yml
+++ b/.github/workflows/lighthouse-to-slack.yml
@@ -15,6 +15,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   react-doctor:
     runs-on: ubuntu-latest

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import { type PropsWithChildren, Suspense } from 'react'
 import { ReactTempus } from 'tempus/react'
 import { Link } from '@/components/ui/link'
 import { RealViewport } from '@/components/ui/real-viewport'
+import { ToastProvider, ToastViewport } from '@/components/ui/toast'
 import { APP_BASE_URL, env } from '@/lib/env'
 import { OptionalFeatures } from '@/lib/features'
 import { isConfigured } from '@/lib/integrations/registry'
@@ -115,14 +116,17 @@ export default async function Layout({ children }: PropsWithChildren) {
         </Suspense>
         {/* Critical: CSS custom properties needed for layout */}
         <RealViewport>
-          <TransformProvider>
-            {/*
-              DO NOT add Header or Footer here.
-              They are included in the <Wrapper> component used by each page.
-              See: components/layout/wrapper/index.tsx
-            */}
-            {children}
-          </TransformProvider>
+          <ToastProvider>
+            <TransformProvider>
+              {/*
+                DO NOT add Header or Footer here.
+                They are included in the <Wrapper> component used by each page.
+                See: components/layout/wrapper/index.tsx
+              */}
+              {children}
+            </TransformProvider>
+            <ToastViewport />
+          </ToastProvider>
         </RealViewport>
         {/* Optional features - conditionally loaded based on configuration */}
         <OptionalFeatures />

--- a/components/ui/form/fields/fields.module.css
+++ b/components/ui/form/fields/fields.module.css
@@ -102,6 +102,9 @@
 }
 
 .option {
+  display: flex;
+  align-items: center;
+  gap: mobile-vw(8px);
   padding: mobile-vw(6px) mobile-vw(12px);
   border: 1px solid var(--color-secondary);
   border-radius: mobile-vw(4px);
@@ -115,6 +118,7 @@
     border-color 150ms ease;
 
   @media (--desktop) {
+    gap: desktop-vw(8px);
     padding: desktop-vw(6px) desktop-vw(12px);
     border-radius: desktop-vw(4px);
   }

--- a/components/ui/form/fields/index.tsx
+++ b/components/ui/form/fields/index.tsx
@@ -2,7 +2,8 @@
 
 import { Field } from '@base-ui/react/field'
 import cn from 'clsx'
-import { useState } from 'react'
+import { useId, useState } from 'react'
+import { Checkbox } from '@/components/ui/checkbox'
 import { useFormContext } from '..'
 import s from './fields.module.css'
 
@@ -170,6 +171,7 @@ export function CheckboxesField({
   const { actions } = useFormContext()
   const { register } = actions
   const [selected, setSelected] = useState<string[]>(['all'])
+  const hiddenInputId = useId()
 
   const handleToggle = (value: string) => {
     setSelected((prev) =>
@@ -185,20 +187,25 @@ export function CheckboxesField({
       <input
         type="hidden"
         name={name}
-        id="hidden"
+        id={hiddenInputId}
         value={JSON.stringify(selected)}
         {...reg}
       />
       <div className={s.options}>
-        {options.map(({ label, value }) => (
-          <button
+        {options.map(({ label: optionLabel, value }) => (
+          // biome-ignore lint/a11y/noLabelWithoutControl: Base UI checkbox is wrapped in label for accessibility
+          <label
             key={value}
             className={cn(s.option, selected.includes(value) && s.selected)}
-            type="button"
-            onClick={() => handleToggle(value)}
           >
-            <span>{label}</span>
-          </button>
+            <Checkbox.Root
+              checked={selected.includes(value)}
+              onCheckedChange={() => handleToggle(value)}
+            >
+              <Checkbox.Indicator />
+            </Checkbox.Root>
+            <span>{optionLabel}</span>
+          </label>
         ))}
       </div>
     </Field.Root>

--- a/components/ui/form/hook.test.tsx
+++ b/components/ui/form/hook.test.tsx
@@ -13,8 +13,9 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 import { cleanup, fireEvent, render } from '@testing-library/react'
 import { useEffect, useState } from 'react'
+import type { FormState } from '@/lib/types/form'
 import { useForm } from './hook'
-import type { FormState, UseFormReturn } from './types'
+import type { UseFormReturn } from './types'
 
 afterEach(cleanup)
 

--- a/components/ui/form/hook.ts
+++ b/components/ui/form/hook.ts
@@ -8,10 +8,10 @@ import {
   useTransition,
 } from 'react'
 import { emailSchema, phoneSchema, zodToValidator } from '@/utils/validation'
+import type { FormState } from '@/lib/types/form'
 import type {
   FieldError,
   FormAction,
-  FormState,
   UseFormOptions,
   UseFormReturn,
 } from './types'

--- a/components/ui/form/index.tsx
+++ b/components/ui/form/index.tsx
@@ -2,6 +2,7 @@
 
 import cn from 'clsx'
 import { createContext, use, useEffect, useState } from 'react'
+import type { FormState } from '@/lib/types/form'
 import { mutate } from '@/utils/raf'
 import s from './form.module.css'
 import { useForm } from './hook'
@@ -9,7 +10,6 @@ import type {
   FormAction,
   FormContextStandard,
   FormProps,
-  FormState,
   MessagesProps,
   SubmitButtonProps,
 } from './types'
@@ -230,13 +230,13 @@ export function Messages({ className, ...props }: MessagesProps) {
   )
 }
 
-export { useForm } from './hook'
 // Re-export types
+export type { FormState } from '@/lib/types/form'
+export { useForm } from './hook'
 export type {
   FormAction,
   FormContextActions,
   FormContextMeta,
   FormContextStandard,
   FormContextState,
-  FormState,
 } from './types'

--- a/components/ui/form/types.ts
+++ b/components/ui/form/types.ts
@@ -1,9 +1,6 @@
 import type { ComponentPropsWithoutRef, ReactNode } from 'react'
 import type { FormState } from '@/lib/types/form'
 
-// Re-export so existing component-layer imports keep working
-export type { FormState }
-
 // Server action type
 export type FormAction<T = unknown> = (
   prevState: FormState<T> | null,

--- a/components/ui/image/index.tsx
+++ b/components/ui/image/index.tsx
@@ -73,8 +73,8 @@ export type ImageProps = Omit<
   desktopSize?: `${number}vw`
   /** Ref for accessing the underlying img element */
   ref?: Ref<HTMLImageElement>
-  /** Alt text for accessibility (required for meaningful images) */
-  alt?: string
+  /** Alt text for accessibility. Required — pass `alt=""` explicitly for decorative images. */
+  alt: string
 } & ImageSizingProps
 
 // Base64 encoding for blur placeholders (works in browser and Node.js)
@@ -214,7 +214,7 @@ export function Image({
   loading,
   objectFit = 'cover',
   quality = 90,
-  alt = '',
+  alt,
   fill,
   block = !fill,
   width,

--- a/components/ui/sanity-image/index.tsx
+++ b/components/ui/sanity-image/index.tsx
@@ -15,7 +15,7 @@ import { urlForImage } from '@/integrations/sanity/utils/image'
 interface SanityImageProps
   extends Omit<
     ImageProps,
-    'src' | 'aspectRatio' | 'fill' | 'width' | 'height'
+    'src' | 'aspectRatio' | 'fill' | 'width' | 'height' | 'alt'
   > {
   image: {
     asset?: {
@@ -27,6 +27,8 @@ interface SanityImageProps
     crop?: SanityImageCrop
   }
   maxWidth?: number
+  /** Alt text override. Falls back to the CMS-provided `image.alt`, then `''`. */
+  alt?: string
 }
 
 export function SanityImage({

--- a/components/ui/select/index.tsx
+++ b/components/ui/select/index.tsx
@@ -122,10 +122,10 @@ function Select<T extends string = string>({
       {...(required !== undefined && { required })}
     >
       {label && (
-        <span className={s.label}>
+        <BaseSelect.Label className={s.label}>
           {label}
           {required && <span aria-hidden="true"> *</span>}
-        </span>
+        </BaseSelect.Label>
       )}
       <BaseSelect.Trigger
         className={cn(

--- a/components/ui/toast/index.tsx
+++ b/components/ui/toast/index.tsx
@@ -8,14 +8,18 @@ import s from './toast.module.css'
 /**
  * Toast component built on Base UI for accessible notifications.
  *
- * @example
- * ```tsx
- * // Wrap your app with ToastProvider
- * <Toast.Provider>
- *   <App />
- *   <Toast.Viewport />
- * </Toast.Provider>
- * ```
+ * `ToastProvider` and `ToastViewport` are mounted app-wide in
+ * `app/layout.tsx` — call `useToast()` from any client component.
+ *
+ * `app/layout.tsx` is a Server Component, so it must import `ToastProvider`
+ * / `ToastViewport` as direct named exports rather than through the `Toast`
+ * compound object below — property access on a plain object exported from a
+ * `'use client'` module (`Toast.Provider`) isn't given a client reference by
+ * Next's RSC/Turbopack transform (only top-level export bindings are), so it
+ * resolves to `undefined` across the server → client boundary. The `Toast.*`
+ * compound object remains safe to use for `Toast.Root` / `Toast.Title` /
+ * etc., since those are only ever consumed from within other client
+ * components (e.g. inside `Viewport` here), never from a Server Component.
  *
  * @example
  * ```tsx
@@ -98,10 +102,23 @@ type ViewportProps = ComponentProps<typeof BaseToast.Viewport> & {
   className?: string
 }
 
-function Viewport({ className, ...props }: ViewportProps) {
+// Renders the toast list itself when given no children — Base UI's Viewport
+// displays nothing without a toasts.map(<Toast.Root>) child.
+function Viewport({ className, children, ...props }: ViewportProps) {
+  const { toasts } = BaseToast.useToastManager()
+
   return (
     <BaseToast.Portal>
-      <BaseToast.Viewport className={cn(s.viewport, className)} {...props} />
+      <BaseToast.Viewport className={cn(s.viewport, className)} {...props}>
+        {children ??
+          toasts.map((toastObject) => (
+            <Root key={toastObject.id} toast={toastObject}>
+              <Title />
+              <Description />
+              <Close aria-label="Dismiss notification">&times;</Close>
+            </Root>
+          ))}
+      </BaseToast.Viewport>
     </BaseToast.Portal>
   )
 }
@@ -145,3 +162,6 @@ export const Toast = {
   Description,
   Close,
 }
+
+// Direct named exports for consumption from Server Components (see note above).
+export { Provider as ToastProvider, Viewport as ToastViewport }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -24,6 +24,18 @@ const envSchema = z.object({
   // Sanity (supports both Satus and Vercel Marketplace conventions)
   NEXT_PUBLIC_SANITY_PROJECT_ID: z.string().optional(),
   NEXT_PUBLIC_SANITY_DATASET: z.string().optional(),
+  // Sanity API version (YYYY-MM-DD) — validated here so a malformed value
+  // fails loudly at startup instead of silently falling back to the
+  // hardcoded default in lib/integrations/sanity/env.ts. NOTE: this schema
+  // key is not currently consumed by sanity/env.ts, which reads
+  // process.env.NEXT_PUBLIC_SANITY_API_VERSION directly to stay client-bundle-safe
+  // for the Sanity Studio route (see sanity/env.ts for the caveat).
+  NEXT_PUBLIC_SANITY_API_VERSION: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, {
+      error: 'NEXT_PUBLIC_SANITY_API_VERSION must be in YYYY-MM-DD format',
+    })
+    .optional(),
   // Public read token; NEXT_PUBLIC_ variant supports Vercel Marketplace installs
   NEXT_PUBLIC_SANITY_API_READ_TOKEN: z.string().optional(),
   // Server-side fallback read token (non-NEXT_PUBLIC_ variant for Vercel Marketplace)

--- a/lib/hooks/README.md
+++ b/lib/hooks/README.md
@@ -3,7 +3,7 @@
 Custom React hooks for common patterns.
 
 ```tsx
-import { useDeviceDetection } from '@/hooks'
+import { useDeviceDetection } from '@/hooks/use-device-detection'
 import { useMediaQuery } from 'hamo'
 ```
 
@@ -24,7 +24,7 @@ import { useMediaQuery } from 'hamo'
 Reveal children on scroll using IntersectionObserver. Toggles `data-reveal` on the container; children marked `data-reveal-item` animate `transform`/`opacity` on the compositor thread. The CSS contract lives in `lib/styles/css/global.css`. Per-container knobs: `--reveal-transform`, `--reveal-stagger`, `--reveal-duration`. Degrades to visible without JS; short-circuits under `prefers-reduced-motion`.
 
 ```tsx
-import { useReveal } from '@/hooks'
+import { useReveal } from '@/hooks/use-reveal'
 
 function Cards({ items }) {
   const ref = useReveal<HTMLDivElement>()
@@ -45,7 +45,7 @@ These hooks use `useSyncExternalStore` for concurrent-rendering safety and optim
 Subscribe to CSS media queries with automatic updates:
 
 ```tsx
-import { useMediaQuery } from '@/hooks'
+import { useMediaQuery } from 'hamo'
 
 function ResponsiveComponent() {
   const isDesktop = useMediaQuery('(min-width: 800px)')
@@ -60,7 +60,7 @@ function ResponsiveComponent() {
 Detect network connectivity:
 
 ```tsx
-import { useOnlineStatus } from '@/hooks'
+import { useOnlineStatus } from '@/hooks/use-sync-external'
 
 function NetworkAwareComponent() {
   const isOnline = useOnlineStatus()
@@ -78,7 +78,7 @@ function NetworkAwareComponent() {
 Get system color scheme preference:
 
 ```tsx
-import { usePreferredColorScheme } from '@/hooks'
+import { usePreferredColorScheme } from '@/hooks/use-sync-external'
 
 function ThemeProvider({ children }) {
   const colorScheme = usePreferredColorScheme() // 'light' | 'dark'
@@ -92,7 +92,7 @@ function ThemeProvider({ children }) {
 Respect user's motion preferences for accessibility:
 
 ```tsx
-import { usePreferredReducedMotion } from '@/hooks'
+import { usePreferredReducedMotion } from '@/hooks/use-sync-external'
 
 function AnimatedComponent() {
   const prefersReducedMotion = usePreferredReducedMotion()
@@ -114,7 +114,7 @@ function AnimatedComponent() {
 React to tab visibility changes:
 
 ```tsx
-import { useDocumentVisibility } from '@/hooks'
+import { useDocumentVisibility } from '@/hooks/use-sync-external'
 
 function VideoPlayer() {
   const visibility = useDocumentVisibility() // 'visible' | 'hidden'
@@ -144,7 +144,7 @@ Detect device capabilities (SSR-safe): screen size, input method, motion
 preference, WebGL support, Safari, and inline-video autoplay support.
 
 ```tsx
-import { useDeviceDetection } from '@/hooks'
+import { useDeviceDetection } from '@/hooks/use-device-detection'
 
 function Component() {
   const { isMobile, isDesktop, isReducedMotion, isTouchOnly, dpr, isWebGL, isSafari, isAutoplaySupported } =

--- a/lib/integrations/sanity/env.ts
+++ b/lib/integrations/sanity/env.ts
@@ -6,7 +6,19 @@
  * if Sanity is properly set up before making API calls.
  */
 
-/** Sanity API version - pinned for stability, update periodically */
+/**
+ * Sanity API version - pinned for stability, update periodically.
+ *
+ * Deliberately reads `process.env.NEXT_PUBLIC_SANITY_API_VERSION` directly
+ * (not via `env` from `@/lib/env`) — this module is bundled client-side
+ * through `sanity.config.ts` -> `app/studio/[[...tool]]/page.tsx` (a
+ * `'use client'` file with no client-boundary component in between), and
+ * `lib/env.ts` parses the whole `process.env` object rather than individual
+ * literal `process.env.NEXT_PUBLIC_X` expressions, so it isn't safe to
+ * import into code that reaches the client bundle. The value IS still
+ * validated (format: YYYY-MM-DD) via the schema in `lib/env.ts` wherever
+ * `env` is imported server-side, so a malformed value fails loudly there.
+ */
 export const apiVersion =
   process.env.NEXT_PUBLIC_SANITY_API_VERSION ?? '2025-03-01'
 

--- a/lib/integrations/sanity/live/index.tsx
+++ b/lib/integrations/sanity/live/index.tsx
@@ -13,10 +13,17 @@ import { privateToken, publicToken } from '../env'
  *
  * When Sanity is not configured, provides stub implementation
  * that returns null instead of throwing errors.
+ *
+ * Live/draft mode additionally requires a non-empty private token —
+ * without it, `defineLive` would silently no-op or error deep inside
+ * next-sanity rather than failing clearly. This gate only affects the
+ * live/draft capability; published-content fetching via `client` does
+ * not depend on `privateToken` and is unaffected.
  */
 const sanityReady = isConfigured('sanity') && client
+const sanityLiveReady = sanityReady && privateToken !== ''
 
-const liveExports = sanityReady
+const liveExports = sanityLiveReady
   ? defineLive({
       client: client!,
       browserToken: publicToken,

--- a/lib/integrations/shopify/cart/add-to-cart/add-to-cart.module.css
+++ b/lib/integrations/shopify/cart/add-to-cart/add-to-cart.module.css
@@ -9,3 +9,7 @@
   cursor: not-allowed;
   transition: 300ms opacity var(--ease-gleasing);
 }
+
+.actionError {
+  color: #dc2626;
+}

--- a/lib/integrations/shopify/cart/add-to-cart/index.tsx
+++ b/lib/integrations/shopify/cart/add-to-cart/index.tsx
@@ -2,7 +2,8 @@
 
 import cn from 'clsx'
 import { useRouter } from 'next/navigation'
-import { startTransition } from 'react'
+import { startTransition, useState } from 'react'
+import { formatMoney } from '@/integrations/shopify/money'
 import type { Product, ProductVariant } from '@/integrations/shopify/types'
 import { addItem } from '../actions'
 import { useCartContext } from '../cart-context'
@@ -26,11 +27,14 @@ export function AddToCart({
   const { addCartItem } = actions
   const { openCart } = useCartModal()
   const router = useRouter()
+  const [error, setError] = useState<string | null>(null)
 
   let buttonState = 'Coming Soon'
 
   if (variant) {
-    buttonState = `ADD TO CART — $${Number(variant?.price?.amount).toFixed(2)}`
+    buttonState = variant.price
+      ? `ADD TO CART — ${formatMoney(variant.price)}`
+      : 'ADD TO CART'
   } else if (product?.availableForSale) {
     buttonState = 'Select a size'
   }
@@ -41,10 +45,12 @@ export function AddToCart({
       openCart()
     })
 
-    await addItem(null, {
+    const result = await addItem(null, {
       variantId: variant?.id || '',
       quantity,
     })
+
+    setError(result.ok ? null : result.error)
 
     // Refresh the router to sync server state with optimistic state
     router.refresh()
@@ -60,6 +66,11 @@ export function AddToCart({
       >
         {buttonState}
       </button>
+      {error && (
+        <p role="status" aria-live="polite" className={cn('p1', s.actionError)}>
+          {error}
+        </p>
+      )}
     </form>
   )
 }

--- a/lib/integrations/shopify/cart/modal/index.tsx
+++ b/lib/integrations/shopify/cart/modal/index.tsx
@@ -7,6 +7,7 @@ import { createContext, use, useState } from 'react'
 import { useFormStatus } from 'react-dom'
 import { Image } from '@/components/ui/image'
 import { Link } from '@/components/ui/link'
+import { formatMoney } from '@/integrations/shopify/money'
 import { removeItem, updateItemQuantity } from '../actions'
 import { useCartContext } from '../cart-store-context'
 import { quantityAction } from '../optimistic-utils'
@@ -153,7 +154,7 @@ function InnerCart() {
             />
 
             <p className={s.price}>
-              $ {Number(cost?.totalAmount?.amount).toFixed(2)}
+              {cost?.totalAmount ? formatMoney(cost.totalAmount) : ''}
             </p>
           </div>
         ))}
@@ -161,7 +162,11 @@ function InnerCart() {
       <div className={s.checkout}>
         <div className={s.top}>
           <p>sub total</p>
-          <p>$ {Number(cart?.cost?.subtotalAmount?.amount).toFixed(2)}</p>
+          <p>
+            {cart?.cost?.subtotalAmount
+              ? formatMoney(cart.cost.subtotalAmount)
+              : ''}
+          </p>
         </div>
         {cart?.checkoutUrl && (
           <Link className={s.action} href={cart.checkoutUrl}>
@@ -177,6 +182,7 @@ function Quantity({ className, payload }: QuantityProps) {
   const { actions } = useCartContext()
   const { updateCartItem } = actions
   const router = useRouter()
+  const [error, setError] = useState<string | null>(null)
 
   async function formAction(type: 'minus' | 'plus') {
     const updatePayload = {
@@ -185,7 +191,9 @@ function Quantity({ className, payload }: QuantityProps) {
     }
 
     updateCartItem(payload.merchandiseId, type)
-    await updateItemQuantity(null, updatePayload)
+    const result = await updateItemQuantity(null, updatePayload)
+
+    setError(result.ok ? null : result.error)
 
     // Refresh the router to sync server state with optimistic state
     router.refresh()
@@ -206,6 +214,11 @@ function Quantity({ className, payload }: QuantityProps) {
       >
         +
       </QuantityButton>
+      {error && (
+        <p role="status" aria-live="polite" className={cn('p1', s.actionError)}>
+          {error}
+        </p>
+      )}
     </div>
   )
 }
@@ -263,18 +276,28 @@ function RemoveButton({ merchandiseId, lineId, className }: RemoveButtonProps) {
   const { actions } = useCartContext()
   const { updateCartItem } = actions
   const router = useRouter()
+  const [error, setError] = useState<string | null>(null)
 
   async function formAction() {
     updateCartItem(merchandiseId, 'delete')
-    await removeItem(null, merchandiseId, lineId)
+    const result = await removeItem(null, merchandiseId, lineId)
+
+    setError(result.ok ? null : result.error)
 
     // Refresh the router to sync server state with optimistic state
     router.refresh()
   }
 
   return (
-    <form action={formAction} className={className}>
-      <RemoveSubmitButton />
-    </form>
+    <div className={className}>
+      <form action={formAction}>
+        <RemoveSubmitButton />
+      </form>
+      {error && (
+        <p role="status" aria-live="polite" className={cn('p1', s.actionError)}>
+          {error}
+        </p>
+      )}
+    </div>
   )
 }

--- a/lib/integrations/shopify/cart/modal/modal.module.css
+++ b/lib/integrations/shopify/cart/modal/modal.module.css
@@ -283,3 +283,7 @@
     }
   }
 }
+
+.actionError {
+  color: #dc2626;
+}

--- a/lib/integrations/shopify/client.ts
+++ b/lib/integrations/shopify/client.ts
@@ -72,6 +72,23 @@ export async function shopifyFetch<T = Record<string, unknown>>({
       ...(tags && { next: { tags } }),
     })
 
+    if (!result.ok) {
+      if (result.status === 401 || result.status === 403) {
+        throw new Error(
+          `Shopify Storefront API auth failed (${result.status}) — check SHOPIFY_STOREFRONT_ACCESS_TOKEN`
+        )
+      }
+      if (result.status === 429) {
+        const retryAfter = result.headers.get('Retry-After')
+        throw new Error(
+          `Shopify Storefront API rate limited (429)${retryAfter ? ` — retry after ${retryAfter}s` : ''}`
+        )
+      }
+      throw new Error(
+        `Shopify Storefront API request failed (${result.status} ${result.statusText})`
+      )
+    }
+
     const raw = await result.json()
     const envelope = parseApiResponse(
       shopifyEnvelopeSchema,

--- a/lib/integrations/shopify/money.ts
+++ b/lib/integrations/shopify/money.ts
@@ -1,0 +1,12 @@
+import type { Money } from './types'
+
+/**
+ * Format a Shopify `Money` object using its own `currencyCode`, instead of
+ * assuming `$` and two decimals. Locale defaults to the runtime's locale.
+ */
+export function formatMoney(money: Money, locale?: string): string {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: money.currencyCode,
+  }).format(Number(money.amount))
+}

--- a/lib/webgl/README.md
+++ b/lib/webgl/README.md
@@ -7,7 +7,7 @@ as GLSL3 `RawShaderMaterial` passes.
 ## Quick Start
 
 ```tsx
-import { Wrapper } from '@/components/layout'
+import { Wrapper } from '@/components/layout/wrapper'
 import { WebGLTunnel } from '@/webgl/components/tunnel'
 
 export default function Page() {

--- a/next.config.ts
+++ b/next.config.ts
@@ -23,6 +23,10 @@ const nextConfig: NextConfig = {
   reactCompiler: true,
   poweredByHeader: false,
   typedRoutes: true,
+  typescript: {
+    // Type checking is owned by `bun run check` (typescript7).
+    ignoreBuildErrors: true,
+  },
   turbopack: {
     rules: {
       '*.svg': {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "bun run setup:styles && next build",
     "start": "next start",
     "preview": "bun run build && next start",
+    "prepare": "lefthook install",
     "check": "biome check && bun node_modules/typescript7/bin/tsc --noEmit && bun test && bun run manifest:check",
     "clean": "rm -rf .next node_modules/.cache",
     "lint": "biome lint --max-diagnostics=200",


### PR DESCRIPTION
## What this does

Failed cart actions now tell the shopper what went wrong instead of silently doing nothing, prices render in the storefront's real currency instead of assuming dollars, and screen readers get real semantics from images, checkbox groups, and selects. Fresh clones also get working git hooks and toasts without any manual setup.

These came out of a low-effort/high-impact review pass over the starter — since every client project forks from here, each gap ships to every build.

## Summary

**Shopify (production-real)**
- `shopifyFetch` branches on HTTP status before parsing: 401/403 → clear token error, 429 → rate-limit error with `Retry-After`, other non-ok → status + statusText
- All three cart mutations (`addItem`, `updateItemQuantity`, `removeItem`) check their `CartActionResult` and render the error in a polite live region with error styling
- New `formatMoney()` (`Intl.NumberFormat` + `currencyCode`) replaces hardcoded `$`/`.toFixed(2)` at all price display sites

**Accessibility**
- `Image` `alt` prop is required — decorative images pass `alt=""` explicitly; `SanityImage` threads CMS alt data through
- `CheckboxesField` rebuilt on the Base UI `Checkbox` primitive (real `aria-checked`) with `useId()`-derived hidden-input ids (fixes duplicate `id="hidden"`)
- `Select`'s simple-API label uses `BaseSelect.Label`, which auto-associates with the trigger

**Toast**
- `ToastProvider`/`ToastViewport` mounted app-wide in the root layout; `Viewport` renders the toast list itself, so `useToast()` works out of the box (was: rendered nothing, audit M5)
- Direct named exports for the Server Component boundary — property access on the `Toast.*` compound object doesn't survive the RSC transform

**Sanity**
- Live/draft mode gated on a non-empty server token instead of half-working with empty strings
- `NEXT_PUBLIC_SANITY_API_VERSION` validated (date-shape regex) in `lib/env.ts`; the sanity-side read stays direct to keep private-token schemas out of the Studio client bundle

**Tooling / CI**
- `prepare: lefthook install` — hooks install on `bun install`
- `concurrency` + `cancel-in-progress` on all three workflows
- `typescript.ignoreBuildErrors` in `next.config.ts` — `bun run check` owns the typecheck; build no longer duplicates it
- `lib/hooks/README.md` and `lib/webgl/README.md` examples import from paths that actually resolve
- `FormState` imported from its source `@/lib/types/form` instead of a component-layer re-export (public re-export from `@/components/ui/form` preserved)

Known, not addressed here: Biome 2.5.4 emits a warning-level internal panic (`biome_module_graph` resolver) on `components/ui/form/hook.ts` — pre-existing, reproduces on pristine main, needs an upstream report.

## Test Plan
- [x] `bun run check` green — Biome 0 errors, tsc clean, 348/348 tests, manifest current
- [x] `bun run prepare` installs lefthook hooks (verified firing on post-checkout)
- [ ] Manual: cart error surfacing against a live storefront