### PR TITLE
fix(form): use SubmitEvent instead of the deprecated FormEvent

### DIFF
--- a/components/ui/form/hook.ts
+++ b/components/ui/form/hook.ts
@@ -1,7 +1,7 @@
 import {
   type ChangeEventHandler,
   type FocusEventHandler,
-  type FormEvent,
+  type SubmitEvent,
   useActionState,
   useRef,
   useState,
@@ -93,7 +93,7 @@ export function useForm<T = unknown>({
     Object.values(isValid).every(Boolean) &&
     Object.values(errors).every(({ state }) => !state)
 
-  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const onSubmit = (event: SubmitEvent<HTMLFormElement>) => {
     event.preventDefault()
 
     // Enter-to-submit must respect the same gate as the SubmitButton.

--- a/components/ui/form/types.ts
+++ b/components/ui/form/types.ts
@@ -25,7 +25,7 @@ export interface UseFormOptions<T = unknown> {
 export interface UseFormReturn<T = unknown> {
   formState: FormState<T> | null
   formAction: (formData: FormData) => void
-  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void
+  onSubmit: (event: React.SubmitEvent<HTMLFormElement>) => void
   register: (name: string) => {
     ref: (node: HTMLInputElement | HTMLTextAreaElement | null) => void
     onChange: (


### PR DESCRIPTION
## What this does
The form hook typed its submit handler as `React.FormEvent`, which React now marks as deprecated. This switches to `React.SubmitEvent`, which is what React already expects. No behaviour change.

## Why now
This isn't only future-proofing — it's the correct type today at our current React version:

- `FormEvent`'s own doc comment in `@types/react` 19.2.17 marks it deprecated and points at `SubmitEvent`
- `DOMAttributes` already types `onSubmit` as `SubmitEventHandler`, not `FormEventHandler`

React 19.2.10 turns this into a visible deprecation warning. Since satus is the base for client projects, fixing it here means no downstream project inherits the warning on its next React bump.

Cherry-picked from the 16.3 preview branch (#259), where it was found. It has nothing to do with Next 16.3, and that branch is parked until 16.3 goes stable, so it shouldn't wait there.

## Summary
- `components/ui/form/types.ts` — `UseFormReturn.onSubmit` now takes `React.SubmitEvent<HTMLFormElement>`
- `components/ui/form/hook.ts` — import and handler signature updated to match

## Test Plan
- [x] `bun run check` → exit 0 (360 tests)
- [x] No `FormEvent` references remain anywhere in `components/`, `lib/`, or `app/`