### PR TITLE
feat(styles): sync design tokens from Figma (colors, layout, typograp…

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -29,7 +29,8 @@
       "!**/*.mdx",
       "!**/tailwind.css",
       "!**/root.css",
-      "!**/*.grit"
+      "!**/*.grit",
+      "!**/*.figma.js"
     ]
   },
 

--- a/lib/styles/colors.ts
+++ b/lib/styles/colors.ts
@@ -1,10 +1,15 @@
+/*
+ * GENERATED FROM FIGMA VARIABLES — DO NOT EDIT DIRECTLY.
+ * Source of truth: Figma variables → figma-tokens.json → bun run figma:import.
+ */
+
 const colors = {
   black: 'oklch(0 0 0)',
   white: 'oklch(1 0 0)',
-  // Lightness is tuned to 0.592 so the red clears WCAG AA (4.5:1) as text on
-  // both black and white. A single colour can only do that inside a narrow band
-  // peaking at 4.583:1, so this value has almost no slack — check
-  // `lib/styles/scripts/contrast.test.ts` before changing it.
+  // L tuned to 0.592 so red clears WCAG AA (4.5:1) as text on BOTH black and
+  // white — a single hue can only do that in a narrow band peaking at
+  // 4.583:1, so almost no slack. Check lib/styles/scripts/contrast.test.ts
+  // before changing.
   red: 'oklch(0.592 0.2339 27.95)',
   blue: 'oklch(0.5731 0.2145 258.25)',
   green: 'oklch(0.8763 0.2278 152.55)',
@@ -24,14 +29,14 @@ const themes = {
     secondary: colors.white,
     contrast: colors.red,
   },
-  evil: {
-    primary: colors.black,
-    secondary: colors.red,
-    contrast: colors.white,
-  },
   red: {
     primary: colors.red,
     secondary: colors.black,
+    contrast: colors.white,
+  },
+  evil: {
+    primary: colors.black,
+    secondary: colors.red,
     contrast: colors.white,
   },
 } as const satisfies Themes

--- a/lib/styles/config.ts
+++ b/lib/styles/config.ts
@@ -1,5 +1,6 @@
 import { colors, themeNames, themes } from './colors'
 import { breakpoints, customSizes, layout, screens } from './layout.mjs'
+import { durations } from './motion'
 import { fonts, typography } from './typography'
 
 const config = {
@@ -12,12 +13,14 @@ const config = {
   layout,
   screens,
   typography,
+  durations,
 } as const
 
 export {
   breakpoints,
   colors,
   customSizes,
+  durations,
   fonts,
   layout,
   screens,

--- a/lib/styles/css/global.css
+++ b/lib/styles/css/global.css
@@ -14,10 +14,11 @@ html {
 }
 
 /*
- * Derived semantic tokens — depth, hairlines, motion.
+ * Derived semantic tokens — depth, hairlines.
  * Surfaces and lines are derived from the active theme's colors via color-mix,
  * so they adapt automatically across every [data-theme] without new palette
  * entries. The red `--color-contrast` doubles as the accent.
+ * Motion durations (`--duration-*`) are Figma-sourced and live in root.css.
  */
 :root {
   --surface: color-mix(
@@ -32,10 +33,6 @@ html {
   );
   --line: color-mix(in oklab, var(--color-secondary) 14%, transparent);
   --line-strong: color-mix(in oklab, var(--color-secondary) 28%, transparent);
-
-  --duration-fast: 200ms;
-  --duration: 400ms;
-  --duration-slow: 800ms;
 }
 
 html.overflow-hidden {

--- a/lib/styles/css/root.css
+++ b/lib/styles/css/root.css
@@ -18,6 +18,10 @@
 
 	--header-height: calc(((58 * 100) / var(--device-width)) * 1vw);
 
+	--duration-fast: 200ms;
+	--duration: 400ms;
+	--duration-slow: 800ms;
+
 	--layout-width: calc(100vw - (2 * var(--safe)));
 	--column-width: calc((var(--layout-width) - (var(--columns) - 1) * var(--gap)) / var(--columns));
 

--- a/lib/styles/css/tailwind.css
+++ b/lib/styles/css/tailwind.css
@@ -40,14 +40,14 @@
 	--color-secondary: oklch(1 0 0);
 	--color-contrast: oklch(0.592 0.2339 27.95);
 }
-[data-theme=evil] {
-  --color-primary: oklch(0 0 0);
-	--color-secondary: oklch(0.592 0.2339 27.95);
-	--color-contrast: oklch(1 0 0);
-}
 [data-theme=red] {
   --color-primary: oklch(0.592 0.2339 27.95);
 	--color-secondary: oklch(0 0 0);
+	--color-contrast: oklch(1 0 0);
+}
+[data-theme=evil] {
+  --color-primary: oklch(0 0 0);
+	--color-secondary: oklch(0.592 0.2339 27.95);
 	--color-contrast: oklch(1 0 0);
 }
   
@@ -159,8 +159,8 @@
 /** Custom variants **/
 @custom-variant light (&:where([data-theme=light], [data-theme=light] *));
 @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
-@custom-variant evil (&:where([data-theme=evil], [data-theme=evil] *));
 @custom-variant red (&:where([data-theme=red], [data-theme=red] *));
+@custom-variant evil (&:where([data-theme=evil], [data-theme=evil] *));
 
 /** Custom function utilities **/
 @utility dr-text-* {

--- a/lib/styles/layout.mjs
+++ b/lib/styles/layout.mjs
@@ -1,4 +1,8 @@
 // THIS FILE HAS TO STAY .mjs AS ITS CONSUMED BY POSTCSS
+/*
+ * GENERATED FROM FIGMA VARIABLES — DO NOT EDIT DIRECTLY.
+ * Source of truth: Figma variables → figma-tokens.json → bun run figma:import. `breakpoints` below is code-owned and preserved across syncs.
+ */
 const breakpoints = {
   dt: 800,
 }
@@ -9,12 +13,18 @@ const screens = {
 }
 
 const layout = {
+  // Grid column count. Drives repeat(var(--columns),1fr) and column-based
+  // sizing.
   columns: { mobile: 4, desktop: 12 },
+  // Grid gutter, in design px at the reference device width. Repo emits it
+  // as fluid vw.
   gap: { mobile: 16, desktop: 16 },
+  // Outer safe margin (inline), design px. Repo emits it as fluid vw.
   safe: { mobile: 16, desktop: 16 },
 }
 
 const customSizes = {
+  // Header height, design px. Repo emits it as fluid vw (--header-height).
   'header-height': { mobile: 58, desktop: 98 },
 }
 

--- a/lib/styles/motion.ts
+++ b/lib/styles/motion.ts
@@ -1,0 +1,11 @@
+/*
+ * GENERATED FROM FIGMA VARIABLES — DO NOT EDIT DIRECTLY.
+ * Source of truth: Figma variables → figma-tokens.json → bun run figma:import.
+ */
+
+/** Motion durations in ms. Emitted to root.css as `--<name>: <ms>ms`. */
+export const durations = {
+  'duration-fast': 200,
+  duration: 400,
+  'duration-slow': 800,
+} as const

--- a/lib/styles/scripts/figma/README.md
+++ b/lib/styles/scripts/figma/README.md
@@ -1,0 +1,139 @@
+# Figma → repo token sync
+
+Design authors tokens as **Figma Variables**; this pipeline pulls them into the
+repo's source config, which the existing style generator turns into CSS. Figma
+is the source of truth for the palette, themes, and grid. One conversion step
+(sRGB → `oklch()`) happens on import, because this repo authors all color in
+`oklch`.
+
+```
+Figma Variables ──export──▶ figma-tokens.json ──import.ts──▶ colors.ts + layout.mjs
+                                                                     │
+                                                            bun run setup:styles
+                                                                     ▼
+                                                          root.css + tailwind.css
+```
+
+The importer only writes the two **source** files; nothing downstream of
+`setup:styles` changes. Every sync is validated by the existing contrast gate
+(`bun run check`), so a design change that breaks WCAG AA fails CI.
+
+## Figma file structure
+
+The scaffolded file (`DqTvmFVFWGEqpuaxrcnWvZ`) has four variable collections plus
+text styles. Figma **modes** map directly onto the repo's responsive breakpoints
+and themes:
+
+| Collection | Modes | Variables | Maps to |
+|---|---|---|---|
+| **Primitives** | `Value` | `black white red blue green` (color) | `colors` raw palette in `colors.ts` → `@theme --color-*` |
+| **Color** | `Light Dark Red Evil` | `primary secondary contrast` (aliased to Primitives) | `themes` in `colors.ts` → `[data-theme=*]` overrides |
+| **Layout** | `Mobile Desktop` | `columns gap safe device-width device-height header-height` (number) | `layout` / `screens` / `customSizes` in `layout.mjs` |
+| **Typography** | `Mobile Desktop` | `{style}/font-size` + `{style}/line-height` (number) | `typography.figma.ts` → `typography.ts` → `@utility` classes |
+| **Motion** | `Value` | `duration-fast duration duration-slow` (number, ms) | `motion.ts` → `--duration-*` in `root.css` |
+| **Text styles** | — | `h1 h2 p-big p caption cta link` | per-style family / weight / letter-spacing / trim / OpenType features |
+
+Conventions the pipeline relies on:
+
+- Every variable carries **WEB code syntax** = its CSS var (`var(--color-primary)`,
+  `var(--columns)`), so Figma Dev Mode shows the exact token the code uses.
+- Semantic colors are **aliases** to primitives, never raw values — that's what
+  lets `import.ts` emit `primary: colors.white` instead of a duplicated literal.
+- Variable **descriptions** round-trip into code as comments (e.g. the red
+  WCAG-tuning note lives on the `red` primitive in Figma).
+- `Layout` numbers are **design px** at the reference device width; the repo
+  emits them as fluid `vw`. `columns`/`gap`/`safe` → `layout`; `device-*` →
+  `screens`; anything else → `customSizes`.
+
+### Typography specifics
+
+- **font-size** is bound to a variable on each text style, so it's responsive
+  across Mobile/Desktop modes.
+- **line-height** is NOT bound to the text style: Figma reinterprets a bound
+  line-height variable as **pixels**, breaking the percent model. So line-height
+  lives as its own percent variables (`{style}/line-height`, Mobile/Desktop),
+  read by name on export. The text style carries a static percent for preview.
+- **letter-spacing** must be **PERCENT** on text styles (`-5%` ↔ `-0.05em`); the
+  export rejects `PIXELS`/`AUTO` with a clear error.
+- **Vertical trim** ("Cap height to baseline", `leadingTrim: CAP_HEIGHT`) →
+  `text-box-trim: both; text-box-edge: cap alphabetic`. `NONE` omits it.
+  Caveat: `text-box-trim` is newly baseline-available (Chrome 133+, Safari 18.2+);
+  older browsers show untrimmed leading — graceful degradation.
+- **OpenType features** set on a text style export to `font-feature-settings`
+  (e.g. `"tnum" 1`). The Plugin API can *read* them but not *write* them, so the
+  scaffold seeds none — designers toggle them in Figma and they flow into code.
+- **Font families** map via a code-owned table (`Oswald → display`,
+  `Spline Sans Mono → mono`). An unknown family fails the export loudly — wiring a
+  new font is a code change in `fonts.ts`, not something the sync can infer.
+
+### Overriding in code
+
+`typography.ts` is a hand-authored **merge shell**: it layers a code `overrides`
+object over the generated `typography.figma.ts`. Overrides win. Use them where
+the browser and Figma legitimately disagree (CSS half-leading, `text-box-trim`
+support, next/font fallback metrics) or for deliberate divergence. Each
+`figma:import` **warns** (never fails) when an override masks a value that
+changed in Figma, so silent drift is visible.
+
+## Syncing
+
+### 1. Export from Figma → `figma-tokens.json`
+
+`export.figma.js` is Figma **Plugin API** code (not a repo module — that's why
+it's excluded from Biome). Run it one of two ways:
+
+- **Agent / MCP** — paste its body into a `use_figma` call against the file; it
+  returns the interchange object. Save that as `figma-tokens.json`.
+- **Enterprise CI** — port it to the REST Variables API
+  (`GET /v1/files/:key/variables/local`). Same collection/mode names, so the
+  output shape is identical. (REST Variables API requires an Enterprise plan.)
+
+The interchange shape is defined and validated by `schema.ts` (Zod).
+
+### 2. Import into the repo
+
+```bash
+bun run figma:import   # figma-tokens.json → colors.ts + layout.mjs → setup:styles
+bun run check          # validates contrast (WCAG AA), types, tests
+```
+
+`figma:import` converts colors to `oklch`, regenerates the source files
+(formatted to house style), and runs `setup:styles`. It writes `colors.ts`,
+`layout.mjs`, `typography.figma.ts`, and `motion.ts` — but **not** `typography.ts`
+(the hand-authored override shell). `breakpoints` in `layout.mjs` is **code-owned**
+(a media-query value, not a Figma variable) and preserved across syncs.
+
+## Precision / the razor-thin red
+
+sRGB ↔ oklch round-trips losslessly at this repo's precision (4/4/2 decimals):
+the scaffolded palette re-imports byte-for-byte identical to the committed
+values, red's `oklch(0.592 …)` included. Because the `red` primitive sits in a
+narrow band that clears WCAG AA on both black and white (peak 4.583:1), any
+future nudge in Figma is caught by `contrast.test.ts` on the next
+`bun run check` — fix it in Figma, or re-record the baseline with
+`bun run contrast:accept`.
+
+## Scope
+
+Synced today: **colors, layout, typography, motion**. Not synced (deliberately
+code-owned):
+
+- **Surfaces & lines** (`--surface`, `--line`, …) — `color-mix` derivations of
+  `secondary`/`primary` in `global.css`. They auto-adapt across every theme from
+  two inputs; flattening them into Figma would duplicate and drift. The contrast
+  gate already measures them.
+- **Easings** (`--ease-*`) — a curated, near-static set in `easings.css`; low
+  churn, little sync value. Could become STRING variables later if desired.
+- **Breakpoints** (`dt: 800`) — a media-query value, not a design token.
+
+## Files
+
+| File | Role |
+|---|---|
+| `export.figma.js` | Figma Plugin API snippet: Variables + text styles → interchange object |
+| `figma-tokens.json` | The interchange artifact (committed snapshot) |
+| `schema.ts` | Zod schema + `FigmaTokens` type — the export/import contract |
+| `import.ts` | `figma-tokens.json` → source config → `setup:styles` (+ drift report) |
+
+Generated by `import.ts` (do not edit): `colors.ts`, `layout.mjs`,
+`typography.figma.ts`, `motion.ts`. Hand-authored: `typography.ts` (override shell).

--- a/lib/styles/scripts/figma/export.figma.js
+++ b/lib/styles/scripts/figma/export.figma.js
@@ -1,0 +1,169 @@
+/**
+ * Figma Variables + text styles → interchange JSON (the export half of the sync).
+ *
+ * This is Figma Plugin API code, NOT a repo module. It does not run in Node/Bun.
+ * Run it against the Figma file to produce the object that gets saved as
+ * `figma-tokens.json`, which `import.ts` then turns into repo config.
+ *
+ * Two ways to run it:
+ *   1. Agent / MCP: paste this body into a `use_figma` call (returns the JSON),
+ *      then write the result to figma-tokens.json.
+ *   2. Enterprise CI: port to the REST API (variables + text styles).
+ *
+ * It reads collections + text styles by name and maps them to the interchange:
+ *   Primitives (1 mode)              → primitives  (raw sRGB)
+ *   Color      (Light/Dark/Red/Evil) → themes      (aliases resolved to names)
+ *   Layout     (Mobile/Desktop)      → layout / screens / customSizes
+ *   Typography (Mobile/Desktop) + text styles → typography
+ *   Motion     (1 mode)              → motion
+ *
+ * Typography note: font-size binds cleanly to variables; line-height variable
+ * bindings are pixel-only in Figma, so line-height lives as percent VARIABLES
+ * (read here by name) rather than bound to the text style.
+ */
+
+// code ↔ Figma font maps (code-owned; unknown values fail the export loudly)
+const FAMILY_TO_KEY = { Oswald: 'display', 'Spline Sans Mono': 'mono' }
+const STYLE_TO_WEIGHT = {
+  Thin: 100,
+  ExtraLight: 200,
+  Light: 300,
+  Regular: 400,
+  Medium: 500,
+  SemiBold: 600,
+  Bold: 700,
+  ExtraBold: 800,
+  Black: 900,
+}
+
+const cols = await figma.variables.getLocalVariableCollectionsAsync()
+const byName = {}
+for (const c of cols) byName[c.name] = c
+const varById = new Map()
+for (const v of await figma.variables.getLocalVariablesAsync()) varById.set(v.id, v)
+
+const modeKey = (n) => n.toLowerCase()
+const desc = (v) => (v.description ? { description: v.description } : {})
+const errors = []
+
+// Primitives: raw sRGB (+ description)
+const primitives = {}
+{
+  const c = byName.Primitives
+  const mode = c.modes[0].modeId
+  for (const id of c.variableIds) {
+    const v = varById.get(id)
+    const val = v.valuesByMode[mode]
+    primitives[v.name] = { r: val.r, g: val.g, b: val.b, ...desc(v) }
+  }
+}
+
+// Color: semantic tokens per theme mode; aliases resolved to primitive names
+const themes = {}
+{
+  const c = byName.Color
+  for (const m of c.modes) {
+    const theme = {}
+    for (const id of c.variableIds) {
+      const v = varById.get(id)
+      const val = v.valuesByMode[m.modeId]
+      if (val && val.type === 'VARIABLE_ALIAS') theme[v.name] = { ref: varById.get(val.id).name }
+      else if (val) theme[v.name] = { rgb: { r: val.r, g: val.g, b: val.b } }
+    }
+    themes[modeKey(m.name)] = theme
+  }
+}
+
+// Layout: columns/gap/safe → layout; device-* → screens; rest → customSizes
+const RESERVED = new Set(['columns', 'gap', 'safe'])
+const layout = {}
+const screens = {}
+const customSizes = {}
+{
+  const c = byName.Layout
+  const modes = c.modes.map((m) => ({ key: modeKey(m.name), id: m.modeId }))
+  const read = (v) => Object.fromEntries(modes.map((m) => [m.key, v.valuesByMode[m.id]]))
+  for (const id of c.variableIds) {
+    const v = varById.get(id)
+    const vals = read(v)
+    if (RESERVED.has(v.name)) layout[v.name] = { ...vals, ...desc(v) }
+    else if (v.name === 'device-width') for (const m of modes) (screens[m.key] ??= {}).width = vals[m.key]
+    else if (v.name === 'device-height') for (const m of modes) (screens[m.key] ??= {}).height = vals[m.key]
+    else customSizes[v.name] = { ...vals, ...desc(v) }
+  }
+}
+
+// Typography: text styles + named Typography variables (font-size, line-height)
+const typography = {}
+{
+  const c = byName.Typography
+  const modes = c.modes.map((m) => ({ key: modeKey(m.name), id: m.modeId }))
+  const vars = {}
+  for (const id of c.variableIds) {
+    const v = varById.get(id)
+    vars[v.name] = Object.fromEntries(modes.map((m) => [m.key, v.valuesByMode[m.id]]))
+  }
+  for (const s of await figma.getLocalTextStylesAsync()) {
+    const name = s.name
+    const family = FAMILY_TO_KEY[s.fontName.family]
+    if (!family) {
+      errors.push(`Unknown font family "${s.fontName.family}" on text style "${name}" — add it to FAMILY_TO_KEY and fonts.ts`)
+      continue
+    }
+    const baseStyle = (s.fontName.style.replace(/ ?Italic$/, '') || 'Regular').replace(/\s+/g, '')
+    const weight = STYLE_TO_WEIGHT[baseStyle]
+    if (!weight) {
+      errors.push(`Unknown weight for style "${s.fontName.style}" on "${name}"`)
+      continue
+    }
+    if (s.letterSpacing.unit !== 'PERCENT') {
+      errors.push(`letter-spacing on "${name}" must be PERCENT (em), got ${s.letterSpacing.unit}`)
+      continue
+    }
+    const size = vars[`${name}/font-size`]
+    const lh = vars[`${name}/line-height`]
+    if (!size || !lh) {
+      errors.push(`Missing "${name}/font-size" or "${name}/line-height" variable`)
+      continue
+    }
+    const feats = s.openTypeFeatures || {}
+    const featKeys = Object.keys(feats)
+    typography[name] = {
+      family,
+      weight,
+      fontStyle: /Italic$/.test(s.fontName.style) ? 'italic' : 'normal',
+      letterSpacing: `${Number((s.letterSpacing.value / 100).toFixed(4))}em`,
+      leadingTrim: s.leadingTrim,
+      fontFeatureSettings: featKeys.length
+        ? featKeys.map((k) => `"${k.toLowerCase()}" ${feats[k] ? 1 : 0}`).join(', ')
+        : null,
+      fontSize: { mobile: size.mobile, desktop: size.desktop },
+      lineHeight: { mobile: `${lh.mobile}%`, desktop: `${lh.desktop}%` },
+    }
+  }
+}
+
+// Motion: durations in ms
+const motion = {}
+{
+  const c = byName.Motion
+  const mode = c.modes[0].modeId
+  for (const id of c.variableIds) {
+    const v = varById.get(id)
+    motion[v.name] = v.valuesByMode[mode]
+  }
+}
+
+if (errors.length) throw new Error(`Figma token export failed:\n- ${errors.join('\n- ')}`)
+
+return {
+  $generatedFrom: 'figma',
+  fileKey: figma.fileKey,
+  primitives,
+  themes,
+  layout,
+  screens,
+  customSizes,
+  typography,
+  motion,
+}

--- a/lib/styles/scripts/figma/figma-tokens.json
+++ b/lib/styles/scripts/figma/figma-tokens.json
@@ -1,0 +1,147 @@
+{
+  "$generatedFrom": "figma",
+  "fileKey": "DqTvmFVFWGEqpuaxrcnWvZ",
+  "primitives": {
+    "black": { "r": 0, "g": 0, "b": 0 },
+    "white": { "r": 1, "g": 1, "b": 1 },
+    "red": {
+      "r": 0.9120299816131592,
+      "g": 0.08732099831104279,
+      "b": 0.10317300260066986,
+      "description": "L tuned to 0.592 so red clears WCAG AA (4.5:1) as text on BOTH black and white — a single hue can only do that in a narrow band peaking at 4.583:1, so almost no slack. Check lib/styles/scripts/contrast.test.ts before changing."
+    },
+    "blue": {
+      "r": 0.00023700000019744039,
+      "g": 0.4392069876194,
+      "b": 0.9529520273208618
+    },
+    "green": { "r": 0, "g": 1, "b": 0.5333470106124878 }
+  },
+  "themes": {
+    "light": {
+      "primary": { "ref": "white" },
+      "secondary": { "ref": "black" },
+      "contrast": { "ref": "red" }
+    },
+    "dark": {
+      "primary": { "ref": "black" },
+      "secondary": { "ref": "white" },
+      "contrast": { "ref": "red" }
+    },
+    "red": {
+      "primary": { "ref": "red" },
+      "secondary": { "ref": "black" },
+      "contrast": { "ref": "white" }
+    },
+    "evil": {
+      "primary": { "ref": "black" },
+      "secondary": { "ref": "red" },
+      "contrast": { "ref": "white" }
+    }
+  },
+  "layout": {
+    "columns": {
+      "mobile": 4,
+      "desktop": 12,
+      "description": "Grid column count. Drives repeat(var(--columns),1fr) and column-based sizing."
+    },
+    "gap": {
+      "mobile": 16,
+      "desktop": 16,
+      "description": "Grid gutter, in design px at the reference device width. Repo emits it as fluid vw."
+    },
+    "safe": {
+      "mobile": 16,
+      "desktop": 16,
+      "description": "Outer safe margin (inline), design px. Repo emits it as fluid vw."
+    }
+  },
+  "screens": {
+    "mobile": { "width": 375, "height": 650 },
+    "desktop": { "width": 1440, "height": 816 }
+  },
+  "customSizes": {
+    "header-height": {
+      "mobile": 58,
+      "desktop": 98,
+      "description": "Header height, design px. Repo emits it as fluid vw (--header-height)."
+    }
+  },
+  "typography": {
+    "h1": {
+      "family": "display",
+      "weight": 700,
+      "fontStyle": "normal",
+      "letterSpacing": "-0.05em",
+      "leadingTrim": "NONE",
+      "fontFeatureSettings": null,
+      "fontSize": { "mobile": 72, "desktop": 120 },
+      "lineHeight": { "mobile": "80%", "desktop": "80%" }
+    },
+    "h2": {
+      "family": "display",
+      "weight": 700,
+      "fontStyle": "normal",
+      "letterSpacing": "-0.03em",
+      "leadingTrim": "NONE",
+      "fontFeatureSettings": null,
+      "fontSize": { "mobile": 32, "desktop": 48 },
+      "lineHeight": { "mobile": "80%", "desktop": "80%" }
+    },
+    "p-big": {
+      "family": "mono",
+      "weight": 400,
+      "fontStyle": "normal",
+      "letterSpacing": "-0.02em",
+      "leadingTrim": "NONE",
+      "fontFeatureSettings": null,
+      "fontSize": { "mobile": 16, "desktop": 20 },
+      "lineHeight": { "mobile": "125%", "desktop": "125%" }
+    },
+    "p": {
+      "family": "mono",
+      "weight": 400,
+      "fontStyle": "normal",
+      "letterSpacing": "-0.01em",
+      "leadingTrim": "NONE",
+      "fontFeatureSettings": null,
+      "fontSize": { "mobile": 12, "desktop": 14 },
+      "lineHeight": { "mobile": "125%", "desktop": "120%" }
+    },
+    "caption": {
+      "family": "mono",
+      "weight": 400,
+      "fontStyle": "normal",
+      "letterSpacing": "-0.01em",
+      "leadingTrim": "NONE",
+      "fontFeatureSettings": null,
+      "fontSize": { "mobile": 8, "desktop": 10 },
+      "lineHeight": { "mobile": "125%", "desktop": "120%" }
+    },
+    "cta": {
+      "family": "mono",
+      "weight": 400,
+      "fontStyle": "normal",
+      "letterSpacing": "-0.01em",
+      "leadingTrim": "NONE",
+      "fontFeatureSettings": null,
+      "fontSize": { "mobile": 12, "desktop": 14 },
+      "lineHeight": { "mobile": "100%", "desktop": "100%" }
+    },
+    "link": {
+      "family": "mono",
+      "weight": 400,
+      "fontStyle": "normal",
+      "letterSpacing": "-0.01em",
+      "leadingTrim": "NONE",
+      "fontFeatureSettings": null,
+      "fontSize": { "mobile": 12, "desktop": 14 },
+      "lineHeight": { "mobile": "125%", "desktop": "120%" }
+    }
+  },
+  "motion": {
+    "duration-fast": 200,
+    "duration": 400,
+    "duration-slow": 800
+  }
+}

--- a/lib/styles/scripts/figma/import.ts
+++ b/lib/styles/scripts/figma/import.ts
@@ -1,0 +1,292 @@
+/**
+ * Figma → repo token importer.
+ *
+ * Reads `figma-tokens.json` (produced by the Figma export step — see README.md),
+ * converts colors to `oklch()`, and regenerates the source config the style
+ * pipeline consumes:
+ *
+ *   figma-tokens.json ──▶ colors.ts + layout.mjs ──▶ bun setup:styles ──▶ CSS
+ *
+ * Figma is the source of truth for the palette, themes, and grid; `breakpoints`
+ * (a code-side media-query value, not a Figma variable) is preserved from the
+ * existing layout.mjs. The contrast gate (`bun run check`) validates every sync.
+ *
+ * Run: bun run figma:import
+ */
+
+import { join } from 'node:path'
+import Color from 'colorjs.io'
+import { type FigmaTokens, figmaTokensSchema } from './schema'
+
+const HERE = import.meta.dir
+const STYLES = join(HERE, '..', '..') // lib/styles
+const TOKENS_PATH = join(HERE, 'figma-tokens.json')
+const COLORS_PATH = join(STYLES, 'colors.ts')
+const LAYOUT_PATH = join(STYLES, 'layout.mjs')
+const TYPO_FIGMA_PATH = join(STYLES, 'typography.figma.ts')
+const MOTION_PATH = join(STYLES, 'motion.ts')
+const TYPO_SHELL_PATH = join(STYLES, 'typography.ts')
+
+const banner = (extra = '') => `/*
+ * GENERATED FROM FIGMA VARIABLES — DO NOT EDIT DIRECTLY.
+ * Source of truth: Figma variables → figma-tokens.json → bun run figma:import.${extra}
+ */`
+
+/** Trim trailing zeros: 0.5920 → "0.592", 0 → "0", 1 → "1". */
+const num = (n: number, digits: number) => String(Number(n.toFixed(digits)))
+
+function toOklch({ r, g, b }: { r: number; g: number; b: number }): string {
+  const [L, C, H] = new Color('srgb', [r, g, b]).to('oklch').coords
+  const hue = H == null || Number.isNaN(H) ? 0 : H
+  return `oklch(${num(L ?? 0, 4)} ${num(C ?? 0, 4)} ${num(hue, 2)})`
+}
+
+/** Wrap a description into `//` comment lines at ~72 chars, indented by `indent`. */
+function commentLines(text: string, indent: string): string[] {
+  const words = text.split(/\s+/)
+  const lines: string[] = []
+  let line = ''
+  for (const word of words) {
+    if (line && `${line} ${word}`.length > 72) {
+      lines.push(`${indent}// ${line}`)
+      line = word
+    } else {
+      line = line ? `${line} ${word}` : word
+    }
+  }
+  if (line) lines.push(`${indent}// ${line}`)
+  return lines
+}
+
+const ident = (key: string) =>
+  /^[A-Za-z_$][\w$]*$/.test(key) ? key : `'${key}'`
+
+function generateColors(tokens: FigmaTokens): string {
+  const { primitives, themes } = tokens
+  const themeNames = Object.keys(themes)
+  const colorNames = Object.keys(themes[themeNames[0] as string] as object)
+
+  const paletteLines: string[] = []
+  for (const [name, value] of Object.entries(primitives)) {
+    if (value.description)
+      paletteLines.push(...commentLines(value.description, '  '))
+    paletteLines.push(`  ${ident(name)}: '${toOklch(value)}',`)
+  }
+
+  const themeLines: string[] = []
+  for (const theme of themeNames) {
+    themeLines.push(`  ${ident(theme)}: {`)
+    for (const role of colorNames) {
+      const entry = (
+        themes[theme] as Record<
+          string,
+          { ref?: string; rgb?: { r: number; g: number; b: number } }
+        >
+      )[role]
+      const rhs = entry?.ref
+        ? `colors.${entry.ref}`
+        : `'${toOklch(entry?.rgb as { r: number; g: number; b: number })}'`
+      themeLines.push(`    ${ident(role)}: ${rhs},`)
+    }
+    themeLines.push('  },')
+  }
+
+  return `${banner()}
+
+const colors = {
+${paletteLines.join('\n')}
+} as const
+
+const themeNames = [${themeNames.map((n) => `'${n}'`).join(', ')}] as const
+const colorNames = [${colorNames.map((n) => `'${n}'`).join(', ')}] as const
+
+const themes = {
+${themeLines.join('\n')}
+} as const satisfies Themes
+
+export { colors, themeNames, themes }
+
+// UTIL TYPES
+export type Themes = Record<
+  (typeof themeNames)[number],
+  Record<(typeof colorNames)[number], string>
+>
+`
+}
+
+function responsiveBlock(name: string, entries: FigmaTokens['layout']): string {
+  const lines: string[] = []
+  for (const [key, value] of Object.entries(entries)) {
+    if (value.description) lines.push(...commentLines(value.description, '  '))
+    lines.push(
+      `  ${ident(key)}: { mobile: ${value.mobile}, desktop: ${value.desktop} },`
+    )
+  }
+  return `const ${name} = {\n${lines.join('\n')}\n}`
+}
+
+async function readBreakpoints(): Promise<Record<string, number>> {
+  try {
+    const mod = (await import(`${LAYOUT_PATH}?t=${Date.now()}`)) as {
+      breakpoints?: Record<string, number>
+    }
+    if (mod.breakpoints) return mod.breakpoints
+  } catch {
+    // fall through to default
+  }
+  return { dt: 800 }
+}
+
+function generateLayout(
+  tokens: FigmaTokens,
+  breakpoints: Record<string, number>
+): string {
+  const bpLines = Object.entries(breakpoints).map(
+    ([k, v]) => `  ${ident(k)}: ${v},`
+  )
+  const screenLines = Object.entries(tokens.screens).map(
+    ([k, v]) => `  ${ident(k)}: { width: ${v.width}, height: ${v.height} },`
+  )
+
+  return `// THIS FILE HAS TO STAY .mjs AS ITS CONSUMED BY POSTCSS
+${banner(' `breakpoints` below is code-owned and preserved across syncs.')}
+const breakpoints = {
+${bpLines.join('\n')}
+}
+
+const screens = {
+${screenLines.join('\n')}
+}
+
+${responsiveBlock('layout', tokens.layout)}
+
+${responsiveBlock('customSizes', tokens.customSizes)}
+
+export { breakpoints, customSizes, layout, screens }
+`
+}
+
+function generateTypographyFigma(tokens: FigmaTokens): string {
+  const lines: string[] = []
+  for (const [style, t] of Object.entries(tokens.typography)) {
+    lines.push(`  ${ident(style)}: {`)
+    lines.push(`    family: '${t.family}',`)
+    lines.push(`    weight: ${t.weight},`)
+    lines.push(`    fontStyle: '${t.fontStyle}',`)
+    lines.push(`    letterSpacing: '${t.letterSpacing}',`)
+    lines.push(`    leadingTrim: '${t.leadingTrim}',`)
+    lines.push(
+      `    fontFeatureSettings: ${t.fontFeatureSettings == null ? 'null' : `'${t.fontFeatureSettings}'`},`
+    )
+    lines.push(
+      `    fontSize: { mobile: ${t.fontSize.mobile}, desktop: ${t.fontSize.desktop} },`
+    )
+    lines.push(
+      `    lineHeight: { mobile: '${t.lineHeight.mobile}', desktop: '${t.lineHeight.desktop}' },`
+    )
+    lines.push('  },')
+  }
+  return `${banner(' Overrides live in typography.ts.')}
+
+export const figmaTypography = {
+${lines.join('\n')}
+} as const
+`
+}
+
+function generateMotion(tokens: FigmaTokens): string {
+  const lines = Object.entries(tokens.motion).map(
+    ([name, ms]) => `  ${ident(name)}: ${ms},`
+  )
+  return `${banner()}
+
+/** Motion durations in ms. Emitted to root.css as \`--<name>: <ms>ms\`. */
+export const durations = {
+${lines.join('\n')}
+} as const
+`
+}
+
+/**
+ * Warn (never fail) when a code override in typography.ts masks a live Figma
+ * value — so a design change that silently does nothing is visible.
+ */
+async function reportTypographyDrift(tokens: FigmaTokens): Promise<void> {
+  let overrides: Record<string, Record<string, unknown>> = {}
+  try {
+    const mod = (await import(`${TYPO_SHELL_PATH}?t=${Date.now()}`)) as {
+      overrides?: Record<string, Record<string, unknown>>
+    }
+    overrides = mod.overrides ?? {}
+  } catch {
+    return
+  }
+  const drift: string[] = []
+  for (const [style, props] of Object.entries(overrides)) {
+    const figmaStyle = (
+      tokens.typography as Record<string, Record<string, unknown>>
+    )[style]
+    if (!figmaStyle) continue
+    for (const [prop, overrideVal] of Object.entries(props)) {
+      const figmaVal = figmaStyle[prop]
+      if (JSON.stringify(figmaVal) !== JSON.stringify(overrideVal)) {
+        drift.push(
+          `    ${style}.${prop}: figma=${JSON.stringify(figmaVal)} → override=${JSON.stringify(overrideVal)}`
+        )
+      }
+    }
+  }
+  if (drift.length) {
+    console.warn(
+      `\n⚠ ${drift.length} code override(s) mask Figma values (intentional, but review):\n${drift.join('\n')}`
+    )
+  }
+}
+
+async function run() {
+  const raw = await Bun.file(TOKENS_PATH).json()
+  const tokens = figmaTokensSchema.parse(raw)
+
+  const breakpoints = await readBreakpoints()
+  await Bun.write(COLORS_PATH, generateColors(tokens))
+  await Bun.write(LAYOUT_PATH, generateLayout(tokens, breakpoints))
+  await Bun.write(TYPO_FIGMA_PATH, generateTypographyFigma(tokens))
+  await Bun.write(MOTION_PATH, generateMotion(tokens))
+
+  // Normalize formatting to house style, then regenerate the CSS.
+  await Bun.spawn(
+    [
+      'bun',
+      'biome',
+      'format',
+      '--write',
+      COLORS_PATH,
+      LAYOUT_PATH,
+      TYPO_FIGMA_PATH,
+      MOTION_PATH,
+    ],
+    {
+      cwd: join(STYLES, '..', '..'),
+      stdout: 'inherit',
+      stderr: 'inherit',
+    }
+  ).exited
+
+  const setup = Bun.spawn(['bun', 'run', 'setup:styles'], {
+    cwd: join(STYLES, '..', '..'),
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+  await setup.exited
+
+  await reportTypographyDrift(tokens)
+
+  console.log(
+    `\n✓ Imported ${Object.keys(tokens.primitives).length} palette colors, ${Object.keys(tokens.themes).length} themes, ${Object.keys(tokens.layout).length + Object.keys(tokens.customSizes).length} layout tokens, ${Object.keys(tokens.typography).length} type styles, ${Object.keys(tokens.motion).length} durations from Figma.`
+  )
+  console.log(
+    '  Next: bun run check   (validates contrast + types before commit)'
+  )
+}
+
+run()

--- a/lib/styles/scripts/figma/schema.ts
+++ b/lib/styles/scripts/figma/schema.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod'
+
+/**
+ * Interchange schema for Figma → repo token sync.
+ *
+ * This is the contract between whatever pulls variables out of Figma (the
+ * `use_figma` export snippet in `export.figma.js`, or a REST job on Enterprise)
+ * and `import.ts`, which turns it into `colors.ts` / `layout.mjs`. Colors arrive
+ * as Figma-native sRGB (0–1); the importer converts them to `oklch()`.
+ */
+
+const rgb = z.object({
+  r: z.number().min(0).max(1),
+  g: z.number().min(0).max(1),
+  b: z.number().min(0).max(1),
+})
+
+const responsive = z.object({
+  mobile: z.number(),
+  desktop: z.number(),
+  description: z.string().optional(),
+})
+
+/** A semantic color is either an alias to a primitive (by name) or a raw sRGB value. */
+const semanticColor = z.union([
+  z.object({ ref: z.string() }),
+  z.object({ rgb }),
+])
+
+/**
+ * One text-ramp style. font-size + line-height come from bound/named Typography
+ * variables (per breakpoint); the rest are static properties of the text style.
+ * `leadingTrim` maps to CSS `text-box-trim`; `fontFeatureSettings` to
+ * `font-feature-settings` (null when no OpenType features are set).
+ */
+const typographyStyle = z.object({
+  family: z.string(),
+  weight: z.number(),
+  fontStyle: z.string(),
+  letterSpacing: z.string(),
+  leadingTrim: z.enum(['NONE', 'CAP_HEIGHT']),
+  fontFeatureSettings: z.string().nullable(),
+  fontSize: z.object({ mobile: z.number(), desktop: z.number() }),
+  lineHeight: z.object({ mobile: z.string(), desktop: z.string() }),
+})
+
+export const figmaTokensSchema = z.object({
+  $generatedFrom: z.literal('figma').optional(),
+  fileKey: z.string().optional(),
+  /** Raw palette (Primitives collection). oklch is derived from these. */
+  primitives: z.record(
+    z.string(),
+    rgb.extend({ description: z.string().optional() })
+  ),
+  /** Theme modes → semantic role → alias/raw (Color collection). */
+  themes: z.record(z.string(), z.record(z.string(), semanticColor)),
+  /** Grid tokens: columns/gap/safe, per breakpoint (Layout collection). */
+  layout: z.record(z.string(), responsive),
+  /** Reference device dimensions per breakpoint. */
+  screens: z.record(
+    z.string(),
+    z.object({ width: z.number(), height: z.number() })
+  ),
+  /** Everything else in the Layout collection, e.g. header-height. */
+  customSizes: z.record(z.string(), responsive),
+  /** Text ramp (Typography collection + text styles). Keyed by style name. */
+  typography: z.record(z.string(), typographyStyle),
+  /** Motion durations in ms (Motion collection). */
+  motion: z.record(z.string(), z.number()),
+})
+
+export type FigmaTokens = z.infer<typeof figmaTokensSchema>

--- a/lib/styles/scripts/generate-root.ts
+++ b/lib/styles/scripts/generate-root.ts
@@ -4,9 +4,13 @@ import { formatObject, scalingCalc } from './utils'
 export function generateRoot({
   breakpoints,
   customSizes,
+  durations,
   layout,
   screens,
-}: Pick<Config, 'breakpoints' | 'customSizes' | 'layout' | 'screens'>) {
+}: Pick<
+  Config,
+  'breakpoints' | 'customSizes' | 'durations' | 'layout' | 'screens'
+>) {
   return `@custom-media --hover (hover: hover);
 @custom-media --mobile (width <= ${breakpoints.dt - 0.02}px);
 @custom-media --desktop (width >= ${breakpoints.dt}px);
@@ -23,6 +27,8 @@ export function generateRoot({
   })}
 
 	${formatObject(customSizes, ([name, { mobile }]) => `--${name}: ${scalingCalc(mobile)};`)}
+
+	${formatObject(durations, ([name, ms]) => `--${name}: ${ms}ms;`)}
 
 	--layout-width: calc(100vw - (2 * var(--safe)));
 	--column-width: calc((var(--layout-width) - (var(--columns) - 1) * var(--gap)) / var(--columns));

--- a/lib/styles/typography.figma.ts
+++ b/lib/styles/typography.figma.ts
@@ -1,0 +1,77 @@
+/*
+ * GENERATED FROM FIGMA VARIABLES — DO NOT EDIT DIRECTLY.
+ * Source of truth: Figma variables → figma-tokens.json → bun run figma:import. Overrides live in typography.ts.
+ */
+
+export const figmaTypography = {
+  h1: {
+    family: 'display',
+    weight: 700,
+    fontStyle: 'normal',
+    letterSpacing: '-0.05em',
+    leadingTrim: 'NONE',
+    fontFeatureSettings: null,
+    fontSize: { mobile: 72, desktop: 120 },
+    lineHeight: { mobile: '80%', desktop: '80%' },
+  },
+  h2: {
+    family: 'display',
+    weight: 700,
+    fontStyle: 'normal',
+    letterSpacing: '-0.03em',
+    leadingTrim: 'NONE',
+    fontFeatureSettings: null,
+    fontSize: { mobile: 32, desktop: 48 },
+    lineHeight: { mobile: '80%', desktop: '80%' },
+  },
+  'p-big': {
+    family: 'mono',
+    weight: 400,
+    fontStyle: 'normal',
+    letterSpacing: '-0.02em',
+    leadingTrim: 'NONE',
+    fontFeatureSettings: null,
+    fontSize: { mobile: 16, desktop: 20 },
+    lineHeight: { mobile: '125%', desktop: '125%' },
+  },
+  p: {
+    family: 'mono',
+    weight: 400,
+    fontStyle: 'normal',
+    letterSpacing: '-0.01em',
+    leadingTrim: 'NONE',
+    fontFeatureSettings: null,
+    fontSize: { mobile: 12, desktop: 14 },
+    lineHeight: { mobile: '125%', desktop: '120%' },
+  },
+  caption: {
+    family: 'mono',
+    weight: 400,
+    fontStyle: 'normal',
+    letterSpacing: '-0.01em',
+    leadingTrim: 'NONE',
+    fontFeatureSettings: null,
+    fontSize: { mobile: 8, desktop: 10 },
+    lineHeight: { mobile: '125%', desktop: '120%' },
+  },
+  cta: {
+    family: 'mono',
+    weight: 400,
+    fontStyle: 'normal',
+    letterSpacing: '-0.01em',
+    leadingTrim: 'NONE',
+    fontFeatureSettings: null,
+    fontSize: { mobile: 12, desktop: 14 },
+    lineHeight: { mobile: '100%', desktop: '100%' },
+  },
+  link: {
+    family: 'mono',
+    weight: 400,
+    fontStyle: 'normal',
+    letterSpacing: '-0.01em',
+    leadingTrim: 'NONE',
+    fontFeatureSettings: null,
+    fontSize: { mobile: 12, desktop: 14 },
+    lineHeight: { mobile: '125%', desktop: '120%' },
+  },
+} as const

--- a/lib/styles/typography.ts
+++ b/lib/styles/typography.ts
@@ -1,85 +1,77 @@
-import type { CSSProperties } from 'react'
+/**
+ * Typography — Figma-sourced ramp + code overrides.
+ *
+ * The raw ramp is generated from Figma into `typography.figma.ts` (do not edit
+ * that file). This module is hand-authored: it owns the font-key → CSS-variable
+ * map, the code `overrides` layer, and the transform into the CSS-property shape
+ * that `generate-tailwind.ts` compiles into `@utility` classes.
+ *
+ * Why overrides exist: text renders differently in a browser than in Figma
+ * (CSS half-leading, `text-box-trim` support, next/font fallback metrics), so a
+ * value that's right in Figma is occasionally wrong on the web. Overrides win,
+ * and `bun run figma:import` warns whenever one masks a changed Figma value.
+ */
 
+import { figmaTypography } from './typography.figma'
+
+// Code-owned: font key → the CSS variable next/font exposes (see fonts.ts).
 const fonts = {
   display: '--next-font-display',
-  mono: '--next-font-mono', // this should be the variable name defined in fonts.ts
+  mono: '--next-font-mono',
 } as const
 
-const typography: TypeStyles = {
-  h1: {
-    'font-family': `var(${fonts.display})`,
-    'font-style': 'normal',
-    'font-weight': 700,
-    'line-height': '80%',
-    'letter-spacing': '-0.05em',
-    'font-size': { mobile: 72, desktop: 120 },
-  },
-  h2: {
-    'font-family': `var(${fonts.display})`,
-    'font-style': 'normal',
-    'font-weight': 700,
-    'line-height': '80%',
-    'letter-spacing': '-0.03em',
-    'font-size': { mobile: 32, desktop: 48 },
-  },
-  'p-big': {
-    'font-family': `var(${fonts.mono})`,
-    'font-style': 'normal',
-    'font-weight': 400,
-    'line-height': '125%',
-    'letter-spacing': '-0.02em',
-    'font-size': { mobile: 16, desktop: 20 },
-  },
-  p: {
-    'font-family': `var(${fonts.mono})`,
-    'font-style': 'normal',
-    'font-weight': 400,
-    'line-height': { mobile: '125%', desktop: '120%' },
-    'letter-spacing': '-0.01em',
-    'font-size': { mobile: 12, desktop: 14 },
-  },
-  caption: {
-    'font-family': `var(${fonts.mono})`,
-    'font-style': 'normal',
-    'font-weight': 400,
-    'line-height': { mobile: '125%', desktop: '120%' },
-    'letter-spacing': '-0.01em',
-    'font-size': { mobile: 8, desktop: 10 },
-  },
-  cta: {
-    'font-family': `var(${fonts.mono})`,
-    'font-style': 'normal',
-    'font-weight': 400,
-    'line-height': '100%',
-    'letter-spacing': '-0.01em',
-    'font-size': { mobile: 12, desktop: 14 },
-  },
-  link: {
-    'font-family': `var(${fonts.mono})`,
-    'font-style': 'normal',
-    'font-weight': 400,
-    'line-height': { mobile: '125%', desktop: '120%' },
-    'letter-spacing': '-0.01em',
-    'font-size': { mobile: 12, desktop: 14 },
-  },
-} as const
+type FontKey = keyof typeof fonts
+type Responsive<T> = { mobile: T; desktop: T }
+type StyleName = keyof typeof figmaTypography
+
+type TypeStyle = {
+  family: FontKey
+  weight: number
+  fontStyle: string
+  letterSpacing: string
+  leadingTrim: 'NONE' | 'CAP_HEIGHT'
+  fontFeatureSettings: string | null
+  fontSize: Responsive<number>
+  lineHeight: Responsive<string>
+}
+
+/**
+ * Code overrides — merged over the Figma ramp, per style, per property. Empty
+ * means "pure Figma". Example: `{ p: { lineHeight: { mobile: '130%', desktop:
+ * '125%' } } }`. Each override is reported on the next `figma:import`.
+ */
+export const overrides: Partial<Record<StyleName, Partial<TypeStyle>>> = {}
+
+type CssValue = string | number | Responsive<string | number>
+type CssStyle = Record<string, CssValue>
+
+const collapse = <T>(r: Responsive<T>): T | Responsive<T> =>
+  r.mobile === r.desktop ? r.mobile : r
+
+/** Structured style → CSS-property object (the shape generate-tailwind expects). */
+function toCss(style: TypeStyle): CssStyle {
+  const css: CssStyle = {
+    'font-family': `var(${fonts[style.family]})`,
+    'font-style': style.fontStyle,
+    'font-weight': style.weight,
+    'line-height': collapse(style.lineHeight),
+    'letter-spacing': style.letterSpacing,
+  }
+  // Figma "Vertical trim: Cap height to baseline" → CSS text-box trimming.
+  if (style.leadingTrim === 'CAP_HEIGHT') {
+    css['text-box-trim'] = 'both'
+    css['text-box-edge'] = 'cap alphabetic'
+  }
+  if (style.fontFeatureSettings)
+    css['font-feature-settings'] = style.fontFeatureSettings
+  css['font-size'] = style.fontSize
+  return css
+}
+
+const typography = {} as Record<StyleName, CssStyle>
+for (const name of Object.keys(figmaTypography) as StyleName[]) {
+  const base = figmaTypography[name] as TypeStyle
+  typography[name] = toCss({ ...base, ...(overrides[name] ?? {}) })
+}
 
 export { fonts, typography }
-
-// UTIL TYPES
-type TypeStyles = Record<
-  string,
-  {
-    'font-family': string
-    'font-style': CSSProperties['fontStyle']
-    'font-weight': CSSProperties['fontWeight']
-    'line-height':
-      | `${number}%`
-      | { mobile: `${number}%`; desktop: `${number}%` }
-    'letter-spacing':
-      | `${number}em`
-      | { mobile: `${number}em`; desktop: `${number}em` }
-    'font-feature-settings'?: string
-    'font-size': number | { mobile: number; desktop: number }
-  }
->

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "doctor": "bun ./lib/scripts/doctor.ts",
     "contrast:accept": "bun ./lib/styles/scripts/contrast-accept.ts",
     "setup:styles": "bun ./lib/styles/scripts/setup-styles.ts",
+    "figma:import": "bun ./lib/styles/scripts/figma/import.ts",
     "generate": "bun ./lib/scripts/generate.ts",
     "generate:manifest": "bun ./lib/scripts/generate-manifest.ts",
     "manifest:check": "bun ./lib/scripts/generate-manifest.ts --check",


### PR DESCRIPTION
Summary

Adds a Figma → repo design-token sync. Figma Variables + text styles are the source of truth; a pipeline regenerates the style config, and setup:styles compiles it to CSS. Every sync is validated by the existing contrast gate. Also scaffolds the Figma file (colors, layout, typography, motion) — see lib/styles/scripts/figma/README.md.

Flow: Figma → figma-tokens.json → import.ts → colors.ts / layout.mjs / typography.figma.ts / motion.ts → setup:styles → CSS

Changes

- New pipeline lib/styles/scripts/figma/: export.figma.js (Plugin API snippet), schema.ts (Zod contract), import.ts (importer + drift report), figma-tokens.json (snapshot), README.md. Adds bun run figma:import.
- colors + layout now generated from Figma (colors.ts, layout.mjs); sRGB→oklch via colorjs.io, lossless round-trip. breakpoints stays code-owned.
- typography: 7 text styles + per-style font-size/line-height vars → generated typography.figma.ts; typography.ts becomes a hand-authored override shell (code overrides win; import warns on drift).
- motion: durations → motion.ts → --duration-* in generated root.css (moved out of hand-authored global.css).
- biome.json ignores *.figma.js runtime snippets.

Figma constraints handled: font-size is variable-bound (responsive); line-height lives as percent vars read by name (bound line-height is px-only in Figma); leadingTrim CAP_HEIGHT → text-box-trim; OpenType features → font-feature-settings.

Checklist

- [x] bun run check passes (biome + typecheck + tests) — 360 tests, WCAG AA contrast gate green
- [x] Tested locally in dev mode and verified via lossless round-trip (regenerated CSS byte-identical bar an evil/red theme reorder) + setup:styles
- [x] No breaking runtime changes — public exports (fonts, typography, tokens) unchanged. Note: restructures colors.ts/typography.ts into generated + shell files — a divergence from upstream to keep in mind when rebasing onto new Satūs releases.