### PR TITLE
fix: nudge brand red to clear WCAG AA on black and white

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -2,7 +2,7 @@ import { addons } from 'storybook/manager-api'
 import { create } from 'storybook/theming'
 
 // Brand the Storybook UI to match Satūs. Values mirror the brand palette in
-// lib/styles/colors.ts (red #e30613, dark = black/white) and --line from
+// lib/styles/colors.ts (red #e9161a, dark = black/white) and --line from
 // global.css. The story canvas tracks the site's CSS tokens live; this manager
 // chrome is build-time JS, so update it here if the brand palette changes.
 // These values intentionally stay hex/rgba: storybook/theming's `create()` runs
@@ -12,8 +12,8 @@ const satus = create({
   brandTitle: 'Satūs',
   brandUrl: 'https://github.com/darkroomengineering/satus',
 
-  colorPrimary: '#e30613',
-  colorSecondary: '#e30613',
+  colorPrimary: '#e9161a',
+  colorSecondary: '#e9161a',
 
   appBg: '#000000',
   appContentBg: '#000000',
@@ -27,7 +27,7 @@ const satus = create({
   barBg: '#000000',
   barTextColor: 'rgba(255, 255, 255, 0.55)',
   barSelectedColor: '#ffffff',
-  barHoverColor: '#e30613',
+  barHoverColor: '#e9161a',
 
   inputBg: '#000000',
   inputBorder: 'rgba(255, 255, 255, 0.14)',

--- a/lib/styles/colors.ts
+++ b/lib/styles/colors.ts
@@ -1,7 +1,11 @@
 const colors = {
   black: 'oklch(0 0 0)',
   white: 'oklch(1 0 0)',
-  red: 'oklch(0.577 0.2339 27.95)',
+  // Lightness is tuned to 0.592 so the red clears WCAG AA (4.5:1) as text on
+  // both black and white. A single colour can only do that inside a narrow band
+  // peaking at 4.583:1, so this value has almost no slack — check
+  // `contrast.test.ts` before changing it.
+  red: 'oklch(0.592 0.2339 27.95)',
   blue: 'oklch(0.5731 0.2145 258.25)',
   green: 'oklch(0.8763 0.2278 152.55)',
   purple: 'oklch(0.4907 0.2275 300.45)',

--- a/lib/styles/css/tailwind.css
+++ b/lib/styles/css/tailwind.css
@@ -11,10 +11,10 @@
   --color-*: initial;
 	--color-primary: oklch(1 0 0);
 	--color-secondary: oklch(0 0 0);
-	--color-contrast: oklch(0.577 0.2339 27.95);
+	--color-contrast: oklch(0.592 0.2339 27.95);
   --color-black: oklch(0 0 0);
 	--color-white: oklch(1 0 0);
-	--color-red: oklch(0.577 0.2339 27.95);
+	--color-red: oklch(0.592 0.2339 27.95);
 	--color-blue: oklch(0.5731 0.2145 258.25);
 	--color-green: oklch(0.8763 0.2278 152.55);
 	--color-purple: oklch(0.4907 0.2275 300.45);
@@ -35,20 +35,20 @@
 [data-theme=light] {
   --color-primary: oklch(1 0 0);
 	--color-secondary: oklch(0 0 0);
-	--color-contrast: oklch(0.577 0.2339 27.95);
+	--color-contrast: oklch(0.592 0.2339 27.95);
 }
 [data-theme=dark] {
   --color-primary: oklch(0 0 0);
 	--color-secondary: oklch(1 0 0);
-	--color-contrast: oklch(0.577 0.2339 27.95);
+	--color-contrast: oklch(0.592 0.2339 27.95);
 }
 [data-theme=evil] {
   --color-primary: oklch(0 0 0);
-	--color-secondary: oklch(0.577 0.2339 27.95);
+	--color-secondary: oklch(0.592 0.2339 27.95);
 	--color-contrast: oklch(1 0 0);
 }
 [data-theme=red] {
-  --color-primary: oklch(0.577 0.2339 27.95);
+  --color-primary: oklch(0.592 0.2339 27.95);
 	--color-secondary: oklch(0 0 0);
 	--color-contrast: oklch(1 0 0);
 }

--- a/lib/styles/scripts/contrast.test.ts
+++ b/lib/styles/scripts/contrast.test.ts
@@ -26,25 +26,16 @@ const AA_NON_TEXT = 3
 /**
  * Pairs that fail today, each `theme/pair` keyed to its measured ratio.
  *
- * Every entry traces to one cause: the brand red resolves to a relative
- * luminance of 0.165, which is 4.30:1 against both black and white — just under
- * AA. A single colour can only clear 4.5:1 in both directions inside a very
- * narrow band peaking at 4.583:1, so this is a palette decision, not a bug to
- * patch token by token. Tracked rather than silenced.
+ * All three are red against a tinted surface. The red clears AA against pure
+ * black and pure white with only ~0.08 to spare, and `--surface` / `--surface-2`
+ * shift the background 4–8% toward the opposite end, which is enough to spend
+ * that margin. Fixing them needs a surface-specific accent rather than another
+ * lightness tweak, so they are tracked rather than silenced.
  */
 const KNOWN_DEBT: Record<string, number> = {
-  'light/contrast on surface-2': 3.85,
-  'dark/contrast on primary': 4.3,
-  'dark/primary on contrast': 4.3,
-  'dark/contrast on surface-2': 4.26,
-  'evil/secondary on primary': 4.3,
-  'evil/primary on secondary': 4.3,
-  'evil/secondary on surface': 4.3,
-  'evil/secondary on surface-2': 4.3,
-  'red/secondary on primary': 4.3,
-  'red/primary on secondary': 4.3,
-  'red/secondary on surface': 3.92,
-  'red/secondary on surface-2': 3.57,
+  'light/contrast on surface-2': 3.62,
+  'red/secondary on surface': 4.17,
+  'red/secondary on surface-2': 3.79,
 }
 
 type Role = 'primary' | 'secondary' | 'contrast'


### PR DESCRIPTION
## What this does
The red was 4.30:1 against both black and white, just under the 4.5 needed for normal text. That put 12 color pairings below AA across all four themes, including the actual body copy in the evil and red themes. Raising its lightness slightly fixes 9 of them.

## Summary
- `oklch(0.577 …)` → `oklch(0.592 …)`, hex `#e30613` → `#e9161a`. Now 4.58:1 in both directions
- The change is about 1.8 ΔE, roughly the threshold where a difference becomes visible
- 3 failures remain, all red on a tinted `--surface`, where the 4–8% tint spends the small margin the red has. Those need a surface-specific accent rather than another lightness tweak, so they stay tracked in `KNOWN_DEBT`
- Storybook's manager theme carries the same value by hand (polished can't parse oklch) and is updated to match

## Test Plan
- [x] `bun run check` → exit 0 (358 tests)
- [x] Contrast gate green with the debt list down from 12 entries to 3
- [x] New value verified in sRGB gamut