### PR TITLE
refactor: author all colors in oklch, mix in oklab

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -5,6 +5,8 @@ import { create } from 'storybook/theming'
 // lib/styles/colors.ts (red #e30613, dark = black/white) and --line from
 // global.css. The story canvas tracks the site's CSS tokens live; this manager
 // chrome is build-time JS, so update it here if the brand palette changes.
+// These values intentionally stay hex/rgba: storybook/theming's `create()` runs
+// them through polished, which cannot parse oklch and would crash the manager UI.
 const satus = create({
   base: 'dark',
   brandTitle: 'Satūs',

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -419,6 +419,15 @@ Tailwind v4 conventions:
 - Container queries are built-in (no plugin)
 - Opacity via slash syntax: `bg-black/50`
 
+### Colors: always oklch (oklab for interpolation)
+
+ALL color values are authored in `oklch()` — palette entries in `lib/styles/colors.ts`, CSS module values, inline style strings, SVG fills. No hex, `rgb()`, or `hsl()` literals. Alpha uses slash syntax: `oklch(0 0 0 / 0.5)`, never `rgba()`.
+
+- Palette source of truth is `lib/styles/colors.ts`; the theme CSS is generated from it by `bun run setup:styles`. Never hand-edit `lib/styles/css/tailwind.css` / `root.css`.
+- All color mixing happens in `oklab`: `color-mix(in oklab, ...)` always (never `in srgb`), and gradients that blend across hues take an interpolation hint (`linear-gradient(to top in oklab, ...)`). Hard-stop gradients (adjacent stops at the same position) don't need one. Any future JS color-mixing utility must mix in OKLab/OKLCH and return oklch strings.
+- CSS keywords (`transparent`, `currentColor`, system colors) remain fine.
+- Sanctioned exceptions, each for a non-CSS parser or spec that cannot use oklch: `.storybook/manager.ts` (storybook/theming → polished), GLSL in `lib/webgl/` (shader math is linear RGB, not CSS — and the blend modes in `lib/webgl/utils/blend.ts` are ports of the compositing spec's sRGB/HSL definitions, so rewriting them in OKLab would change standard blend-mode output). Anything new that must stay non-oklch needs a comment stating which parser or spec forces it.
+
 ---
 
 ## Integrations

--- a/components/ui/alert-dialog/alert-dialog.module.css
+++ b/components/ui/alert-dialog/alert-dialog.module.css
@@ -1,7 +1,7 @@
 .backdrop {
   position: fixed;
   inset: 0;
-  background-color: rgba(0 0 0 / 0.5);
+  background-color: oklch(0 0 0 / 0.5);
   z-index: 100;
   backdrop-filter: blur(2px);
 
@@ -27,7 +27,7 @@
   padding: mobile-vw(24px);
   max-width: min(400px, 90vw);
   width: 100%;
-  box-shadow: 0 8px 32px rgba(0 0 0 / 0.2);
+  box-shadow: 0 8px 32px oklch(0 0 0 / 0.2);
 
   /* Base UI animation states */
   transition:
@@ -126,6 +126,6 @@
   }
 
   &.destructive {
-    background-color: #dc2626;
+    background-color: oklch(0.577 0.2152 27.33);
   }
 }

--- a/components/ui/form/fields/fields.module.css
+++ b/components/ui/form/fields/fields.module.css
@@ -10,7 +10,7 @@
   &.error {
     .input,
     .textarea {
-      border-color: #dc2626;
+      border-color: oklch(0.577 0.2152 27.33);
     }
   }
 
@@ -68,7 +68,7 @@
 
 .errorMessage {
   font-size: 0.75rem;
-  color: #dc2626;
+  color: oklch(0.577 0.2152 27.33);
   margin-top: mobile-vw(2px);
 
   @media (--desktop) {

--- a/components/ui/form/form.module.css
+++ b/components/ui/form/form.module.css
@@ -9,7 +9,7 @@
   &.disabled {
     pointer-events: none;
     background-color: var(--color-secondary);
-    color: rgba(0, 0, 0, 0.25);
+    color: oklch(0 0 0 / 0.25);
     opacity: 0.5;
   }
 

--- a/components/ui/form/hook.ts
+++ b/components/ui/form/hook.ts
@@ -7,8 +7,8 @@ import {
   useState,
   useTransition,
 } from 'react'
-import { emailSchema, phoneSchema, zodToValidator } from '@/utils/validation'
 import type { FormState } from '@/lib/types/form'
+import { emailSchema, phoneSchema, zodToValidator } from '@/utils/validation'
 import type {
   FieldError,
   FormAction,

--- a/components/ui/image/index.tsx
+++ b/components/ui/image/index.tsx
@@ -90,12 +90,12 @@ function generateShimmer(w: number, h: number): string {
   <svg width="${w}" height="${h}" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <defs>
       <linearGradient id="g">
-        <stop stop-color="rgba(255,255,255,0.1)" offset="20%" />
-        <stop stop-color="rgba(255,255,255,0.2)" offset="50%" />
-        <stop stop-color="rgba(255,255,255,0.1)" offset="70%" />
+        <stop stop-color="oklch(1 0 0 / 0.1)" offset="20%" />
+        <stop stop-color="oklch(1 0 0 / 0.2)" offset="50%" />
+        <stop stop-color="oklch(1 0 0 / 0.1)" offset="70%" />
       </linearGradient>
     </defs>
-    <rect width="${w}" height="${h}" fill="rgba(0,0,0,0)" />
+    <rect width="${w}" height="${h}" fill="oklch(0 0 0 / 0)" />
     <rect id="r" width="${w}" height="${h}" fill="url(#g)" />
     <animate xlink:href="#r" attributeName="x" from="-${w}" to="${w}" dur="1s" repeatCount="indefinite"  />
   </svg>`

--- a/components/ui/select/select.module.css
+++ b/components/ui/select/select.module.css
@@ -11,7 +11,7 @@
 }
 
 .trigger {
-  box-shadow: 0 1px 2px rgba(0 0 0 / 0.1);
+  box-shadow: 0 1px 2px oklch(0 0 0 / 0.1);
   display: flex;
   align-items: center;
   background-color: var(--color-primary);
@@ -39,7 +39,7 @@
   border: 1px solid var(--color-secondary);
   border-radius: mobile-vw(4px);
   padding: mobile-vw(4px);
-  box-shadow: 0 4px 12px rgba(0 0 0 / 0.15);
+  box-shadow: 0 4px 12px oklch(0 0 0 / 0.15);
   outline: none;
   z-index: 50;
   max-height: 300px;

--- a/components/ui/switch/switch.module.css
+++ b/components/ui/switch/switch.module.css
@@ -60,7 +60,7 @@
   background-color: var(--color-primary);
   border-radius: 50%;
   transition: transform 150ms ease;
-  box-shadow: 0 1px 3px rgba(0 0 0 / 0.2);
+  box-shadow: 0 1px 3px oklch(0 0 0 / 0.2);
 
   @media (--desktop) {
     width: desktop-vw(20px);

--- a/components/ui/toast/toast.module.css
+++ b/components/ui/toast/toast.module.css
@@ -23,7 +23,7 @@
   background-color: var(--color-primary);
   border: 1px solid var(--color-secondary);
   border-radius: mobile-vw(8px);
-  box-shadow: 0 4px 12px rgba(0 0 0 / 0.15);
+  box-shadow: 0 4px 12px oklch(0 0 0 / 0.15);
   position: relative;
 
   /* Base UI animation states */
@@ -51,15 +51,15 @@
 
   /* Toast types */
   &.success {
-    border-left: 4px solid #22c55e;
+    border-left: 4px solid oklch(0.7227 0.192 149.58);
   }
 
   &.error {
-    border-left: 4px solid #dc2626;
+    border-left: 4px solid oklch(0.577 0.2152 27.33);
   }
 
   &.info {
-    border-left: 4px solid #3b82f6;
+    border-left: 4px solid oklch(0.6231 0.188 259.81);
   }
 
   &.default {

--- a/components/ui/tooltip/tooltip.module.css
+++ b/components/ui/tooltip/tooltip.module.css
@@ -6,7 +6,7 @@
   font-size: 0.875rem;
   max-width: 280px;
   z-index: 100;
-  box-shadow: 0 2px 8px rgba(0 0 0 / 0.15);
+  box-shadow: 0 2px 8px oklch(0 0 0 / 0.15);
 
   /* Base UI animation states */
   transform-origin: var(--transform-origin);

--- a/lib/dev/grid/grid.module.css
+++ b/lib/dev/grid/grid.module.css
@@ -1,8 +1,8 @@
 .debugger {
   background-image: linear-gradient(
     0deg,
-    rgba(0, 0, 0, 0.1) 50%,
-    rgba(247, 181, 68, 0.1) 50%
+    oklch(0 0 0 / 0.1) 50%,
+    oklch(0.8156 0.146 77.1 / 0.1) 50%
   );
   background-size: var(--gap) var(--gap);
 

--- a/lib/dev/toggle.tsx
+++ b/lib/dev/toggle.tsx
@@ -46,7 +46,7 @@ export function OrchestraToggle({
         Orchestra.setState((state) => ({ [id]: !state[id] }))
       }}
       style={{
-        backgroundColor: active ? 'rgba(0, 255, 0, 0.5)' : '',
+        backgroundColor: active ? 'oklch(0.8664 0.2948 142.5 / 0.5)' : '',
       }}
       className="grid size-20 place-items-center rounded-[8px] text-[64px]"
       title={id}

--- a/lib/integrations/hubspot/embed/form.module.css
+++ b/lib/integrations/hubspot/embed/form.module.css
@@ -1,5 +1,5 @@
 .hubspot-form {
-  --gray: rgba(0, 0, 0, 0.25);
+  --gray: oklch(0 0 0 / 0.25);
   padding: 0 mobile-vw(24px);
 
   @media (--desktop) {

--- a/lib/integrations/shopify/cart/add-to-cart/add-to-cart.module.css
+++ b/lib/integrations/shopify/cart/add-to-cart/add-to-cart.module.css
@@ -11,5 +11,5 @@
 }
 
 .actionError {
-  color: #dc2626;
+  color: oklch(0.577 0.2152 27.33);
 }

--- a/lib/integrations/shopify/cart/modal/modal.module.css
+++ b/lib/integrations/shopify/cart/modal/modal.module.css
@@ -25,7 +25,7 @@
   width: 100%;
   height: 100%;
   transition: 500ms opacity var(--ease-gleasing);
-  background: rgba(0, 0, 0, 0.7);
+  background: oklch(0 0 0 / 0.7);
 }
 
 .inner {
@@ -231,9 +231,9 @@
     position: absolute;
     top: desktop-vw(-50px);
     background: linear-gradient(
-      0deg,
-      rgba(0, 0, 0, 1) 55%,
-      rgba(12, 0, 36, 0) 100%
+      0deg in oklab,
+      oklch(0 0 0) 55%,
+      oklch(0.1375 0.0763 293.26 / 0) 100%
     );
     pointer-events: none;
 
@@ -285,5 +285,5 @@
 }
 
 .actionError {
-  color: #dc2626;
+  color: oklch(0.577 0.2152 27.33);
 }

--- a/lib/styles/colors.ts
+++ b/lib/styles/colors.ts
@@ -1,11 +1,11 @@
 const colors = {
-  black: '#000000',
-  white: '#ffffff',
-  red: '#e30613',
-  blue: '#0070f3',
-  green: '#00ff88',
-  purple: '#7928ca',
-  pink: '#ff0080',
+  black: 'oklch(0 0 0)',
+  white: 'oklch(1 0 0)',
+  red: 'oklch(0.577 0.2339 27.95)',
+  blue: 'oklch(0.5731 0.2145 258.25)',
+  green: 'oklch(0.8763 0.2278 152.55)',
+  purple: 'oklch(0.4907 0.2275 300.45)',
+  pink: 'oklch(0.6453 0.2603 2.47)',
 } as const
 
 const themeNames = ['light', 'dark', 'red', 'evil'] as const

--- a/lib/styles/css/global.css
+++ b/lib/styles/css/global.css
@@ -21,17 +21,17 @@ html {
  */
 :root {
   --surface: color-mix(
-    in srgb,
+    in oklab,
     var(--color-secondary) 4%,
     var(--color-primary)
   );
   --surface-2: color-mix(
-    in srgb,
+    in oklab,
     var(--color-secondary) 8%,
     var(--color-primary)
   );
-  --line: color-mix(in srgb, var(--color-secondary) 14%, transparent);
-  --line-strong: color-mix(in srgb, var(--color-secondary) 28%, transparent);
+  --line: color-mix(in oklab, var(--color-secondary) 14%, transparent);
+  --line-strong: color-mix(in oklab, var(--color-secondary) 28%, transparent);
 
   --duration-fast: 200ms;
   --duration: 400ms;

--- a/lib/styles/css/tailwind.css
+++ b/lib/styles/css/tailwind.css
@@ -9,16 +9,16 @@
 	--breakpoint-dt: 800px;
 
   --color-*: initial;
-	--color-primary: #ffffff;
-	--color-secondary: #000000;
-	--color-contrast: #e30613;
-  --color-black: #000000;
-	--color-white: #ffffff;
-	--color-red: #e30613;
-	--color-blue: #0070f3;
-	--color-green: #00ff88;
-	--color-purple: #7928ca;
-	--color-pink: #ff0080;
+	--color-primary: oklch(1 0 0);
+	--color-secondary: oklch(0 0 0);
+	--color-contrast: oklch(0.577 0.2339 27.95);
+  --color-black: oklch(0 0 0);
+	--color-white: oklch(1 0 0);
+	--color-red: oklch(0.577 0.2339 27.95);
+	--color-blue: oklch(0.5731 0.2145 258.25);
+	--color-green: oklch(0.8763 0.2278 152.55);
+	--color-purple: oklch(0.4907 0.2275 300.45);
+	--color-pink: oklch(0.6453 0.2603 2.47);
 
   --spacing-*: initial;
 	--spacing-0: 0;
@@ -33,24 +33,24 @@
 
 /** Custom theme overwrites **/
 [data-theme=light] {
-  --color-primary: #ffffff;
-	--color-secondary: #000000;
-	--color-contrast: #e30613;
+  --color-primary: oklch(1 0 0);
+	--color-secondary: oklch(0 0 0);
+	--color-contrast: oklch(0.577 0.2339 27.95);
 }
 [data-theme=dark] {
-  --color-primary: #000000;
-	--color-secondary: #ffffff;
-	--color-contrast: #e30613;
+  --color-primary: oklch(0 0 0);
+	--color-secondary: oklch(1 0 0);
+	--color-contrast: oklch(0.577 0.2339 27.95);
 }
 [data-theme=evil] {
-  --color-primary: #000000;
-	--color-secondary: #e30613;
-	--color-contrast: #ffffff;
+  --color-primary: oklch(0 0 0);
+	--color-secondary: oklch(0.577 0.2339 27.95);
+	--color-contrast: oklch(1 0 0);
 }
 [data-theme=red] {
-  --color-primary: #e30613;
-	--color-secondary: #000000;
-	--color-contrast: #ffffff;
+  --color-primary: oklch(0.577 0.2339 27.95);
+	--color-secondary: oklch(0 0 0);
+	--color-contrast: oklch(1 0 0);
 }
   
 


### PR DESCRIPTION
## What this does
Every color in the starter is now written in oklch, and anywhere colors blend (surfaces, hairlines, the cart-modal fade) now mixes in oklab, so tints and fades look even instead of muddy. The rule is written into AGENTS.md so it stays that way in every project scaffolded from satus.

## Summary
- `lib/styles/colors.ts` palette converted to oklch (exact CSS Color 4 conversions, 4-decimal round-trip); `tailwind.css` regenerated via `setup:styles`
- 13 component/integration CSS modules, the image shimmer SVG, and dev tooling converted from hex/rgba
- `color-mix()` tokens in `global.css` and the cross-hue cart-modal gradient now interpolate `in oklab`
- Two documented exceptions: `.storybook/manager.ts` (polished can't parse oklch) and `lib/webgl` blend modes (compositing spec defines them in sRGB/HSL)
- New AGENTS.md section: colors always oklch, mixing always oklab, exceptions must name the parser that forces them

## Test Plan
- [x] `bun run check` → exit 0 (Biome, tsc, 348 tests, manifest)
- [x] Repo-wide grep: zero hex/rgb/hsl literals outside the two documented exceptions
- [x] Independent reviews (Claude reviewer + Codex): all conversions verified exact, no findings