### PR TITLE
fix(setup): strip the sanity route folders with the sanity bundle

### DIFF
--- a/lib/scripts/integration-bundles.ts
+++ b/lib/scripts/integration-bundles.ts
@@ -103,7 +103,15 @@ export const INTEGRATION_BUNDLES = defineBundles({
       'next-sanity',
     ],
     devDependencies: ['@sanity/vision', 'sanity'],
-    folders: ['lib/integrations/sanity', 'components/ui/sanity-image'],
+    // The two app/ route folders import from lib/integrations/sanity — they
+    // must live and die with the bundle, or a fork that drops Sanity keeps
+    // routes whose imports no longer exist and fails to build.
+    folders: [
+      'lib/integrations/sanity',
+      'components/ui/sanity-image',
+      'app/(examples)/sanity',
+      'app/studio',
+    ],
     files: ['app/api/draft-mode/enable/route.ts'],
     envVars: [
       'NEXT_PUBLIC_SANITY_PROJECT_ID',

--- a/lib/scripts/setup-project.test.ts
+++ b/lib/scripts/setup-project.test.ts
@@ -853,6 +853,15 @@ describe('declaredBundlePaths / findMissingPaths (H8 preflight)', () => {
     expect(paths).toContain('app/layout.tsx')
   })
 
+  it('sanity bundle owns every route folder that imports from it', () => {
+    // These routes import from lib/integrations/sanity. If they fall out of
+    // the bundle's folders, a fork that drops Sanity keeps them and fails to
+    // build on module-not-found (the lean-fork build break).
+    const paths = declaredBundlePaths(['sanity'])
+    expect(paths).toContain('app/(examples)/sanity')
+    expect(paths).toContain('app/studio')
+  })
+
   it('declaredBundlePaths is empty for an empty keep set', () => {
     expect(declaredBundlePaths([])).toEqual([])
   })


### PR DESCRIPTION
## What this does
Every fork created without Sanity has been broken at creation: `setup:project` deleted `lib/integrations/sanity` but left `app/(examples)/sanity` and `app/studio` importing from it, so the fork failed its first build. Those two folders now belong to the sanity bundle — removed when Sanity is dropped, snapshot-restored when it's kept.

Fixes #307.

## Summary
- `app/(examples)/sanity` + `app/studio` added to the sanity bundle's `folders` (2-line fix; every `/studio` reference outside them lives inside `lib/integrations/sanity`, verified by grep)
- Regression test locking the ownership: bundle paths must include both route folders

## Test plan
- [x] `bun run check` → 361 pass / 0 fail
- [x] E2E lean (`--keep ''`): both folders removed, `bun run build` exits 0 (previously module-not-found)
- [x] E2E keep (`--keep sanity`): both folders restored by the snapshot, `bun run build` exits 0 with PPR routes intact

## Note
The lean fork keeps an empty `app/(examples)/` directory on disk (the strip removes the child folder only). Git never tracks it, Next ignores it — left alone to keep this a two-line fix.