### PR TITLE
feat(setup): disable Cache Components when no CMS/storefront is kept

### DIFF
--- a/lib/scripts/ast-operation-types.ts
+++ b/lib/scripts/ast-operation-types.ts
@@ -187,6 +187,41 @@ export interface RemoveArrayStringElementOp {
 }
 
 // ---------------------------------------------------------------------------
+// Mutating operations
+// Unlike the additive ops below, these never create a construct that doesn't
+// already exist — they overwrite an existing value in place.
+// ---------------------------------------------------------------------------
+
+/**
+ * Set an existing property's value in an object literal at
+ * `variableName`.`propertyPath` (dot-separated, walking nested object
+ * properties, e.g. `'experimental.cachedNavigations'`). Overwrites the
+ * property's current initializer with `valueText`, inserted verbatim as
+ * source text — callers are responsible for quoting (e.g. `'false'` for a
+ * boolean, `"'some string'"` for a string literal).
+ *
+ * Designed for flipping a `next.config.ts` flag conditionally, e.g. turning
+ * `cacheComponents` off when no kept integration benefits from it.
+ *
+ * No-op (returns the source unchanged) when `variableName`/`propertyPath`
+ * doesn't resolve to an existing property, or the property's current value
+ * already equals `valueText` — see `applySetObjectProperty`'s doc for the
+ * exact conditions.
+ */
+export interface SetObjectPropertyOp {
+  kind: 'setObjectProperty'
+  /** The variable name that holds the object, e.g. `'nextConfig'`. */
+  variableName: string
+  /**
+   * Dot-separated path from the variable declaration down to the property
+   * to set, e.g. `'cacheComponents'` or `'experimental.cachedNavigations'`.
+   */
+  propertyPath: string
+  /** Replacement value, as source text, e.g. `'false'`. */
+  valueText: string
+}
+
+// ---------------------------------------------------------------------------
 // Additive operations (inverse of the removals above)
 // Every additive op is IDEMPOTENT: when the construct it would add is already
 // present, the source text is returned byte-for-byte unchanged, so applying
@@ -318,6 +353,7 @@ export type AstOperation =
   | RemoveIfStatementOp
   | RemoveArrayObjectElementOp
   | RemoveArrayStringElementOp
+  | SetObjectPropertyOp
   | AddImportOp
   | AddArrayStringElementOp
   | AddArrayObjectElementOp

--- a/lib/scripts/ast-transforms.test.ts
+++ b/lib/scripts/ast-transforms.test.ts
@@ -233,6 +233,123 @@ export async function POST(request: NextRequest) {
 })
 
 // ---------------------------------------------------------------------------
+// setObjectProperty
+// ---------------------------------------------------------------------------
+
+describe('setObjectProperty', () => {
+  const cacheConfigFixture = `const nextConfig: NextConfig = {
+  cacheComponents: true,
+  experimental: {
+    cachedNavigations: true,
+    prefetchInlining: true,
+  },
+}
+
+export default nextConfig
+`
+
+  it('overwrites a top-level property value and is idempotent', () => {
+    const op: AstOperation = {
+      kind: 'setObjectProperty',
+      variableName: 'nextConfig',
+      propertyPath: 'cacheComponents',
+      valueText: 'false',
+    }
+    const result = applyOpsToText(cacheConfigFixture, [op])
+
+    expect(result).toContain('cacheComponents: false')
+    expect(result).not.toContain('cacheComponents: true')
+    // Setting the same value twice is a byte-for-byte no-op.
+    expect(applyOpsToText(result, [op])).toBe(result)
+  })
+
+  it('overwrites a nested property value via a dotted path, leaving siblings intact', () => {
+    const result = applyOpsToText(cacheConfigFixture, [
+      {
+        kind: 'setObjectProperty',
+        variableName: 'nextConfig',
+        propertyPath: 'experimental.cachedNavigations',
+        valueText: 'false',
+      },
+    ])
+
+    expect(result).toContain('cachedNavigations: false')
+    expect(result).toContain('prefetchInlining: true')
+    expect(result).toContain('cacheComponents: true')
+  })
+
+  it('is an exact no-op when the final path segment names a missing property', () => {
+    const result = applyOpsToText(cacheConfigFixture, [
+      {
+        kind: 'setObjectProperty',
+        variableName: 'nextConfig',
+        propertyPath: 'experimental.doesNotExist',
+        valueText: 'false',
+      },
+    ])
+    expect(result).toBe(cacheConfigFixture)
+  })
+
+  it('is an exact no-op when a parent path segment does not resolve', () => {
+    const result = applyOpsToText(cacheConfigFixture, [
+      {
+        kind: 'setObjectProperty',
+        variableName: 'nextConfig',
+        propertyPath: 'doesNotExist.cachedNavigations',
+        valueText: 'false',
+      },
+    ])
+    expect(result).toBe(cacheConfigFixture)
+  })
+
+  it('is an exact no-op when the variable is missing', () => {
+    const result = applyOpsToText(cacheConfigFixture, [
+      {
+        kind: 'setObjectProperty',
+        variableName: 'otherConfig',
+        propertyPath: 'cacheComponents',
+        valueText: 'false',
+      },
+    ])
+    expect(result).toBe(cacheConfigFixture)
+  })
+
+  it('is an exact no-op when the value already equals the target', () => {
+    const result = applyOpsToText(cacheConfigFixture, [
+      {
+        kind: 'setObjectProperty',
+        variableName: 'nextConfig',
+        propertyPath: 'cacheComponents',
+        valueText: 'true',
+      },
+    ])
+    expect(result).toBe(cacheConfigFixture)
+  })
+
+  it('applies two ops in sequence — the cacheComponents opt-out pairing', () => {
+    const result = applyOpsToText(cacheConfigFixture, [
+      {
+        kind: 'setObjectProperty',
+        variableName: 'nextConfig',
+        propertyPath: 'cacheComponents',
+        valueText: 'false',
+      },
+      {
+        kind: 'setObjectProperty',
+        variableName: 'nextConfig',
+        propertyPath: 'experimental.cachedNavigations',
+        valueText: 'false',
+      },
+    ])
+
+    expect(result).toContain('cacheComponents: false')
+    expect(result).toContain('cachedNavigations: false')
+    // prefetchInlining is deliberately left untouched (probed separately).
+    expect(result).toContain('prefetchInlining: true')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // addImport
 // ---------------------------------------------------------------------------
 

--- a/lib/scripts/ast-transforms.ts
+++ b/lib/scripts/ast-transforms.ts
@@ -5,6 +5,7 @@
  *   ast-transforms/helpers.ts     — shared helpers
  *   ast-transforms/remove-ops.ts  — subtractive operation handlers
  *   ast-transforms/add-ops.ts     — additive operation handlers
+ *   ast-transforms/set-ops.ts     — mutating (overwrite-in-place) operation handlers
  *   ast-transforms/index.ts       — dispatch + disk API
  */
 

--- a/lib/scripts/ast-transforms/index.ts
+++ b/lib/scripts/ast-transforms/index.ts
@@ -33,6 +33,7 @@ import {
   applyRemoveVariableStatement,
   applyReplaceJsDoc,
 } from './remove-ops'
+import { applySetObjectProperty } from './set-ops'
 
 // ---------------------------------------------------------------------------
 // Per-file transform runner
@@ -104,6 +105,9 @@ export function applyOpsToText(
         break
       case 'removeArrayStringElement':
         text = applyRemoveArrayStringElement(project, text, op)
+        break
+      case 'setObjectProperty':
+        text = applySetObjectProperty(project, text, op)
         break
       case 'addImport':
         text = applyAddImport(project, text, op)

--- a/lib/scripts/ast-transforms/set-ops.ts
+++ b/lib/scripts/ast-transforms/set-ops.ts
@@ -1,0 +1,75 @@
+/**
+ * Mutating AST operation handlers — overwrite an existing value in place.
+ *
+ * Unlike the additive handlers in `add-ops.ts`, these never create a
+ * construct that doesn't already exist.
+ */
+
+import { type Project, SyntaxKind } from 'ts-morph'
+import type { SetObjectPropertyOp } from '../ast-operation-types'
+import { resolvePropertyPath, withSourceFile } from './helpers'
+
+/**
+ * Set an existing property's value in an object literal at
+ * `variableName`.`propertyPath` (dot-separated — walks nested object
+ * properties down to the parent of the final segment, e.g.
+ * `'experimental.cachedNavigations'` resolves `experimental` as the parent
+ * object literal and sets its `cachedNavigations` property).
+ *
+ * No-op — returns `sourceText` unchanged — when:
+ *  - `variableName` isn't found, or its initializer isn't an object literal
+ *  - any parent segment of `propertyPath` doesn't resolve to a nested
+ *    object literal (reuses `resolvePropertyPath`'s traversal for this)
+ *  - the final path segment doesn't name an existing property on that object
+ *    (this op only ever overwrites — it never creates a missing property)
+ *  - the property's current initializer text already equals `op.valueText`
+ *    (idempotent — reapplying with the same value is a byte-for-byte no-op)
+ */
+export function applySetObjectProperty(
+  project: Project,
+  sourceText: string,
+  op: SetObjectPropertyOp
+): string {
+  return withSourceFile(project, sourceText, (sf) => {
+    const parts = op.propertyPath.split('.')
+    const lastPart = parts.pop()
+    if (!lastPart) return sourceText
+    const parentPath = parts.join('.')
+
+    const parentNode =
+      parentPath === ''
+        ? sf
+            .getVariableDeclarations()
+            .find((v) => v.getName() === op.variableName)
+            ?.getInitializer()
+        : resolvePropertyPath(sf, op.variableName, parentPath)
+
+    if (
+      !parentNode ||
+      parentNode.getKind() !== SyntaxKind.ObjectLiteralExpression
+    ) {
+      return sourceText
+    }
+
+    const parentObj = parentNode.asKindOrThrow(
+      SyntaxKind.ObjectLiteralExpression
+    )
+    const targetProp = parentObj
+      .getProperties()
+      .find(
+        (p) =>
+          p.getKind() === SyntaxKind.PropertyAssignment &&
+          p.asKindOrThrow(SyntaxKind.PropertyAssignment).getName() === lastPart
+      )
+    if (!targetProp) return sourceText
+
+    const pa = targetProp.asKindOrThrow(SyntaxKind.PropertyAssignment)
+    const currentInit = pa.getInitializer()
+    if (currentInit?.getText() === op.valueText) {
+      return sourceText // already the target value — exact no-op
+    }
+
+    pa.setInitializer(op.valueText)
+    return undefined // proceed with sf.getFullText()
+  })
+}

--- a/lib/scripts/setup-project.test.ts
+++ b/lib/scripts/setup-project.test.ts
@@ -18,12 +18,16 @@ import {
   INTEGRATION_BUNDLES,
 } from './integration-bundles'
 import {
+  CACHE_COMPONENTS_DISABLE_TRANSFORM,
   collectSelfPruneTestFiles,
   declaredBundlePaths,
   findMissingPaths,
+  isCacheComponentsDisabled,
   PROJECT_PRESETS,
+  replaceAnchoredText,
   resolveTransitiveKeepSet,
   SELF_PRUNE_KEEP_TEST_FILES,
+  shouldDisableCacheComponents,
   shouldSkipConfirm,
 } from './setup-project'
 import { getFlagValue } from './utils'
@@ -1015,5 +1019,179 @@ describe('shouldSkipConfirm (H6 — --yes gating)', () => {
     expect(
       shouldSkipConfirm({ yes: false, hasFlags: true, isTTY: false })
     ).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cache Components opt-out (no CMS/storefront kept)
+//
+// `setupCacheComponentsOptOut` itself does real disk I/O keyed off
+// `process.cwd()` (via `resolvePath`), and this repo's test harness has no
+// fixture-project-tree mechanism to redirect that safely — every other test
+// in this file exercises pure/exported helpers rather than spinning up a
+// fake project directory. These tests cover the same four keep-set cases
+// (a–d from the plan) at the level this harness actually supports: the pure
+// decision function, the exact production config transform (applied
+// in-memory via `applyOpsToText`, exactly as `applyCodeTransforms` would),
+// and the pure doc-anchor replacement against the REAL current doc sentences
+// (a regression check that the anchors haven't silently gone stale).
+// ---------------------------------------------------------------------------
+
+describe('shouldDisableCacheComponents', () => {
+  it('(a) is true for a lean keep set (no integrations)', () => {
+    expect(shouldDisableCacheComponents([])).toBe(true)
+  })
+
+  it('(b) is false when shopify is kept', () => {
+    expect(shouldDisableCacheComponents(['shopify'])).toBe(false)
+  })
+
+  it('(c) is false when sanity is kept', () => {
+    expect(shouldDisableCacheComponents(['sanity'])).toBe(false)
+  })
+
+  it('(d) is true when only hubspot (no CMS/storefront) is kept', () => {
+    expect(shouldDisableCacheComponents(['hubspot'])).toBe(true)
+  })
+
+  it('is false when sanity is kept alongside other non-CMS integrations', () => {
+    expect(
+      shouldDisableCacheComponents(['sanity', 'hubspot', 'mailchimp'])
+    ).toBe(false)
+  })
+
+  it('is true when every kept integration is neither sanity nor shopify', () => {
+    expect(
+      shouldDisableCacheComponents(['hubspot', 'mailchimp', 'turnstile'])
+    ).toBe(true)
+  })
+})
+
+describe('CACHE_COMPONENTS_DISABLE_TRANSFORM (production ops applied to a next.config-shaped fixture)', () => {
+  const nextConfigFixture = `const nextConfig: NextConfig = {
+  cacheComponents: true,
+  experimental: {
+    taint: true,
+    cachedNavigations: true,
+    prefetchInlining: true,
+  },
+}
+
+export default nextConfig
+`
+
+  it('flips cacheComponents and experimental.cachedNavigations to false, leaving other flags untouched', () => {
+    const result = applyOpsToText(
+      nextConfigFixture,
+      CACHE_COMPONENTS_DISABLE_TRANSFORM.ops
+    )
+
+    expect(result).toContain('cacheComponents: false')
+    expect(result).not.toContain('cacheComponents: true')
+    expect(result).toContain('cachedNavigations: false')
+    // Probed separately as not requiring cacheComponents — left untouched.
+    expect(result).toContain('prefetchInlining: true')
+    expect(result).toContain('taint: true')
+  })
+
+  it('is idempotent — applying twice yields the same result', () => {
+    const once = applyOpsToText(
+      nextConfigFixture,
+      CACHE_COMPONENTS_DISABLE_TRANSFORM.ops
+    )
+    const twice = applyOpsToText(once, CACHE_COMPONENTS_DISABLE_TRANSFORM.ops)
+    expect(twice).toBe(once)
+  })
+
+  it('targets next.config.ts', () => {
+    expect(CACHE_COMPONENTS_DISABLE_TRANSFORM.file).toBe('next.config.ts')
+  })
+})
+
+describe('isCacheComponentsDisabled (docs-vs-config consistency guard)', () => {
+  it('is true after the production transform runs', () => {
+    const nextConfigFixture = `const nextConfig: NextConfig = {
+  cacheComponents: true,
+  experimental: { cachedNavigations: true },
+}
+`
+    const flipped = applyOpsToText(
+      nextConfigFixture,
+      CACHE_COMPONENTS_DISABLE_TRANSFORM.ops
+    )
+    expect(isCacheComponentsDisabled(flipped)).toBe(true)
+  })
+
+  it('is true for hand-edited spacing variants', () => {
+    expect(isCacheComponentsDisabled('cacheComponents:false,')).toBe(true)
+    expect(isCacheComponentsDisabled('cacheComponents : false,')).toBe(true)
+  })
+
+  it('is false when the flip silently no-opped (unrecognized config shape)', () => {
+    // A fork that renamed `nextConfig` — the op finds no variable and
+    // returns the text unchanged; docs must then NOT claim it is disabled.
+    const renamed = `const config: NextConfig = {
+  cacheComponents: true,
+}
+`
+    const result = applyOpsToText(
+      renamed,
+      CACHE_COMPONENTS_DISABLE_TRANSFORM.ops
+    )
+    expect(result).toBe(renamed)
+    expect(isCacheComponentsDisabled(result)).toBe(false)
+  })
+
+  it('is false for an empty/missing config', () => {
+    expect(isCacheComponentsDisabled('')).toBe(false)
+  })
+})
+
+describe('replaceAnchoredText (doc patching)', () => {
+  it('replaces the exact anchor substring and reports changed:true', () => {
+    const content = 'before\nCache Components are enabled globally.\nafter\n'
+    const { text, changed } = replaceAnchoredText(
+      content,
+      'Cache Components are enabled globally.',
+      'Cache Components is disabled in this project.'
+    )
+    expect(changed).toBe(true)
+    expect(text).toBe(
+      'before\nCache Components is disabled in this project.\nafter\n'
+    )
+  })
+
+  it('is an exact no-op (changed:false) when the anchor is absent', () => {
+    const content = 'no matching sentence here\n'
+    const result = replaceAnchoredText(content, 'not present', 'replacement')
+    expect(result.changed).toBe(false)
+    expect(result.text).toBe(content)
+  })
+
+  it("finds the current AGENTS.md sentence claiming Cache Components is enabled (anchor hasn't gone stale)", async () => {
+    const agentsMd = await Bun.file('AGENTS.md').text()
+    const anchor =
+      'Cache Components are enabled globally (`cacheComponents: true` in `next.config.ts`).'
+    const { text, changed } = replaceAnchoredText(
+      agentsMd,
+      anchor,
+      'Cache Components is disabled in this project (no CMS/storefront integration kept at setup). Re-enable `cacheComponents` in next.config.ts when adding one.'
+    )
+    expect(changed).toBe(true)
+    expect(text).not.toContain(anchor)
+    expect(text).toContain('Cache Components is disabled in this project')
+  })
+
+  it("finds the current ARCHITECTURE.md sentence claiming Cache Components is enabled (anchor hasn't gone stale)", async () => {
+    const architectureMd = await Bun.file('ARCHITECTURE.md').text()
+    const anchor = 'Server Components use advanced caching. Key rules:'
+    const { text, changed } = replaceAnchoredText(
+      architectureMd,
+      anchor,
+      'Cache Components is disabled in this project (no CMS/storefront integration kept at setup). Re-enable `cacheComponents` in next.config.ts when adding one.'
+    )
+    expect(changed).toBe(true)
+    expect(text).not.toContain(anchor)
+    expect(text).toContain('Cache Components is disabled in this project')
   })
 })

--- a/lib/scripts/setup-project.ts
+++ b/lib/scripts/setup-project.ts
@@ -615,6 +615,206 @@ const setupAddIntegrations = async (
   return { failures }
 }
 
+// ---------------------------------------------------------------------------
+// Cache Components opt-out (no CMS/storefront kept)
+// ---------------------------------------------------------------------------
+
+/**
+ * Integration ids whose kept presence justifies keeping Cache Components on
+ * — a CMS (sanity) or storefront (shopify) is the kind of project that
+ * benefits from `'use cache'` route caching. When the FINAL kept set
+ * (after `resolveTransitiveKeepSet` expansion) contains neither, the project
+ * is a simple site: Cache Components costs ~30ms/dev request and buys
+ * nothing, and `cacheComponents: true` hard-breaks AWS/SST deploys.
+ *
+ * Do not widen this list without re-verifying the empirical probe this relies
+ * on: disabling `cacheComponents` is only safe because pruning sanity ALSO
+ * removes the `/sanity` route's `'use cache'` directive — that directive is a
+ * hard compile error once `cacheComponents` is off. A kept CMS/storefront
+ * integration could reintroduce a `'use cache'` route, so this condition must
+ * stay exactly "neither sanity nor shopify kept", never loosened.
+ */
+const CACHE_COMPONENTS_WORTH_KEEPING: readonly RemovableId[] = [
+  'sanity',
+  'shopify',
+]
+
+/**
+ * True when the kept integration set has no CMS/storefront — the condition
+ * under which Cache Components should be disabled. Pure and exported for
+ * unit testing (mirrors `shouldSkipConfirm`'s pattern).
+ */
+export const shouldDisableCacheComponents = (
+  keepIntegrations: RemovableId[]
+): boolean =>
+  !keepIntegrations.some((id) => CACHE_COMPONENTS_WORTH_KEEPING.includes(id))
+
+/**
+ * next.config.ts transform that flips Cache Components off.
+ *
+ * Both ops are required together: an empirical `bun run build` probe showed
+ * `experimental.cachedNavigations: true` hard-errors Next's config
+ * validation when `cacheComponents` is false ("`experimental.cachedNavigations`
+ * requires `cacheComponents` to be enabled."). `experimental.prefetchInlining`
+ * was probed too and needs no change — Next's config validation accepts it
+ * fine with `cacheComponents` off.
+ */
+export const CACHE_COMPONENTS_DISABLE_TRANSFORM: CodeTransform = {
+  file: 'next.config.ts',
+  ops: [
+    {
+      kind: 'setObjectProperty',
+      variableName: 'nextConfig',
+      propertyPath: 'cacheComponents',
+      valueText: 'false',
+    },
+    {
+      kind: 'setObjectProperty',
+      variableName: 'nextConfig',
+      propertyPath: 'experimental.cachedNavigations',
+      valueText: 'false',
+    },
+  ],
+}
+
+/**
+ * Anchored doc-sentence replacements so a fork's docs don't claim Cache
+ * Components is enabled after setup just disabled it. Each `anchor` is
+ * matched as an exact substring; when absent (doc since reworded), the file
+ * is skipped with a warning instead of failing the whole setup run over a
+ * doc sentence — see `setupCacheComponentsOptOut`.
+ */
+const CACHE_COMPONENTS_DOC_PATCHES: ReadonlyArray<{
+  file: string
+  anchor: string
+  replacement: string
+}> = [
+  {
+    file: 'AGENTS.md',
+    anchor:
+      'Cache Components are enabled globally (`cacheComponents: true` in `next.config.ts`).',
+    replacement:
+      'Cache Components is disabled in this project (no CMS/storefront integration kept at setup). Re-enable `cacheComponents` in next.config.ts when adding one.',
+  },
+  {
+    file: 'ARCHITECTURE.md',
+    anchor: 'Server Components use advanced caching. Key rules:',
+    replacement:
+      'Cache Components is disabled in this project (no CMS/storefront integration kept at setup). Re-enable `cacheComponents` in next.config.ts when adding one.',
+  },
+]
+
+/**
+ * Replace the first exact occurrence of `anchor` in `content` with
+ * `replacement`. Returns `changed: false` (content returned byte-for-byte
+ * unchanged) when the anchor isn't found. Pure — no I/O — exported for unit
+ * testing.
+ */
+export const replaceAnchoredText = (
+  content: string,
+  anchor: string,
+  replacement: string
+): { text: string; changed: boolean } => {
+  if (!content.includes(anchor)) return { text: content, changed: false }
+  return { text: content.replace(anchor, replacement), changed: true }
+}
+
+/**
+ * True when `configText` has Cache Components off. Pure — exported for unit
+ * testing. Matches any spacing so a hand-edited `cacheComponents:false`
+ * counts, keeping re-runs of setup on an already-disabled fork quiet.
+ */
+export const isCacheComponentsDisabled = (configText: string): boolean =>
+  /cacheComponents\s*:\s*false/.test(configText)
+
+/**
+ * When the final kept set has no CMS/storefront (`shouldDisableCacheComponents`),
+ * flip Cache Components off in next.config.ts and patch the two doc sections
+ * that otherwise claim it's enabled (AGENTS.md, ARCHITECTURE.md). No-op
+ * (nothing printed, nothing written) when a CMS or storefront is kept.
+ *
+ * The docs are only rewritten once the flip is verified on disk — a
+ * next.config.ts the ops don't recognize (renamed `nextConfig`, restructured
+ * config) must not produce docs claiming Cache Components is off while the
+ * config still says otherwise. Dry runs skip that verification (nothing was
+ * written) and report intent only.
+ *
+ * A missing doc anchor only warns — it never fails the setup run.
+ */
+const setupCacheComponentsOptOut = async (
+  keepIntegrations: RemovableId[],
+  dryRun: boolean
+): Promise<{ failures: TransformFailure[] }> => {
+  if (!shouldDisableCacheComponents(keepIntegrations)) {
+    return { failures: [] }
+  }
+
+  const s = p.spinner()
+  s.start('Disabling Cache Components (no CMS/storefront kept)...')
+
+  const { failures } = await applyCodeTransforms(
+    [CACHE_COMPONENTS_DISABLE_TRANSFORM],
+    dryRun
+  )
+
+  // Verify the flip landed before rewriting docs to claim it did. A zero
+  // change count alone is ambiguous — it also occurs on the (fine) re-run
+  // where a previous setup already disabled it — so read the file instead.
+  if (!dryRun) {
+    const configPath = resolvePath('next.config.ts')
+    const configText = (await pathExists(configPath))
+      ? await Bun.file(configPath).text()
+      : ''
+    if (!isCacheComponentsDisabled(configText)) {
+      s.stop(
+        'Could not disable Cache Components — next.config.ts shape not recognized; docs left as-is'
+      )
+      failures.push({
+        file: 'next.config.ts',
+        error:
+          'setObjectProperty found no `cacheComponents` property on `nextConfig` to flip — disable it manually (and `experimental.cachedNavigations` with it)',
+      })
+      return { failures }
+    }
+  }
+
+  for (const { file, anchor, replacement } of CACHE_COMPONENTS_DOC_PATCHES) {
+    try {
+      const fullPath = resolvePath(file)
+      if (!(await pathExists(fullPath))) continue
+
+      const original = await Bun.file(fullPath).text()
+      const { text, changed } = replaceAnchoredText(
+        original,
+        anchor,
+        replacement
+      )
+
+      if (!changed) {
+        p.log.warn(
+          `Could not find the Cache Components sentence to update in ${file} — leaving it as-is.`
+        )
+        continue
+      }
+
+      if (!dryRun) {
+        await Bun.write(fullPath, text)
+      }
+    } catch (error) {
+      failures.push({
+        file,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  s.stop(
+    'Cache Components disabled (no CMS/storefront kept) — re-enable in next.config.ts if this project adds one'
+  )
+
+  return { failures }
+}
+
 /**
  * Mutate the in-memory package.json object to remove the `setup:project` and
  * `test:setup` script entries, and delete the setup script files from disk.
@@ -738,17 +938,20 @@ const selfPrune = async (
  *   6. setupLean — strip ALL integrations (mutates in-memory pkg)
  *   7. Write package.json (dep removal applied). Must happen BEFORE
  *      setupAddIntegrations so the snapshot re-add sees a consistent lockfile
- *      target; this is NOT the final write — see step 10.
+ *      target; this is NOT the final write — see step 11.
  *   8. setupAddIntegrations — re-add the kept set from the snapshot
  *   9. snapshot.cleanup()
- *  10. selfPrune — delete setup files (including this script) and mutate
+ *  10. setupCacheComponentsOptOut — when the final kept set has neither
+ *      sanity nor shopify, flip `cacheComponents` off in next.config.ts and
+ *      patch the docs that claim it's enabled. No-op otherwise.
+ *  11. selfPrune — delete setup files (including this script) and mutate
  *      pkg.scripts in-memory, THEN a second package.json write to persist
  *      the scripts removal. This is deliberately the LAST mutating step:
  *      running it only after setupAddIntegrations has completed
  *      successfully means any failure in steps 3–8 leaves
  *      lib/scripts/setup-project.ts (and its package.json script entry)
  *      intact, so the run can simply be repeated (H8).
- *  11. bun install (unless --skip-install). Non-fatal on failure (M5): a
+ *  12. bun install (unless --skip-install). Non-fatal on failure (M5): a
  *      registry/offline error is reported and surfaced to the caller via
  *      the returned `installFailed` flag, but does not undo or block the
  *      steps above — the setup itself already succeeded by this point.
@@ -804,7 +1007,7 @@ const setup = async (
 
   // 5. Read package.json ONCE into memory. The dep-removal mutator operates
   //    on this object; selfPrune's script removal is applied to the same
-  //    object later (step 10) and persisted with its own write, so this
+  //    object later (step 11) and persisted with its own write, so this
   //    object stays the single source of truth throughout.
   const pkgPath = resolvePath('package.json')
   const pkg = (await Bun.file(pkgPath).json()) as PackageJson
@@ -816,7 +1019,7 @@ const setup = async (
   // 7. Write package.json (dep removal applied). Runs before
   //    setupAddIntegrations so the re-add's dependency pins land on a
   //    consistent base; the scripts removal from selfPrune is persisted by
-  //    a second write at step 10, after setupAddIntegrations succeeds.
+  //    a second write at step 11, after setupAddIntegrations succeeds.
   if (!dryRun) {
     await Bun.write(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`)
   }
@@ -839,7 +1042,15 @@ const setup = async (
     }
   }
 
-  // 10. Self-prune: delete setup files (including this script), mutate
+  // 10. When the final kept set has no CMS/storefront, disable Cache
+  //     Components in next.config.ts and patch the docs claiming it's
+  //     enabled. No-op otherwise. Runs after the kept set is fully re-added
+  //     (so a re-added integration's own transforms aren't clobbered) and
+  //     before selfPrune (so a failure here still leaves the setup script
+  //     repeatable, per H8).
+  const cacheResult = await setupCacheComponentsOptOut(keepIntegrations, dryRun)
+
+  // 11. Self-prune: delete setup files (including this script), mutate
   //     pkg.scripts in-memory, and persist that with a second package.json
   //     write. Deliberately last — see the docstring above.
   await selfPrune(pkg, dryRun)
@@ -847,7 +1058,7 @@ const setup = async (
     await Bun.write(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`)
   }
 
-  // 11. Run bun install to update the lockfile. Non-fatal: an offline /
+  // 12. Run bun install to update the lockfile. Non-fatal: an offline /
   //     registry failure is reported but does not mask the setup steps
   //     above having already succeeded.
   let installFailed = false
@@ -868,7 +1079,11 @@ const setup = async (
 
   return {
     installFailed,
-    transformFailures: [...leanResult.failures, ...addFailures],
+    transformFailures: [
+      ...leanResult.failures,
+      ...addFailures,
+      ...cacheResult.failures,
+    ],
   }
 }
 


### PR DESCRIPTION
## What this does
A fork that keeps neither Sanity nor Shopify at setup has nothing that uses Cache Components — but was still paying for it: roughly doubled dev-server response times (~30ms of validation on every request, measured) and a hard build failure on AWS/SST deploys. `setup:project` now turns `cacheComponents` off for exactly that case, so simple sites get the fast dev loop by default and CMS/storefront forks keep the feature untouched.

## Summary
- New `setObjectProperty` AST op (overwrite-only, dotted paths, idempotent) — the transform vocabulary had add/remove but no "set existing value"
- New setup step after integration re-add: kept set ∩ {sanity, shopify} = ∅ → flip `cacheComponents` and `experimental.cachedNavigations` to `false`. Both together, verified empirically: Next's config validation hard-errors on `cachedNavigations` without `cacheComponents`; `prefetchInlining` is accepted and stays on
- The flip is verified on disk before the AGENTS.md / ARCHITECTURE.md sections are rewritten — an unrecognized `next.config.ts` (renamed `nextConfig`, restructured) fails loudly instead of producing docs that claim the flag is off while the config says otherwise
- The condition is safety-critical, not just heuristic: `'use cache'` is a compile error with `cacheComponents` off, and the only such directive lives in the Sanity example page — which the sanity bundle removes before this step can ever run
- 24 new tests (op unit tests, keep-set decisions, production ops against a config fixture, doc-anchor drift guards that read the real docs)

## Review order
1. `lib/scripts/setup-project.ts` — the step + condition (the substance)
2. `lib/scripts/ast-transforms/set-ops.ts` — the new op
3. Tests + type plumbing (fallout)

## Test plan
- [x] `bun run check` → 384 pass / 0 fail
- [x] E2E: `setup:project --keep '' --yes` in a scratch copy → `cacheComponents: false`, `cachedNavigations: false`, `prefetchInlining: true`, both doc notes present, `bun run build` exits 0
- [x] E2E control: `--keep shopify` and `--keep sanity` paths leave `next.config.ts` untouched (unit-tested via the exported decision fn)

## Known limitation
The lean-fork E2E build only passes after deleting `app/(examples)/` and `app/studio/` manually — a **pre-existing** bug on `main` (the sanity bundle strips `lib/integrations/sanity` but not the route folders that import it; reproduced on clean `main`). Filed separately; not caused by and not fixed in this PR.
