### PR TITLE
chore: polish pass — loading shell, dead CSS, doc accuracy, CI caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,14 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('bun.lock') }}-${{ hashFiles('**/*.ts', '**/*.tsx') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('bun.lock') }}-
+
       # Build first: generates next-env.d.ts + .next/types (gitignored) that
       # tsc needs, and catches RSC/prerender regressions before deploy.
       - name: Build
@@ -47,10 +55,28 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: bunx playwright install --with-deps chromium
 
-      # playwright.config.ts boots the dev server itself (webServer), so no
-      # separate server step is needed here.
+      # playwright.config.ts boots the prod server itself in CI (webServer),
+      # so no separate server step is needed here.
       - name: Run e2e tests
         run: bun run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ import { useDeviceDetection } from '@/hooks/use-device-detection'
 import { clamp } from '@/utils/math'
 ```
 
-Available aliases: `@/*`, `@/components/*`, `@/lib/*`, `@/hooks/*`, `@/styles/*`, `@/integrations/*`, `@/webgl/*`, `@/utils/*`, `@/config`, `@/dev/*`.
+Named shortcut aliases: `@/hooks/*`, `@/styles/*`, `@/integrations/*`, `@/webgl/*`, `@/utils/*`, `@/config`, `@/dev`, `@/dev/*`. Everything else — including `@/components/*` and `@/lib/*` — resolves through the `@/*` root catch-all (`@/*` maps to the repo root in `tsconfig.json`, so e.g. `@/components/ui/link` resolves to `components/ui/link`).
 
 ---
 
@@ -268,28 +268,31 @@ across routes) or per page via `<Wrapper webgl>`. Pick one strategy.
 
 ```
 <Canvas root> (layout OR <Wrapper webgl>) -> WebGLTunnel.Out, DOMTunnel.Out
-Page -> WebGLTunnel.In (portals 3D content up into the root canvas)
+Page -> <WebGLTunnel> (portals 3D content up into the root canvas)
 ```
 
 ```tsx
 // DOM side
 'use client'
 import { useWebGLElement } from '@/webgl/hooks/use-webgl-element'
-import { useCanvas } from '@/webgl/components/canvas'
+import { WebGLTunnel } from '@/webgl/components/tunnel'
 
 function MyWebGLComponent({ className }: { className?: string }) {
   const { setRef, rect, isVisible } = useWebGLElement()
-  const { WebGLTunnel } = useCanvas()
   return (
-    <>
-      <div ref={setRef} className={className} />
-      <WebGLTunnel.In>
+    <div ref={setRef} className={className}>
+      <WebGLTunnel>
         <MyMesh rect={rect} visible={isVisible} />
-      </WebGLTunnel.In>
-    </>
+      </WebGLTunnel>
+    </div>
   )
 }
 ```
+
+`WebGLTunnel` (and `DOMTunnel`, for HTML overlays) already wrap `useCanvas()`
+internally — this is the intended public API. Reach for `useCanvas()` directly
+only as a low-level escape hatch, e.g. building a new portal primitive. See
+`lib/webgl/README.md`.
 
 Always dispose GPU resources (materials, textures, geometries, render targets) on unmount.
 
@@ -460,11 +463,17 @@ Pre-commit hook (lefthook) runs in parallel on staged files: Biome check + tsc t
 | `COMPONENTS.md` | Auto-generated component / hook / utility inventory |
 | `CHANGELOG.md` | Release history and versioning policy |
 | `SECURITY.md` | Security policy and vulnerability reporting |
+| `app/README.md` | App Router structure, page patterns, Wrapper props |
 | `components/README.md` | Component inventory and conventions |
+| `components/layout/README.md` | Header, footer, and page wrapper architecture |
+| `components/effects/README.md` | Animation component docs |
 | `lib/README.md` | Library structure overview |
 | `lib/integrations/README.md` | Per-integration docs (Sanity, Shopify, HubSpot) |
 | `lib/styles/README.md` | Design system and style generation |
-| `components/effects/README.md` | Animation component docs |
+| `lib/webgl/README.md` | WebGL/R3F architecture, tunnel system, device gating |
+| `lib/hooks/README.md` | Custom hook inventory |
+| `lib/dev/README.md` | Debug tools suite (Orchestra) |
+| `lib/features/README.md` | Optional feature loading for the root layout |
 
 ---
 

--- a/app/README.md
+++ b/app/README.md
@@ -43,7 +43,7 @@ export default function Page() {
 ```
 
 **Wrapper Props:**
-- `theme` — 'dark' | 'light' | 'red'
+- `theme` — 'dark' | 'light' | 'red' | 'evil'
 - `lenis` — Enable smooth scrolling
 - `webgl` — Enable WebGL canvas
 

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -2,6 +2,7 @@
 
 import { Wrapper } from '@/components/layout/wrapper'
 import { ErrorView } from '@/components/ui/error-view'
+import { Link } from '@/components/ui/link'
 
 interface ErrorPageProps {
   error: Error & { digest?: string }
@@ -11,7 +12,18 @@ interface ErrorPageProps {
 export default function ErrorPage({ error, reset }: ErrorPageProps) {
   return (
     <Wrapper theme="light" className="font-mono">
-      <ErrorView error={error} reset={reset} />
+      <ErrorView
+        error={error}
+        reset={reset}
+        homeLink={
+          <Link
+            href="/"
+            className="rounded border border-gray-300 px-6 py-3 transition-colors hover:bg-gray-50"
+          >
+            Go Home
+          </Link>
+        }
+      />
     </Wrapper>
   )
 }

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,7 +1,11 @@
+import { Wrapper } from '@/components/layout/wrapper'
+
 export default function Loading() {
   return (
-    <div className="flex min-h-screen items-center justify-center font-mono uppercase">
-      <p>Cooking...</p>
-    </div>
+    <Wrapper className="font-mono">
+      <div className="my-auto flex flex-col items-center justify-center uppercase">
+        <p>Cooking...</p>
+      </div>
+    </Wrapper>
   )
 }

--- a/components/layout/header/header.module.css
+++ b/components/layout/header/header.module.css
@@ -33,12 +33,6 @@
   white-space: nowrap;
 }
 
-.nav {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-}
-
 .navItem {
   display: flex;
   align-items: center;
@@ -77,30 +71,6 @@
 
 .navLinkDim {
   opacity: 0.5;
-}
-
-/* Examples sub-group */
-.examplesGroup {
-  display: flex;
-  flex-direction: column;
-}
-
-.examplesLabel {
-  display: flex;
-  align-items: center;
-  gap: 0.3em;
-}
-
-.examplesList {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  padding-left: calc((12 * 100) / var(--device-width) * 1vw);
-  margin-top: 1px;
-  overflow: hidden;
-  transition:
-    opacity var(--duration-fast) var(--ease-out-expo),
-    transform var(--duration-fast) var(--ease-out-expo);
 }
 
 /* Mobile menu toggle button — only shown on mobile */
@@ -146,14 +116,6 @@
 /* Mobile touch targets — bump up link height */
 @media (--mobile) {
   .navItem {
-    min-height: 44px;
-  }
-
-  .examplesLabel {
-    min-height: 44px;
-  }
-
-  .examplesGroup .navItem {
     min-height: 44px;
   }
 }

--- a/components/layout/wrapper/index.tsx
+++ b/components/layout/wrapper/index.tsx
@@ -21,7 +21,7 @@ import { Canvas } from '@/webgl/components/canvas'
  * Props for the Wrapper component.
  */
 interface WrapperProps extends React.HTMLAttributes<HTMLDivElement> {
-  /** Theme to apply ('dark' | 'light' | 'red'). Defaults to 'dark'. */
+  /** Theme to apply ('dark' | 'light' | 'red' | 'evil'). Defaults to 'dark'. */
   theme?: ThemeName
   /** Enable smooth scrolling. Can be boolean or Lenis configuration object. Defaults to true. */
   lenis?: boolean | LenisOptions

--- a/components/ui/error-view/index.tsx
+++ b/components/ui/error-view/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { ReactNode } from 'react'
 import { useEffect } from 'react'
 
 interface ErrorViewProps {
@@ -7,7 +8,24 @@ interface ErrorViewProps {
   reset: () => void
   title?: string
   description?: string
+  /**
+   * Element rendered in place of the default "Go Home" anchor. Pass the
+   * project's `Link` (from '@/components/ui/link') when rendering inside the
+   * router (e.g. app/error.tsx). Defaults to a raw `<a>`, which is required
+   * in app/global-error.tsx since it renders outside the router.
+   */
+  homeLink?: ReactNode
 }
+
+const DEFAULT_HOME_LINK = (
+  // biome-ignore lint: global-error renders outside the router, so the Link component cannot be used here
+  <a
+    href="/"
+    className="rounded border border-gray-300 px-6 py-3 transition-colors hover:bg-gray-50"
+  >
+    Go Home
+  </a>
+)
 
 /**
  * Shared error boundary view used by both app/error.tsx and app/global-error.tsx.
@@ -21,6 +39,7 @@ export function ErrorView({
   reset,
   title = 'Something went wrong',
   description = "We're sorry, but something unexpected happened. Please try again.",
+  homeLink = DEFAULT_HOME_LINK,
 }: ErrorViewProps) {
   useEffect(() => {
     console.error('Error boundary caught:', error)
@@ -52,13 +71,7 @@ export function ErrorView({
         >
           Try Again
         </button>
-        {/* biome-ignore lint: global-error renders outside the router, so the Link component cannot be used here */}
-        <a
-          href="/"
-          className="rounded border border-gray-300 px-6 py-3 transition-colors hover:bg-gray-50"
-        >
-          Go Home
-        </a>
+        {homeLink}
       </div>
     </div>
   )

--- a/lib/integrations/shopify/cart/optimistic-utils.ts
+++ b/lib/integrations/shopify/cart/optimistic-utils.ts
@@ -174,6 +174,8 @@ function createOrUpdateCartItem(
   }
 }
 
+// Cosmetic only — drives the optimistic UI flash; Shopify's server response
+// is authoritative. Never use these totals for checkout math.
 function calculateItemCost(quantity: number, price: string): string {
   return (Number(price) * quantity).toString()
 }

--- a/lib/integrations/shopify/constants.ts
+++ b/lib/integrations/shopify/constants.ts
@@ -47,4 +47,8 @@ export const TAGS = {
 } as const
 
 export const HIDDEN_PRODUCT_TAG = 'nextjs-frontend-hidden'
+/**
+ * Storefront API version — quarterly releases, ~12-month support window.
+ * Check https://shopify.dev/docs/api/usage/versioning before bumping.
+ */
 export const SHOPIFY_GRAPHQL_API_ENDPOINT = '/api/2026-04/graphql.json'

--- a/lib/integrations/shopify/pages.ts
+++ b/lib/integrations/shopify/pages.ts
@@ -25,6 +25,13 @@ interface MenuItem {
  * connected custom domain, or otherwise) or already-relative paths. Parsing
  * as a URL and taking `pathname + search` handles all absolute cases
  * regardless of host; invalid/relative URLs pass through unchanged.
+ *
+ * The extracted path is then remapped onto this starter's route naming:
+ * `/collections` -> `/search` (this app's collection/product browse route
+ * is `/search`, not `/collections`), and the `/pages` prefix is stripped
+ * (Shopify's static "pages" content is served at the site root here, e.g.
+ * `/pages/about` -> `/about`). These remaps are Shopify-menu-specific and
+ * only apply to `path`, not the original `url`.
  */
 function menuItemPath(url: string): string {
   let path: string

--- a/lib/styles/README.md
+++ b/lib/styles/README.md
@@ -102,8 +102,8 @@ in the hand-authored `css/easings.css`. Key families:
   semantic tokens — never hard-code a hex in a component.
 - **Easing** — `--ease-out-expo`, `--ease-in-out-cubic`, `--ease-gleasing`, … are
   defined in `css/easings.css` as a hand-authored `@theme` block (static
-  cubic-bezier strings, no generation needed). This eliminates the duplicate
-  declarations that previously appeared in both `root.css` and `tailwind.css`.
+  cubic-bezier strings, no generation needed). Easing tokens live only in
+  `css/easings.css` — no `@theme` duplication in `css/tailwind.css`.
 - **Layout** — `--gap`, `--device-width`, and the column grid that powers
   `columns()` and `dr-*-col-*`.
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,8 +6,11 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   reporter: 'list',
+  retries: process.env.CI ? 1 : 0,
   use: {
     baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
   },
   projects: [
     {
@@ -19,9 +22,11 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'bun run dev',
+    // Dev server never exercises prod-only next.config.ts flags (e.g.
+    // cacheComponents), so CI runs against a real production build.
+    command: process.env.CI ? 'bun run build && bun run start' : 'bun run dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
+    timeout: process.env.CI ? 300_000 : 120_000,
   },
 })


### PR DESCRIPTION
## What this does

Loading states keep the site shell instead of flashing a bare screen, the docs an agent reads first now match what the code actually exports, and CI gets faster (caching) and more debuggable (failure traces) while e2e finally tests the production build.

Stacked on #285 — the remaining "later tier" items from the same review pass.

## Summary

**App/components**
- `app/loading.tsx` wraps in `Wrapper` like every other boundary page (also removes the `min-h-screen` house-style violation)
- `ErrorView` gains an optional `homeLink` prop: `app/error.tsx` (inside the router) passes the project `Link`; `global-error.tsx` keeps the default raw `<a>` it actually needs
- Dead `.nav`/`.examples*` blocks removed from `header.module.css` (zero references, confirmed incl. dynamic access)

**Docs**
- AGENTS.md WebGL Pattern 6 teaches the exported `WebGLTunnel` component; `useCanvas()` demoted to escape hatch
- AGENTS.md documentation map lists all six missing per-directory READMEs; alias list now matches `tsconfig.json`
- `theme` docstrings include the fourth theme (`evil`) in wrapper JSDoc + `app/README.md`
- Shopify Storefront API version pin gets an update-cue comment; `menuItemPath()` documents its `/collections`→`/search` and `/pages` remaps; optimistic cart math marked display-only
- `lib/styles/README.md` history note rewritten as present-tense fact

**CI / e2e**
- `actions/cache` for `.next/cache` and `~/.cache/ms-playwright` (browser install skipped on cache hit)
- e2e runs `build && start` in CI so `cacheComponents` and friends are actually exercised; dev server locally
- `trace: on-first-retry`, `screenshot: only-on-failure`, 1 CI retry, and failure-only artifact upload (7-day retention)

## Test Plan
- [x] `bun run check` green — 0 errors, 348/348 tests, manifest current
- [x] `ci.yml` parses (js-yaml)
- [ ] CI run on this PR proves the cache + prod-build e2e path