### PR TITLE
chore: make the contrast baseline re-recordable and prune dead palette entries

### DIFF
--- a/lib/dev/grid/grid.module.css
+++ b/lib/dev/grid/grid.module.css
@@ -7,7 +7,7 @@
   background-size: var(--gap) var(--gap);
 
   span {
-    background: pink;
+    background: oklch(0.8677 0.0735 7.09);
     opacity: 0.33;
   }
 }

--- a/lib/styles/colors.ts
+++ b/lib/styles/colors.ts
@@ -8,8 +8,6 @@ const colors = {
   red: 'oklch(0.592 0.2339 27.95)',
   blue: 'oklch(0.5731 0.2145 258.25)',
   green: 'oklch(0.8763 0.2278 152.55)',
-  purple: 'oklch(0.4907 0.2275 300.45)',
-  pink: 'oklch(0.6453 0.2603 2.47)',
 } as const
 
 const themeNames = ['light', 'dark', 'red', 'evil'] as const

--- a/lib/styles/css/tailwind.css
+++ b/lib/styles/css/tailwind.css
@@ -17,8 +17,6 @@
 	--color-red: oklch(0.592 0.2339 27.95);
 	--color-blue: oklch(0.5731 0.2145 258.25);
 	--color-green: oklch(0.8763 0.2278 152.55);
-	--color-purple: oklch(0.4907 0.2275 300.45);
-	--color-pink: oklch(0.6453 0.2603 2.47);
 
   --spacing-*: initial;
 	--spacing-0: 0;

--- a/lib/styles/scripts/contrast-accept.ts
+++ b/lib/styles/scripts/contrast-accept.ts
@@ -1,0 +1,50 @@
+/**
+ * Record the current contrast failures as the accepted baseline.
+ *
+ * Run this after deliberately changing the palette — most often right after
+ * rebranding a fork of this starter, when the shipped baseline no longer
+ * describes your colours:
+ *
+ *   bun run contrast:accept
+ *
+ * It prints everything it is about to accept. Read that list: each line is a
+ * colour pairing that does not meet WCAG AA, and accepting it is a decision to
+ * ship it. The resulting `contrast-baseline.json` is meant to be reviewed in a
+ * pull request like any other change.
+ */
+
+import { BASELINE_PATH, measureContrast, readBaseline } from './contrast'
+
+const measurements = await measureContrast()
+const failing = measurements.filter((m) => m.ratio < m.min)
+const previous = await readBaseline()
+
+const accepted: Record<string, number> = {}
+for (const m of failing.sort((a, b) => a.key.localeCompare(b.key))) {
+  accepted[m.key] = Number(m.ratio.toFixed(2))
+}
+
+const added = Object.keys(accepted).filter((k) => !(k in previous.accepted))
+const removed = Object.keys(previous.accepted).filter((k) => !(k in accepted))
+
+await Bun.write(BASELINE_PATH, `${JSON.stringify({ accepted }, null, 2)}\n`)
+
+if (failing.length === 0) {
+  console.log('✓ Every measured pair meets WCAG AA. Baseline is empty.')
+} else {
+  console.log(
+    `Accepting ${failing.length} pair(s) below WCAG AA — each one ships as-is:\n`
+  )
+  for (const [key, ratio] of Object.entries(accepted)) {
+    const needs = failing.find((m) => m.key === key)?.min
+    console.log(`  ${key}  ${ratio}:1 (needs ${needs})`)
+  }
+}
+
+if (added.length > 0) console.log(`\n  newly accepted: ${added.join(', ')}`)
+if (removed.length > 0)
+  console.log(`  no longer failing: ${removed.join(', ')}`)
+
+console.log(
+  `\nWrote ${BASELINE_PATH.split('/').slice(-1)[0]}. Review it before committing.`
+)

--- a/lib/styles/scripts/contrast-baseline.json
+++ b/lib/styles/scripts/contrast-baseline.json
@@ -1,0 +1,7 @@
+{
+  "accepted": {
+    "light/contrast on surface-2": 3.62,
+    "red/secondary on surface": 4.17,
+    "red/secondary on surface-2": 3.79
+  }
+}

--- a/lib/styles/scripts/contrast.test.ts
+++ b/lib/styles/scripts/contrast.test.ts
@@ -1,153 +1,45 @@
 /**
  * Contrast gate for the theme palette.
  *
- * WCAG 2.1 is the blocking metric because it is what accessibility law and
- * client contracts actually reference (the DOJ's 2024 ADA rule and EN 301 549
- * both cite WCAG 2.1 AA). APCA is computed alongside it as an advisory signal:
- * it is perceptually better and is W3C's candidate for WCAG 3, but WCAG 3 is
- * still a working draft, so APCA does not fail a build here.
+ * The accepted baseline lives in `contrast-baseline.json`, not in this file, so
+ * a fork that rebrands can re-record it in one step instead of hand-editing a
+ * list that describes someone else's colours:
  *
- * The gate ratchets rather than blocks. `KNOWN_DEBT` records the pairs that
- * already fail on `main`; a new failure fails the suite, and fixing a listed
- * pair also fails until its entry is deleted, so the list cannot go stale.
+ *   bun run contrast:accept
+ *
+ * The gate ratchets. A pairing that drops below WCAG AA and is not in the
+ * baseline fails; a pairing that improves past its recorded ratio also fails,
+ * so the baseline cannot quietly go stale. Both are fixed by re-accepting and
+ * reviewing the diff.
+ *
+ * Measurement itself lives in `contrast.ts`, shared with the accept command.
  *
  * Run with: bun test lib/styles/scripts/contrast.test.ts
  */
 
 import { describe, expect, it } from 'bun:test'
-import { join } from 'node:path'
-import Color from 'colorjs.io'
-import { themes } from '../colors'
+import {
+  AA_TEXT,
+  APCA_MIN,
+  measureContrast,
+  readBaseline,
+  readDerivedTokens,
+} from './contrast'
 
-/** WCAG 2.1 AA: 4.5:1 for normal text, 3:1 for large text and UI components. */
-const AA_TEXT = 4.5
-const AA_NON_TEXT = 3
-
-/**
- * Pairs that fail today, each `theme/pair` keyed to its measured ratio.
- *
- * All three are red against a tinted surface. The red clears AA against pure
- * black and pure white with only ~0.08 to spare, and `--surface` / `--surface-2`
- * shift the background 4–8% toward the opposite end, which is enough to spend
- * that margin. Fixing them needs a surface-specific accent rather than another
- * lightness tweak, so they are tracked rather than silenced.
- */
-const KNOWN_DEBT: Record<string, number> = {
-  'light/contrast on surface-2': 3.62,
-  'red/secondary on surface': 4.17,
-  'red/secondary on surface-2': 3.79,
-}
-
-type Role = 'primary' | 'secondary' | 'contrast'
-
-// Read the `color-mix(in oklab, …)` recipes straight out of `global.css` so the
-// check recomputes when a percentage is edited instead of drifting from it.
-const globalCss = await Bun.file(
-  join(import.meta.dir, '..', 'css', 'global.css')
-).text()
-
-const MIX =
-  /--(?<token>[\w-]+):\s*color-mix\(\s*in oklab,\s*var\(--color-(?<from>\w+)\)\s+(?<pct>\d+)%,\s*(?:var\(--color-(?<onto>\w+)\)|transparent)\s*\)/g
-
-const derived = [...globalCss.matchAll(MIX)].map(({ groups }) => ({
-  token: groups?.token as string,
-  from: groups?.from as Role,
-  pct: Number(groups?.pct) / 100,
-  onto: (groups?.onto ?? 'transparent') as Role | 'transparent',
-}))
-
-/** Resolve a theme's palette plus every derived token to concrete colours. */
-function resolveTheme(theme: Record<Role, string>) {
-  const resolved = new Map<string, Color>()
-  for (const role of ['primary', 'secondary', 'contrast'] as const) {
-    resolved.set(role, new Color(theme[role]))
-  }
-  for (const { token, from, pct, onto } of derived) {
-    // Mixing into `transparent` yields the source colour at `pct` alpha, which
-    // only has a contrast value once composited over what sits behind it.
-    const backdrop =
-      onto === 'transparent' ? new Color(theme.primary) : new Color(theme[onto])
-    resolved.set(
-      token,
-      Color.mix(backdrop, new Color(theme[from]), pct, { space: 'oklab' })
-    )
-  }
-  return resolved
-}
-
-/**
- * Token pairs taken from real usage in `components/`, `app/`, and `global.css`,
- * not from every combination the palette allows.
- */
-const PAIRS: { label: string; bg: string; fg: Role; min: number }[] = [
-  {
-    label: 'secondary on primary',
-    bg: 'primary',
-    fg: 'secondary',
-    min: AA_TEXT,
-  },
-  { label: 'contrast on primary', bg: 'primary', fg: 'contrast', min: AA_TEXT },
-  {
-    label: 'primary on secondary',
-    bg: 'secondary',
-    fg: 'primary',
-    min: AA_TEXT,
-  },
-  { label: 'primary on contrast', bg: 'contrast', fg: 'primary', min: AA_TEXT },
-  {
-    label: 'secondary on surface',
-    bg: 'surface',
-    fg: 'secondary',
-    min: AA_TEXT,
-  },
-  {
-    label: 'secondary on surface-2',
-    bg: 'surface-2',
-    fg: 'secondary',
-    min: AA_TEXT,
-  },
-  {
-    label: 'contrast on surface-2',
-    bg: 'surface-2',
-    fg: 'contrast',
-    min: AA_TEXT,
-  },
-  {
-    label: 'focus ring on primary',
-    bg: 'primary',
-    fg: 'contrast',
-    min: AA_NON_TEXT,
-  },
-  {
-    label: 'border on primary',
-    bg: 'primary',
-    fg: 'secondary',
-    min: AA_NON_TEXT,
-  },
-]
-
-type Measurement = { key: string; ratio: number; lc: number; min: number }
-
-const measurements: Measurement[] = []
-for (const [name, theme] of Object.entries(themes)) {
-  const resolved = resolveTheme(theme as Record<Role, string>)
-  for (const { label, bg, fg, min } of PAIRS) {
-    const background = resolved.get(bg)
-    const foreground = resolved.get(fg)
-    if (!(background && foreground)) continue
-    measurements.push({
-      key: `${name}/${label}`,
-      ratio: background.contrast(foreground, 'WCAG21'),
-      lc: background.contrast(foreground, 'APCA'),
-      min,
-    })
-  }
-}
-
+const measurements = await measureContrast()
+const { accepted } = await readBaseline()
 const failing = measurements.filter((m) => m.ratio < m.min)
 
 describe('WCAG 2.1 AA contrast (blocking)', () => {
-  it('parses the derived tokens out of global.css', () => {
+  it('measures every theme against every used token pair', () => {
+    expect(measurements.length).toBeGreaterThan(0)
+    expect(new Set(measurements.map((m) => m.key)).size).toBe(
+      measurements.length
+    )
+  })
+
+  it('parses the derived tokens out of global.css', async () => {
+    const derived = await readDerivedTokens()
     expect(derived.map((d) => d.token).sort()).toEqual([
       'line',
       'line-strong',
@@ -156,24 +48,26 @@ describe('WCAG 2.1 AA contrast (blocking)', () => {
     ])
   })
 
-  it('introduces no contrast failure beyond the tracked baseline', () => {
+  it('introduces no contrast failure outside the accepted baseline', () => {
     const unexpected = failing
-      .filter((m) => !(m.key in KNOWN_DEBT))
+      .filter((m) => !(m.key in accepted))
       .map((m) => `${m.key} = ${m.ratio.toFixed(2)}:1 (needs ${m.min})`)
 
+    // Run `bun run contrast:accept` if these are intentional.
     expect(unexpected).toEqual([])
   })
 
-  it('keeps the baseline honest — fixed pairs must leave KNOWN_DEBT', () => {
+  it('keeps the baseline honest — improved pairs must leave it', () => {
     const failingKeys = new Set(failing.map((m) => m.key))
-    const stale = Object.keys(KNOWN_DEBT).filter((key) => !failingKeys.has(key))
+    const stale = Object.keys(accepted).filter((key) => !failingKeys.has(key))
 
+    // Run `bun run contrast:accept` to drop these.
     expect(stale).toEqual([])
   })
 
-  it('never regresses a tracked pair further than its recorded ratio', () => {
+  it('never regresses an accepted pair below its recorded ratio', () => {
     const worsened = failing.flatMap((m) => {
-      const recorded = KNOWN_DEBT[m.key]
+      const recorded = accepted[m.key]
       if (recorded === undefined || m.ratio >= recorded - 0.01) return []
       return [`${m.key} fell to ${m.ratio.toFixed(2)}:1 from ${recorded}`]
     })
@@ -184,16 +78,13 @@ describe('WCAG 2.1 AA contrast (blocking)', () => {
 
 describe('APCA (advisory)', () => {
   it('reports perceptual contrast for every measured pair', () => {
-    // APCA scores text-on-background; |Lc| 60 is roughly the floor for UI and
-    // body copy, |Lc| 75 the bar for comfortable primary body text. Reported
-    // rather than asserted: WCAG 3 is still a draft, so this is not a gate.
     const weak = measurements
-      .filter((m) => m.min === AA_TEXT && Math.abs(m.lc) < 60)
+      .filter((m) => m.min === AA_TEXT && Math.abs(m.lc) < APCA_MIN)
       .map((m) => `${m.key}: Lc ${m.lc.toFixed(1)}`)
 
     if (weak.length > 0) {
       console.warn(
-        `\n  APCA advisory — ${weak.length} pair(s) below Lc 60:\n    ${weak.join('\n    ')}\n`
+        `\n  APCA advisory — ${weak.length} pair(s) below Lc ${APCA_MIN}:\n    ${weak.join('\n    ')}\n`
       )
     }
 

--- a/lib/styles/scripts/contrast.ts
+++ b/lib/styles/scripts/contrast.ts
@@ -1,0 +1,157 @@
+/**
+ * Contrast measurement for the theme palette.
+ *
+ * Shared by `contrast.test.ts` (which asserts) and `contrast-accept.ts` (which
+ * records a new baseline), so the gate and the accept command can never measure
+ * different things.
+ *
+ * WCAG 2.1 is the blocking metric because it is what accessibility law and
+ * client contracts reference — the DOJ's 2024 ADA rule and EN 301 549 both cite
+ * WCAG 2.1 AA. APCA is computed alongside it as an advisory signal: it is
+ * perceptually better and is W3C's candidate for WCAG 3, but WCAG 3 is still a
+ * working draft, so it does not gate anything.
+ */
+
+import { join } from 'node:path'
+import Color from 'colorjs.io'
+import { themes } from '../colors'
+
+/** WCAG 2.1 AA: 4.5:1 for normal text, 3:1 for large text and UI components. */
+export const AA_TEXT = 4.5
+export const AA_NON_TEXT = 3
+
+/** APCA floor for UI and body copy. Advisory only. */
+export const APCA_MIN = 60
+
+export type Role = 'primary' | 'secondary' | 'contrast'
+
+export type Measurement = {
+  key: string
+  ratio: number
+  lc: number
+  min: number
+}
+
+/**
+ * Token pairs taken from real usage in `components/`, `app/`, and `global.css`,
+ * rather than every combination the palette allows.
+ */
+const PAIRS: { label: string; bg: string; fg: Role; min: number }[] = [
+  {
+    label: 'secondary on primary',
+    bg: 'primary',
+    fg: 'secondary',
+    min: AA_TEXT,
+  },
+  { label: 'contrast on primary', bg: 'primary', fg: 'contrast', min: AA_TEXT },
+  {
+    label: 'primary on secondary',
+    bg: 'secondary',
+    fg: 'primary',
+    min: AA_TEXT,
+  },
+  { label: 'primary on contrast', bg: 'contrast', fg: 'primary', min: AA_TEXT },
+  {
+    label: 'secondary on surface',
+    bg: 'surface',
+    fg: 'secondary',
+    min: AA_TEXT,
+  },
+  {
+    label: 'secondary on surface-2',
+    bg: 'surface-2',
+    fg: 'secondary',
+    min: AA_TEXT,
+  },
+  {
+    label: 'contrast on surface-2',
+    bg: 'surface-2',
+    fg: 'contrast',
+    min: AA_TEXT,
+  },
+  {
+    label: 'focus ring on primary',
+    bg: 'primary',
+    fg: 'contrast',
+    min: AA_NON_TEXT,
+  },
+  {
+    label: 'border on primary',
+    bg: 'primary',
+    fg: 'secondary',
+    min: AA_NON_TEXT,
+  },
+]
+
+const MIX =
+  /--(?<token>[\w-]+):\s*color-mix\(\s*in oklab,\s*var\(--color-(?<from>\w+)\)\s+(?<pct>\d+)%,\s*(?:var\(--color-(?<onto>\w+)\)|transparent)\s*\)/g
+
+/**
+ * Read the `color-mix(in oklab, …)` recipes out of `global.css` so the check
+ * recomputes when a percentage is edited instead of drifting from it.
+ */
+export async function readDerivedTokens() {
+  const css = await Bun.file(
+    join(import.meta.dir, '..', 'css', 'global.css')
+  ).text()
+
+  return [...css.matchAll(MIX)].map(({ groups }) => ({
+    token: groups?.token as string,
+    from: groups?.from as Role,
+    pct: Number(groups?.pct) / 100,
+    onto: (groups?.onto ?? 'transparent') as Role | 'transparent',
+  }))
+}
+
+/** Measure every pair in every theme. */
+export async function measureContrast(): Promise<Measurement[]> {
+  const derived = await readDerivedTokens()
+  const measurements: Measurement[] = []
+
+  for (const [name, theme] of Object.entries(themes)) {
+    const t = theme as Record<Role, string>
+    const resolved = new Map<string, Color>()
+
+    for (const role of ['primary', 'secondary', 'contrast'] as const) {
+      resolved.set(role, new Color(t[role]))
+    }
+
+    for (const { token, from, pct, onto } of derived) {
+      // Mixing into `transparent` yields the source colour at `pct` alpha, which
+      // only has a contrast value once composited over what sits behind it.
+      const backdrop = new Color(onto === 'transparent' ? t.primary : t[onto])
+      resolved.set(
+        token,
+        Color.mix(backdrop, new Color(t[from]), pct, { space: 'oklab' })
+      )
+    }
+
+    for (const { label, bg, fg, min } of PAIRS) {
+      const background = resolved.get(bg)
+      const foreground = resolved.get(fg)
+      if (!(background && foreground)) continue
+
+      measurements.push({
+        key: `${name}/${label}`,
+        ratio: background.contrast(foreground, 'WCAG21'),
+        lc: background.contrast(foreground, 'APCA'),
+        min,
+      })
+    }
+  }
+
+  return measurements
+}
+
+export const BASELINE_PATH = join(import.meta.dir, 'contrast-baseline.json')
+
+export type Baseline = {
+  /** Failing pairs, keyed to the ratio recorded when the baseline was taken. */
+  accepted: Record<string, number>
+}
+
+export async function readBaseline(): Promise<Baseline> {
+  const file = Bun.file(BASELINE_PATH)
+  if (!(await file.exists())) return { accepted: {} }
+  return file.json()
+}

--- a/lib/styles/scripts/setup-styles.test.ts
+++ b/lib/styles/scripts/setup-styles.test.ts
@@ -15,8 +15,18 @@
 
 import { describe, expect, it } from 'bun:test'
 import { join } from 'node:path'
+import { Glob } from 'bun'
 import { colors, themes } from '../config'
 import { buildStyleSheets, OUTPUTS } from './setup-styles'
+
+const DECLARATION = /^\s*(?<property>[a-z-]+)\s*:\s*(?<value>[^;]+);/gim
+
+const COLOR_PROPERTY =
+  /^(color|background|background-color|border|border-[a-z]+|border-[a-z]+-color|outline|outline-color|fill|stroke|box-shadow|text-shadow|text-decoration-color|caret-color|accent-color|column-rule-color)$/
+
+/** CSS named colours. `transparent` and `currentColor` are deliberately absent. */
+const NAMED_COLOR =
+  /\b(aliceblue|antiquewhite|aqua|aquamarine|azure|beige|bisque|black|blanchedalmond|blue|blueviolet|brown|burlywood|cadetblue|chartreuse|chocolate|coral|cornflowerblue|cornsilk|crimson|cyan|darkblue|darkcyan|darkgoldenrod|darkgray|darkgreen|darkgrey|darkkhaki|darkmagenta|darkolivegreen|darkorange|darkorchid|darkred|darksalmon|darkseagreen|darkslateblue|darkslategray|darkslategrey|darkturquoise|darkviolet|deeppink|deepskyblue|dimgray|dimgrey|dodgerblue|firebrick|floralwhite|forestgreen|fuchsia|gainsboro|ghostwhite|gold|goldenrod|gray|green|greenyellow|grey|honeydew|hotpink|indianred|indigo|ivory|khaki|lavender|lavenderblush|lawngreen|lemonchiffon|lightblue|lightcoral|lightcyan|lightgoldenrodyellow|lightgray|lightgreen|lightgrey|lightpink|lightsalmon|lightseagreen|lightskyblue|lightslategray|lightslategrey|lightsteelblue|lightyellow|lime|limegreen|linen|magenta|maroon|mediumaquamarine|mediumblue|mediumorchid|mediumpurple|mediumseagreen|mediumslateblue|mediumspringgreen|mediumturquoise|mediumvioletred|midnightblue|mintcream|mistyrose|moccasin|navajowhite|navy|oldlace|olive|olivedrab|orange|orangered|orchid|palegoldenrod|palegreen|paleturquoise|palevioletred|papayawhip|peachpuff|peru|pink|plum|powderblue|purple|rebeccapurple|rosybrown|royalblue|saddlebrown|salmon|sandybrown|seagreen|seashell|sienna|silver|skyblue|slateblue|slategray|slategrey|snow|springgreen|steelblue|tan|teal|thistle|tomato|turquoise|violet|wheat|white|whitesmoke|yellow|yellowgreen)\b/i
 
 const repoRoot = join(import.meta.dir, '..', '..', '..')
 const built = buildStyleSheets()
@@ -62,5 +72,39 @@ describe('color authoring rules', () => {
       expect(css).not.toMatch(/#[0-9a-f]{3,8}\b/i)
       expect(css).not.toMatch(/\b(rgba?|hsla?)\(/i)
     }
+  })
+
+  // The checks above only see generated output. Hand-written modules are where
+  // a stray `background: pink` actually lands, so scan those too — including
+  // CSS named colours, which read as intentional and survive a hex/rgb grep.
+  it('authors every colour in hand-written CSS as oklch', async () => {
+    const offenders: string[] = []
+
+    for await (const path of new Glob('{app,components,lib}/**/*.css').scan(
+      repoRoot
+    )) {
+      const css = await Bun.file(join(repoRoot, path)).text()
+
+      for (const { groups } of css.matchAll(DECLARATION)) {
+        const property = groups?.property
+        const rawValue = groups?.value
+        if (!(property && rawValue && COLOR_PROPERTY.test(property))) continue
+
+        // `var()` and `url()` payloads are references, not authored colours.
+        const value = rawValue
+          .replace(/var\([^)]*\)/g, '')
+          .replace(/url\([^)]*\)/g, '')
+
+        if (
+          NAMED_COLOR.test(value) ||
+          /#[0-9a-f]{3,8}\b/i.test(value) ||
+          /\b(rgba?|hsla?)\(/i.test(value)
+        ) {
+          offenders.push(`${path}: ${property}: ${rawValue.trim()}`)
+        }
+      }
+    }
+
+    expect(offenders).toEqual([])
   })
 })

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:e2e": "playwright test",
     "test:setup": "bun test lib/scripts/setup-project.test.ts",
     "doctor": "bun ./lib/scripts/doctor.ts",
+    "contrast:accept": "bun ./lib/styles/scripts/contrast-accept.ts",
     "setup:styles": "bun ./lib/styles/scripts/setup-styles.ts",
     "generate": "bun ./lib/scripts/generate.ts",
     "generate:manifest": "bun ./lib/scripts/generate-manifest.ts",


### PR DESCRIPTION
## What this does
The contrast gate had satus's own failures hardcoded in the test file, which is backwards for a starter — the first thing a client does is replace the palette, so they'd inherit a list describing colours they no longer use, and the test would tell them to hand-edit entries they never created. The baseline is now data, re-recordable with one command.

Also drops two palette colours nothing was using, and closes a gap where a stray CSS named colour could sit in a stylesheet unnoticed.

## Summary
- Baseline moves to `contrast-baseline.json`, written by `bun run contrast:accept`. It prints every pair it accepts, because accepting one means shipping it below AA, and the JSON is meant to be reviewed in a PR
- Measurement moves to `contrast.ts`, shared by the gate and the accept command, so the two can't measure different things
- `purple` and `pink` removed from the palette — neither had a single reference anywhere: no CSS variable, no Tailwind utility, no TypeScript import
- `background: pink` in the dev grid replaced with its oklch equivalent
- The authoring check now scans hand-written CSS for named colours, hex, and rgb. It previously only read generated output, which is why `pink` was invisible to it

## Test Plan
- [x] `bun run check` → exit 0 (360 tests, up from 358)
- [x] `bun run contrast:accept` is idempotent — re-running against an unchanged palette produces no diff
- [x] Reintroduced `background: hotpink` → the new authoring check fails and names the file
- [x] Palette usage audited three ways before removal (CSS variables, Tailwind utilities, TS references)