### PR TITLE
test: add WCAG contrast gate over the theme palette

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -53,6 +53,7 @@
         "@types/react-dom": "^19.2.3",
         "@types/three": "^0.185.1",
         "babel-plugin-react-compiler": "^1.0.0",
+        "colorjs.io": "^0.7.0",
         "deslop-cli": "^0.8.1",
         "happy-dom": "^20.11.0",
         "lefthook": "^2.1.10",
@@ -1623,6 +1624,8 @@
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "color2k": ["color2k@2.0.4", "", {}, "sha512-OXAPGFRNeLFnUfqDtloYdxkwsJoIdXe28+bjbpJiPqyei2HPa3VHmMCWa0Qe62+U4Ftf9Hj7hRssOkxz7WiWbg=="],
+
+    "colorjs.io": ["colorjs.io@0.7.0", "", {}, "sha512-JfLy3aZW1Xp2iwSFzGlLn0XSMnIdItH3BmzsXtwHVFEWwVUJIwKBWNzjQq2Tgf3998OY7qW2R6klrlYo8vmEGg=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 

--- a/lib/styles/scripts/contrast.test.ts
+++ b/lib/styles/scripts/contrast.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Contrast gate for the theme palette.
+ *
+ * WCAG 2.1 is the blocking metric because it is what accessibility law and
+ * client contracts actually reference (the DOJ's 2024 ADA rule and EN 301 549
+ * both cite WCAG 2.1 AA). APCA is computed alongside it as an advisory signal:
+ * it is perceptually better and is W3C's candidate for WCAG 3, but WCAG 3 is
+ * still a working draft, so APCA does not fail a build here.
+ *
+ * The gate ratchets rather than blocks. `KNOWN_DEBT` records the pairs that
+ * already fail on `main`; a new failure fails the suite, and fixing a listed
+ * pair also fails until its entry is deleted, so the list cannot go stale.
+ *
+ * Run with: bun test lib/styles/scripts/contrast.test.ts
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { join } from 'node:path'
+import Color from 'colorjs.io'
+import { themes } from '../colors'
+
+/** WCAG 2.1 AA: 4.5:1 for normal text, 3:1 for large text and UI components. */
+const AA_TEXT = 4.5
+const AA_NON_TEXT = 3
+
+/**
+ * Pairs that fail today, each `theme/pair` keyed to its measured ratio.
+ *
+ * Every entry traces to one cause: the brand red resolves to a relative
+ * luminance of 0.165, which is 4.30:1 against both black and white — just under
+ * AA. A single colour can only clear 4.5:1 in both directions inside a very
+ * narrow band peaking at 4.583:1, so this is a palette decision, not a bug to
+ * patch token by token. Tracked rather than silenced.
+ */
+const KNOWN_DEBT: Record<string, number> = {
+  'light/contrast on surface-2': 3.85,
+  'dark/contrast on primary': 4.3,
+  'dark/primary on contrast': 4.3,
+  'dark/contrast on surface-2': 4.26,
+  'evil/secondary on primary': 4.3,
+  'evil/primary on secondary': 4.3,
+  'evil/secondary on surface': 4.3,
+  'evil/secondary on surface-2': 4.3,
+  'red/secondary on primary': 4.3,
+  'red/primary on secondary': 4.3,
+  'red/secondary on surface': 3.92,
+  'red/secondary on surface-2': 3.57,
+}
+
+type Role = 'primary' | 'secondary' | 'contrast'
+
+// Read the `color-mix(in oklab, …)` recipes straight out of `global.css` so the
+// check recomputes when a percentage is edited instead of drifting from it.
+const globalCss = await Bun.file(
+  join(import.meta.dir, '..', 'css', 'global.css')
+).text()
+
+const MIX =
+  /--(?<token>[\w-]+):\s*color-mix\(\s*in oklab,\s*var\(--color-(?<from>\w+)\)\s+(?<pct>\d+)%,\s*(?:var\(--color-(?<onto>\w+)\)|transparent)\s*\)/g
+
+const derived = [...globalCss.matchAll(MIX)].map(({ groups }) => ({
+  token: groups?.token as string,
+  from: groups?.from as Role,
+  pct: Number(groups?.pct) / 100,
+  onto: (groups?.onto ?? 'transparent') as Role | 'transparent',
+}))
+
+/** Resolve a theme's palette plus every derived token to concrete colours. */
+function resolveTheme(theme: Record<Role, string>) {
+  const resolved = new Map<string, Color>()
+  for (const role of ['primary', 'secondary', 'contrast'] as const) {
+    resolved.set(role, new Color(theme[role]))
+  }
+  for (const { token, from, pct, onto } of derived) {
+    // Mixing into `transparent` yields the source colour at `pct` alpha, which
+    // only has a contrast value once composited over what sits behind it.
+    const backdrop =
+      onto === 'transparent' ? new Color(theme.primary) : new Color(theme[onto])
+    resolved.set(
+      token,
+      Color.mix(backdrop, new Color(theme[from]), pct, { space: 'oklab' })
+    )
+  }
+  return resolved
+}
+
+/**
+ * Token pairs taken from real usage in `components/`, `app/`, and `global.css`,
+ * not from every combination the palette allows.
+ */
+const PAIRS: { label: string; bg: string; fg: Role; min: number }[] = [
+  {
+    label: 'secondary on primary',
+    bg: 'primary',
+    fg: 'secondary',
+    min: AA_TEXT,
+  },
+  { label: 'contrast on primary', bg: 'primary', fg: 'contrast', min: AA_TEXT },
+  {
+    label: 'primary on secondary',
+    bg: 'secondary',
+    fg: 'primary',
+    min: AA_TEXT,
+  },
+  { label: 'primary on contrast', bg: 'contrast', fg: 'primary', min: AA_TEXT },
+  {
+    label: 'secondary on surface',
+    bg: 'surface',
+    fg: 'secondary',
+    min: AA_TEXT,
+  },
+  {
+    label: 'secondary on surface-2',
+    bg: 'surface-2',
+    fg: 'secondary',
+    min: AA_TEXT,
+  },
+  {
+    label: 'contrast on surface-2',
+    bg: 'surface-2',
+    fg: 'contrast',
+    min: AA_TEXT,
+  },
+  {
+    label: 'focus ring on primary',
+    bg: 'primary',
+    fg: 'contrast',
+    min: AA_NON_TEXT,
+  },
+  {
+    label: 'border on primary',
+    bg: 'primary',
+    fg: 'secondary',
+    min: AA_NON_TEXT,
+  },
+]
+
+type Measurement = { key: string; ratio: number; lc: number; min: number }
+
+const measurements: Measurement[] = []
+for (const [name, theme] of Object.entries(themes)) {
+  const resolved = resolveTheme(theme as Record<Role, string>)
+  for (const { label, bg, fg, min } of PAIRS) {
+    const background = resolved.get(bg)
+    const foreground = resolved.get(fg)
+    if (!(background && foreground)) continue
+    measurements.push({
+      key: `${name}/${label}`,
+      ratio: background.contrast(foreground, 'WCAG21'),
+      lc: background.contrast(foreground, 'APCA'),
+      min,
+    })
+  }
+}
+
+const failing = measurements.filter((m) => m.ratio < m.min)
+
+describe('WCAG 2.1 AA contrast (blocking)', () => {
+  it('parses the derived tokens out of global.css', () => {
+    expect(derived.map((d) => d.token).sort()).toEqual([
+      'line',
+      'line-strong',
+      'surface',
+      'surface-2',
+    ])
+  })
+
+  it('introduces no contrast failure beyond the tracked baseline', () => {
+    const unexpected = failing
+      .filter((m) => !(m.key in KNOWN_DEBT))
+      .map((m) => `${m.key} = ${m.ratio.toFixed(2)}:1 (needs ${m.min})`)
+
+    expect(unexpected).toEqual([])
+  })
+
+  it('keeps the baseline honest — fixed pairs must leave KNOWN_DEBT', () => {
+    const failingKeys = new Set(failing.map((m) => m.key))
+    const stale = Object.keys(KNOWN_DEBT).filter((key) => !failingKeys.has(key))
+
+    expect(stale).toEqual([])
+  })
+
+  it('never regresses a tracked pair further than its recorded ratio', () => {
+    const worsened = failing.flatMap((m) => {
+      const recorded = KNOWN_DEBT[m.key]
+      if (recorded === undefined || m.ratio >= recorded - 0.01) return []
+      return [`${m.key} fell to ${m.ratio.toFixed(2)}:1 from ${recorded}`]
+    })
+
+    expect(worsened).toEqual([])
+  })
+})
+
+describe('APCA (advisory)', () => {
+  it('reports perceptual contrast for every measured pair', () => {
+    // APCA scores text-on-background; |Lc| 60 is roughly the floor for UI and
+    // body copy, |Lc| 75 the bar for comfortable primary body text. Reported
+    // rather than asserted: WCAG 3 is still a draft, so this is not a gate.
+    const weak = measurements
+      .filter((m) => m.min === AA_TEXT && Math.abs(m.lc) < 60)
+      .map((m) => `${m.key}: Lc ${m.lc.toFixed(1)}`)
+
+    if (weak.length > 0) {
+      console.warn(
+        `\n  APCA advisory — ${weak.length} pair(s) below Lc 60:\n    ${weak.join('\n    ')}\n`
+      )
+    }
+
+    expect(measurements.length).toBeGreaterThan(0)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/three": "^0.185.1",
     "babel-plugin-react-compiler": "^1.0.0",
+    "colorjs.io": "^0.7.0",
     "deslop-cli": "^0.8.1",
     "happy-dom": "^20.11.0",
     "lefthook": "^2.1.10",


### PR DESCRIPTION
## What this does
Measures the contrast of every color pairing the components actually use, across all four themes, and fails CI if a change makes any of them worse. It also surfaced something we should talk about: **12 pairings in the shipped palette are already below the WCAG AA minimum**, and they all come from one color.

The gate ratchets rather than blocking. Today's failures are recorded in `KNOWN_DEBT` so the build stays green, but a new failure fails the suite, and fixing a listed pair also fails until you delete its entry, so the list can't quietly go stale.

## The finding
The brand red `#e30613` sits at **4.30:1 against both black and white** — 0.2 short of AA for normal text, in every direction. That single fact accounts for 12 failures, including the `evil` theme's body copy (red on black) and the `red` theme's body copy (black on red).

Worth knowing before anyone tries to fix it by nudging the red: a single color can only clear 4.5:1 against both black and white inside a very narrow band that peaks at **4.583:1**. Testing a nudge to `oklch(0.592 …)` / `#e9161a` (ΔE 1.82, barely visible) takes it from 12 failures to 2 — but it makes light-theme red-on-surface worse, because a lighter red loses ground against light backgrounds. There is no single red with comfortable margin in both directions. Getting real headroom means a per-theme accent, or keeping red off normal-size body text. That's a brand call, so this PR only measures it.

## Summary
- New `lib/styles/scripts/contrast.test.ts`: 9 pair shapes × 4 themes, thresholds 4.5:1 for text and 3:1 for focus rings and borders
- Pair list derived from grepping real usage in `components/`, `app/`, and `global.css`, not from every combination the palette allows
- `color-mix` percentages are parsed out of `global.css` so the check recomputes when a recipe changes; tokens mixed into `transparent` are composited over their backdrop before measuring
- APCA reported as a non-blocking advisory; it independently flags the same 12 pairs
- `colorjs.io` as a devDependency (MIT, native oklch, both metrics). Not `apca-w3`, which ships under a custom scope-restricted "Limited W3 License"

## Test Plan
- [x] `bun run check` → exit 0 (358 tests, up from 353)
- [x] Injected a new failure (dimmed white to 0.72) → baseline test fails as intended
- [x] Fixed a tracked pair without updating the list (nudged the red) → staleness test fails as intended
- [x] Library cross-checked against canonical APCA reference values (black-on-white Lc 106.0, white-on-black Lc -107.9) — reproduced exactly