### PR TITLE
fix: form callback double-fire, unnamed form controls, and the react-doctor backlog

### DIFF
--- a/components/ui/form/fields/index.tsx
+++ b/components/ui/form/fields/index.tsx
@@ -84,7 +84,20 @@ export function InputField({
         required={required}
         placeholder={placeholder}
         className={cn(s.input)}
+        // `label` is optional, and without it no <Field.Label> is rendered, so
+        // the control would otherwise reach screen readers with no accessible
+        // name. Fall back to the placeholder, then to the field name, so there
+        // is always one. Deliberately NOT set when a visible label exists:
+        // aria-label would override it, and the announced name could then
+        // drift from the text on screen. Spread rather than passing
+        // `undefined`, which `exactOptionalPropertyTypes` rejects.
+        //
+        {...(label ? {} : { 'aria-label': placeholder ?? fieldName })}
         {...register(fieldName)}
+        // The finding lands on this inner element. Base UI merges id, name and
+        // the aria-label above onto it at runtime, so a static read of this
+        // line sees an unlabelled input that never reaches the DOM.
+        // react-doctor-disable-next-line react-doctor/control-has-associated-label
         render={<input />}
       />
       {error?.state && error.message && (
@@ -146,7 +159,13 @@ export function TextareaField({
         required={required}
         placeholder={placeholder}
         className={s.textarea}
+        // Same as InputField: no `label` means no <Field.Label>, so fall back
+        // to the placeholder and then the field name.
+        {...(label ? {} : { 'aria-label': placeholder ?? fieldName })}
         {...reg}
+        // Same as InputField: Base UI merges the real attributes onto this
+        // element at runtime.
+        // react-doctor-disable-next-line react-doctor/control-has-associated-label
         render={<textarea rows={rows} />}
       />
       {error?.state && error.message && (

--- a/components/ui/form/index.tsx
+++ b/components/ui/form/index.tsx
@@ -3,7 +3,6 @@
 import cn from 'clsx'
 import { createContext, use, useEffect, useState } from 'react'
 
-import type { FormState } from '@/lib/types/form'
 import { mutate } from '@/utils/raf'
 
 import { useForm } from './hook'
@@ -84,6 +83,23 @@ export function Form<T = unknown>({
 }: FormProps<T>) {
   const [key, setKey] = useState<string | null>(null)
 
+  // onSuccess/onError fire from the action itself rather than from an effect
+  // watching formState. The effect had to list them as dependencies, so a
+  // parent re-rendering with fresh inline callbacks re-ran it and fired them a
+  // second time for a submission that had already been handled. The result is
+  // known right here, so there is nothing to observe after the fact.
+  const actionWithCallbacks: FormAction<T> = async (prevState, formData) => {
+    const result = await action(prevState, formData)
+
+    if (result.status === 200) {
+      onSuccess?.(result)
+    } else if (result.status >= 400) {
+      onError?.(result)
+    }
+
+    return result
+  }
+
   const {
     formAction,
     onSubmit,
@@ -95,32 +111,35 @@ export function Form<T = unknown>({
     errors,
     register,
   } = useForm({
-    action: action as FormAction<unknown>,
+    action: actionWithCallbacks as FormAction<unknown>,
     ...(formId && { formId }),
     initialState: null,
   })
 
-  // Handle success/error callbacks
+  // Clear the form a beat after a successful submit. Scheduling goes through
+  // the rAF write queue to keep it off the layout-read path.
+  //
+  // `cancelled` covers unmounting before that queue drains: `resetTimer` is
+  // assigned inside the queued callback, so without the flag the timer could be
+  // created after teardown and setKey would fire on a component that is gone.
   useEffect(() => {
-    if (!formState) return
+    if (formState?.status !== 200) return
 
     let resetTimer: ReturnType<typeof setTimeout> | undefined
-    if (formState.status === 200) {
-      onSuccess?.(formState as FormState<T>)
-      // Reset form after success
-      void mutate(() => {
-        resetTimer = setTimeout(() => {
-          setKey(crypto.randomUUID())
-        }, 2000)
-      })
-    } else if (formState.status >= 400) {
-      onError?.(formState as FormState<T>)
-    }
+    let cancelled = false
+
+    void mutate(() => {
+      if (cancelled) return
+      resetTimer = setTimeout(() => {
+        setKey(crypto.randomUUID())
+      }, 2000)
+    })
 
     return () => {
+      cancelled = true
       if (resetTimer) clearTimeout(resetTimer)
     }
-  }, [formState, onSuccess, onError])
+  }, [formState])
 
   // Reset form function for actions
   const resetForm = () => {

--- a/doctor.config.json
+++ b/doctor.config.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "https://react.doctor/schema/config.json",
-  "rules": {
-    "react-doctor/server-auth-actions": "off",
-    "react-doctor/no-unknown-property": "off",
-    "react-doctor/no-pure-black-background": "off",
-    "react-doctor/jsx-no-constructed-context-values": "off"
-  }
-}

--- a/doctor.config.ts
+++ b/doctor.config.ts
@@ -1,0 +1,59 @@
+/**
+ * React Doctor configuration.
+ *
+ * A `.ts` file rather than `doctor.config.json` so every disabled check can say
+ * why it is disabled — the same reason `oxlint.config.ts` and `oxfmt.config.ts`
+ * are TypeScript.
+ *
+ * Nothing here is switched off to make a number go down. Each entry is either
+ * wrong about this codebase or wrong about this *kind* of codebase.
+ */
+export default {
+  $schema: 'https://react.doctor/schema/config.json',
+
+  /**
+   * Dead-code analysis: unused files, unused exports, unused devDependencies.
+   *
+   * Off because it assumes an application and satus is a template. It ships UI
+   * primitives, hooks and whole opt-in integrations for consumers to reach for;
+   * the demo app deliberately does not import most of them, and
+   * `setup:project` strips the ones a project chooses not to keep. "Nothing
+   * imports this" is the intended state here, not dead code.
+   *
+   * This pass accounted for 85 of 130 findings, including the entire Shopify,
+   * HubSpot and Mailchimp integrations, `components/ui/form`, `fold`,
+   * `scrollbar`, and `lib/hooks/use-reveal` — none of which are dead. It also
+   * called `happy-dom` an unused devDependency, when it is loaded without an
+   * import: `bunfig.toml` preloads `lib/scripts/test-setup.ts`, which registers
+   * happy-dom onto Bun's globals via `@happy-dom/global-registrator`.
+   *
+   * Real dead code is still covered, by a tool tuned for this repo: `bun run
+   * deslop` is a cross-file dead-code, unused-export and circular-import
+   * scanner, and it reports zero unused files and zero dead exports here.
+   */
+  deadCode: false,
+
+  rules: {
+    /**
+     * Fires on any file named `page.*`, including files that are not Next
+     * routes: `lib/integrations/sanity/schemas/page.ts` is a Sanity document
+     * schema and `lib/integrations/shopify/queries/page.ts` is a GROQ query.
+     * The one real route it flagged, `app/studio/[[...tool]]`, is
+     * `'use client'` — a client component cannot export `metadata` — and it is
+     * a CMS admin surface that should not be indexed anyway.
+     */
+    'react-doctor/nextjs-missing-metadata': 'off',
+
+    'react-doctor/server-auth-actions': 'off',
+    'react-doctor/no-unknown-property': 'off',
+    'react-doctor/no-pure-black-background': 'off',
+
+    /**
+     * React Compiler memoizes context values automatically, so hoisting them by
+     * hand is pre-Compiler folklore. oxlint's equivalent
+     * (`react/jsx-no-constructed-context-values`) is left out of the enabled
+     * rule set for the same reason.
+     */
+    'react-doctor/jsx-no-constructed-context-values': 'off',
+  },
+}

--- a/doctor.config.ts
+++ b/doctor.config.ts
@@ -33,6 +33,66 @@ export default {
    */
   deadCode: false,
 
+  /**
+   * Per-path suppressions. Scoped by rule rather than by whole directory on
+   * purpose: a genuine bug of some *other* kind in these files still gets
+   * reported. Nothing here is a blanket "skip this folder".
+   */
+  ignore: {
+    overrides: [
+      {
+        /**
+         * Theatre.js is an external, imperative animation editor. React does
+         * not own this data flow: values change because someone dragged a
+         * keyframe in the studio UI, and the hooks exist to subscribe to that
+         * and mirror it back. Every rule below presupposes React owning the
+         * flow, so each one asks for a rewrite that cannot exist here —
+         * `no-event-handler` in particular says "run the side effect in the
+         * event handler that triggers it", and there is no React event
+         * handler, only Theatre's own change notifications.
+         *
+         * Scope note: this is dev-only tooling. It is lazily imported, gated
+         * behind a dev toggle, and `setup:project` deletes it outright for
+         * projects that do not keep Theatre — so none of it ships to users.
+         */
+        files: ['lib/dev/theatre/**'],
+        rules: [
+          'react-doctor/no-event-handler',
+          'react-doctor/no-effect-event-handler',
+          'react-doctor/no-chain-state-updates',
+          'react-doctor/no-derived-state',
+          'react-doctor/no-pass-data-to-parent',
+          'react-doctor/no-fetch-in-effect',
+          'react-doctor/rendering-hydration-mismatch-time',
+          'react-doctor/exhaustive-deps',
+        ],
+      },
+      {
+        /**
+         * `components/layout/theme` already implements React's documented
+         * pattern for adjusting state when a prop changes — the render-phase
+         * re-sync with a `prevTheme` sentinel, with the docs link in the file.
+         * The three rules below each ask for something that cannot work here:
+         *
+         * - `no-derived-useState` wants the value computed inline, but
+         *   `currentTheme` is overridable at runtime through `setTheme`, so it
+         *   is seeded from the prop rather than derived from it.
+         * - `rerender-state-only-in-handlers` wants a ref, but the value is
+         *   rendered — it goes out through context to every consumer.
+         * - `no-event-handler` flags the `data-theme` write on <html>, which
+         *   is synchronising an external system with React state, the case
+         *   effects are actually for.
+         */
+        files: ['components/layout/theme/**'],
+        rules: [
+          'react-doctor/no-derived-useState',
+          'react-doctor/rerender-state-only-in-handlers',
+          'react-doctor/no-event-handler',
+        ],
+      },
+    ],
+  },
+
   rules: {
     /**
      * Fires on any file named `page.*`, including files that are not Next

--- a/lib/dev/theatre/hooks/use-theatre.ts
+++ b/lib/dev/theatre/hooks/use-theatre.ts
@@ -26,6 +26,15 @@ export function useTheatreObject(
   useEffect(() => {
     if (!sheet) return
 
+    // `set-state-in-effect` fires here, and it stays. The state is what makes
+    // the object observable: useTheatre's subscription effect keys on it, so it
+    // has to re-run when the object appears or is rebuilt. Holding it in a ref
+    // instead would leave subscribers with no signal, and the object is a
+    // Theatre handle that only exists once the sheet does, so it cannot be
+    // derived during render. The bailout costs auto-memoization on Theatre's
+    // dev tooling only — lazily loaded, gated behind a dev toggle, and removed
+    // outright by setup:project for projects that drop Theatre.
+    // react-doctor-disable-next-line react-hooks-js/set-state-in-effect
     setObject(sheet?.object(theatreKey, config, { reconfigure: true }))
 
     return () => {

--- a/lib/hooks/use-device-detection.ts
+++ b/lib/hooks/use-device-detection.ts
@@ -1,5 +1,5 @@
 import { useMediaQuery, useWindowSize } from 'hamo'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useSyncExternalStore } from 'react'
 
 import { breakpoints } from '@/styles/config'
 
@@ -55,6 +55,18 @@ function detectIsAutoplaySupported() {
   return cache.isAutoplaySupported
 }
 
+// Safari / WebGL support never change after load, so there is nothing to
+// subscribe to — a stable no-op keeps useSyncExternalStore happy without
+// ever notifying.
+function subscribeToStaticDetection() {
+  // oxlint-disable-next-line eslint/no-empty-function -- required unsubscribe signature; nothing to tear down since the value is never notified
+  return () => {}
+}
+
+function getStaticDetectionServerSnapshot() {
+  return undefined
+}
+
 /**
  * Detect device capabilities: screen size, input method, motion preference,
  * WebGL support, Safari, and inline-video autoplay support.
@@ -74,15 +86,24 @@ export function useDeviceDetection() {
   const isTouchOnly = useMediaQuery('(any-pointer: coarse) and (hover: none)')
   const { dpr } = useWindowSize()
 
-  // Static detections — resolved from the module cache after mount (client-only
-  // so SSR stays consistent; undefined until then).
-  const [isSafari, setIsSafari] = useState<boolean>()
-  const [supportsWebGL, setSupportsWebGL] = useState<boolean>()
+  // Static detections — resolved from the module cache. Safari / WebGL are
+  // synchronous and read via useSyncExternalStore (undefined on the server so
+  // SSR stays consistent; the real value on the client, no effect needed).
+  const isSafari = useSyncExternalStore(
+    subscribeToStaticDetection,
+    detectIsSafari,
+    getStaticDetectionServerSnapshot
+  )
+  const supportsWebGL = useSyncExternalStore(
+    subscribeToStaticDetection,
+    detectSupportsWebGL,
+    getStaticDetectionServerSnapshot
+  )
+
+  // Autoplay support is genuinely async, so it keeps useState + an effect.
   const [isAutoplaySupported, setIsAutoplaySupported] = useState<boolean>()
 
   useEffect(() => {
-    setIsSafari(detectIsSafari())
-    setSupportsWebGL(detectSupportsWebGL())
     void detectIsAutoplaySupported().then(setIsAutoplaySupported)
   }, [])
 

--- a/lib/integrations/hubspot/action.ts
+++ b/lib/integrations/hubspot/action.ts
@@ -61,10 +61,10 @@ export async function HubspotNewsletterAction(
     run: async ({ email, formId }) => {
       const allowedFormIds = env.HUBSPOT_ALLOWED_FORM_IDS
       if (allowedFormIds) {
-        const allowList = allowedFormIds
-          .split(',')
-          .map((id) => id.trim())
-          .filter(Boolean)
+        const allowList = allowedFormIds.split(',').flatMap((id) => {
+          const trimmed = id.trim()
+          return trimmed ? [trimmed] : []
+        })
         if (!allowList.includes(formId)) {
           return {
             status: 400,

--- a/lib/integrations/hubspot/fetch-form.ts
+++ b/lib/integrations/hubspot/fetch-form.ts
@@ -128,22 +128,20 @@ function apiParser(id: string, data: HubspotFormResponse) {
   return {
     portalId: env.NEXT_PUBLIC_HUBSPOT_PORTAL_ID,
     id: id,
-    inputs: data.fieldGroups
-      .flatMap((item) => item.fields ?? [])
-      .map((flatData) => {
-        return {
-          name: flatData.name || '',
-          label: flatData.label || '',
-          placeholder: flatData.placeholder || '',
-          required: flatData.required,
-          type: flatData.fieldType || '',
-          hidden: flatData.hidden,
-          helpText: flatData.helpText || '',
-          options: flatData.options
-            ? flatData.options.map((option) => option.label)
-            : [],
-        }
-      }),
+    inputs: data.fieldGroups.flatMap((item) =>
+      (item.fields ?? []).map((flatData) => ({
+        name: flatData.name || '',
+        label: flatData.label || '',
+        placeholder: flatData.placeholder || '',
+        required: flatData.required,
+        type: flatData.fieldType || '',
+        hidden: flatData.hidden,
+        helpText: flatData.helpText || '',
+        options: flatData.options
+          ? flatData.options.map((option) => option.label)
+          : [],
+      }))
+    ),
     submitButton: {
       text: data.displayOptions.submitButtonText || 'Submit',
     },

--- a/lib/integrations/shopify/cart/actions.ts
+++ b/lib/integrations/shopify/cart/actions.ts
@@ -10,14 +10,14 @@ import {
   rateLimiters,
 } from '@/lib/utils/rate-limit'
 
-import { TAGS } from '../constants'
 import {
   addToCart,
   createCart,
   getCart,
   removeFromCart,
   updateCart,
-} from '../index'
+} from '../cart-operations'
+import { TAGS } from '../constants'
 import type { AddItemPayload, Cart } from '../types'
 
 /** Unified result shape for all cart mutations. */

--- a/lib/integrations/shopify/customer/actions.ts
+++ b/lib/integrations/shopify/customer/actions.ts
@@ -8,7 +8,7 @@ import { runFormAction } from '@/lib/utils/form-action'
 import { rateLimiters } from '@/lib/utils/rate-limit'
 import { emailSchema } from '@/utils/validation'
 
-import { shopifyFetch } from '../index'
+import { shopifyFetch } from '../client'
 import {
   customerAccessTokenCreateMutation,
   customerAccessTokenDeleteMutation,

--- a/lib/integrations/shopify/money.ts
+++ b/lib/integrations/shopify/money.ts
@@ -1,12 +1,23 @@
 import type { Money } from './types'
 
+// Formatters are keyed on the (locale, currency) pair since both vary at
+// call time; `new Intl.NumberFormat` is expensive to construct, so each
+// unique pair is built once and reused.
+const formatters = new Map<string, Intl.NumberFormat>()
+
 /**
  * Format a Shopify `Money` object using its own `currencyCode`, instead of
  * assuming `$` and two decimals. Locale defaults to the runtime's locale.
  */
 export function formatMoney(money: Money, locale?: string): string {
-  return new Intl.NumberFormat(locale, {
-    style: 'currency',
-    currency: money.currencyCode,
-  }).format(Number(money.amount))
+  const key = JSON.stringify([locale, money.currencyCode])
+  let formatter = formatters.get(key)
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency: money.currencyCode,
+    })
+    formatters.set(key, formatter)
+  }
+  return formatter.format(Number(money.amount))
 }

--- a/lib/scripts/bench-rerender.ts
+++ b/lib/scripts/bench-rerender.ts
@@ -1,0 +1,178 @@
+/**
+ * Re-render cost benchmark.
+ *
+ * The third measurement angle in this repo, and the one that covers what the
+ * other two structurally cannot:
+ *
+ *   bun run lighthouse   one cold page load. Blind to re-renders entirely.
+ *   (bench:nav)          client-side route swaps. Lives on the Next 16.3
+ *                        preview branch, because its useful scenario needs the
+ *                        instant-nav demo routes, which are branch-only.
+ *                        Measures navigation, not the work a mounted tree does
+ *                        when state changes.
+ *   bun run bench:rerender  ← this. Main-thread cost of re-rendering an
+ *                             already-mounted tree.
+ *
+ * Why it exists: React Compiler bailouts (setState synchronously in an effect,
+ * mutating a useState value, creating components during render) cost you
+ * auto-memoization for the WHOLE function they occur in. That shows up as
+ * avoidable work on every subsequent re-render — and nothing else here measures
+ * it. A Lighthouse pass over exactly those fixes moved nothing outside noise,
+ * because it never re-renders anything.
+ *
+ * How: drives viewport resizes, which is the cheapest way to force a real
+ * re-render cascade through this app's shared hooks — useWindowSize feeds
+ * useDeviceDetection, which gates isWebGL and is consumed app-wide. Main-thread
+ * cost comes from CDP's Performance domain (ScriptDuration / TaskDuration /
+ * RecalcStyleDuration), which works against a production build. It does not
+ * depend on React's development-only profiling hooks, so the numbers reflect
+ * what ships.
+ *
+ * SCOPE, and be honest about it: this covers the hooks that are reachable from
+ * a route. `useDeviceDetection` is, and it is the highest-value fix of the set.
+ * The fluid and flowmap simulations are NOT — only FlowmapProvider consumes
+ * them and no route mounts it — so their bailout fixes cannot be measured from
+ * a browser at all, and this script does not pretend to.
+ *
+ * Usage:
+ *   bun run build && PORT=3123 bun run start &
+ *   bun run bench:rerender
+ *   bun run bench:rerender --runs 5 --resizes 40 --path /
+ *
+ * A/B by running it against two builds and diffing the medians. Read the full
+ * sample, not just the median: on a dev machine a small sample's median moves
+ * on one outlier.
+ *
+ * What it found first time out, and it is worth knowing before you reach for a
+ * compiler-bailout fix expecting a speedup. Reverting ONLY
+ * lib/hooks/use-device-detection.ts to its pre-fix shape (setState called
+ * synchronously in an effect, so React Compiler bails out of the whole hook),
+ * 5 runs each, 30 viewport changes, 4x CPU throttle:
+ *
+ *                    pre-fix                 fixed
+ *   script    115ms  (spread 106-122)  121ms  (spread 99-157)
+ *   task      850ms                    931ms
+ *
+ * No improvement. The fixed build's fastest run beats the pre-fix build's
+ * fastest, but the spread swamps the difference either way.
+ *
+ * The reasoning behind the fix was still right — a bailout does cost
+ * auto-memoization for the entire function — but the magnitude was not there,
+ * because this particular hook's body is a handful of media-query reads and
+ * boolean derivations. Losing memoization on work that cheap costs nothing you
+ * can measure, and the resize cascade here is dominated by style recalculation
+ * (~250ms of the ~900ms) and the WebGL canvas, not by that hook's JS.
+ *
+ * Treat compiler bailouts as correctness and hygiene, not as a performance
+ * lever, unless the function they occur in is doing real work. Measure before
+ * claiming a win.
+ */
+import { chromium } from 'playwright-core'
+
+const args = process.argv.slice(2)
+function arg(name: string, fallback: string) {
+  const i = args.indexOf(`--${name}`)
+  return i !== -1 && args[i + 1] ? (args[i + 1] as string) : fallback
+}
+
+const BASE = arg('url', 'http://localhost:3123').replace(/\/+$/, '')
+const PATH = arg('path', '/')
+const RUNS = Number(arg('runs', '5'))
+const RESIZES = Number(arg('resizes', '30'))
+// CPU throttle. Re-render cost is main-thread work, and an unthrottled dev
+// machine is fast enough to bury the difference in noise. 4x is roughly a
+// mid-range laptop, and it widens the signal without inventing it.
+const CPU = Number(arg('cpu', '4'))
+
+type Sample = { script: number; task: number; style: number; wall: number }
+
+const median = (xs: number[]) =>
+  [...xs].sort((a, b) => a - b)[Math.floor(xs.length / 2)] ?? Number.NaN
+
+async function main() {
+  const browser = await chromium.launch({ args: ['--no-sandbox'] })
+  const samples: Sample[] = []
+
+  for (let run = 0; run < RUNS; run++) {
+    // Fresh page per run: a re-used page carries warm JIT and a warm client
+    // cache, so run 2 onward would read faster than anything real.
+    const page = await browser.newPage({
+      viewport: { width: 1280, height: 800 },
+    })
+    const cdp = await page.context().newCDPSession(page)
+    await cdp.send('Performance.enable')
+    if (CPU > 1) {
+      await cdp.send('Emulation.setCPUThrottlingRate', { rate: CPU })
+    }
+
+    await page.goto(`${BASE}${PATH}`, { waitUntil: 'load' })
+    // Let hydration and the lazy root canvas settle, so we time steady-state
+    // re-renders rather than mount.
+    await page.waitForTimeout(1500)
+
+    const readMetrics = async () => {
+      const { metrics } = await cdp.send('Performance.getMetrics')
+      const get = (n: string) =>
+        metrics.find((m: { name: string; value: number }) => m.name === n)
+          ?.value ?? 0
+      return {
+        script: get('ScriptDuration'),
+        task: get('TaskDuration'),
+        style: get('RecalcStyleDuration'),
+      }
+    }
+
+    const before = await readMetrics()
+    const wallStart = Date.now()
+
+    for (let i = 0; i < RESIZES; i++) {
+      // Alternate widths across the `dt` breakpoint so useDeviceDetection's
+      // media queries actually flip, instead of resizing within one bucket
+      // where nothing downstream changes.
+      const width = i % 2 === 0 ? 700 : 1280
+      await page.setViewportSize({ width, height: 800 })
+      // One frame, so React commits between resizes rather than batching the
+      // whole loop into a single update.
+      await page.evaluate(
+        () => new Promise((r) => requestAnimationFrame(() => r(null)))
+      )
+    }
+
+    const wall = Date.now() - wallStart
+    const after = await readMetrics()
+
+    samples.push({
+      script: (after.script - before.script) * 1000,
+      task: (after.task - before.task) * 1000,
+      style: (after.style - before.style) * 1000,
+      wall,
+    })
+
+    await page.close()
+    process.stdout.write('.')
+  }
+
+  await browser.close()
+
+  const col = (k: keyof Sample) => samples.map((s) => s[k])
+  const fmt = (k: keyof Sample) =>
+    `${median(col(k)).toFixed(0)}ms   ${JSON.stringify(col(k).map((v) => Math.round(v)))}`
+
+  console.log(`\n\nre-render cost: ${RESIZES} viewport changes on ${PATH}`)
+  console.log(
+    `${BASE} · ${RUNS} runs · ${CPU > 1 ? `${CPU}x CPU throttle` : 'no CPU throttle'}\n`
+  )
+  console.log(`  script   ${fmt('script')}`)
+  console.log(`  task     ${fmt('task')}`)
+  console.log(`  style    ${fmt('style')}`)
+  console.log(`  wall     ${fmt('wall')}`)
+  console.log(
+    `\n  script is the one to watch — main-thread JS for the re-render` +
+      `\n  cascade. task includes style/layout/paint on top of it.\n`
+  )
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/lib/webgl/components/flowmap-provider/index.tsx
+++ b/lib/webgl/components/flowmap-provider/index.tsx
@@ -13,7 +13,7 @@
  * updated each frame inside the R3F render loop.
  */
 
-import { createContext, use } from 'react'
+import { createContext, type RefObject, use } from 'react'
 
 import { useFlowmapSim } from '@/webgl/utils/flowmaps'
 import type { Flowmap } from '@/webgl/utils/flowmaps/flowmap-sim'
@@ -23,12 +23,16 @@ import type { Fluid } from '@/webgl/utils/fluid/fluid-sim'
 /**
  * Shape of the flowmap context value.
  *
- * @property fluid - The GPU fluid simulation instance (Navier-Stokes).
- * @property flowmap - The GPU flowmap simulation instance (velocity-field displacement).
+ * The simulations are held in refs (not state) because they're mutated
+ * imperatively every frame — reading `.current` gives the latest instance
+ * without ever triggering a re-render.
+ *
+ * @property fluid - Ref to the GPU fluid simulation instance (Navier-Stokes).
+ * @property flowmap - Ref to the GPU flowmap simulation instance (velocity-field displacement).
  */
 type FlowmapContextType = {
-  fluid: Fluid | null
-  flowmap: Flowmap | null
+  fluid: RefObject<Fluid | null> | null
+  flowmap: RefObject<Flowmap | null> | null
 }
 
 export const FlowmapContext = createContext<FlowmapContextType>({
@@ -37,7 +41,7 @@ export const FlowmapContext = createContext<FlowmapContextType>({
 })
 
 /**
- * Retrieves the active GPU simulation instance from context.
+ * Retrieves the active GPU simulation instance ref from context.
  *
  * Must be called inside a {@link FlowmapProvider} (which itself must be
  * inside the R3F `<Canvas>` tree, since the simulations depend on the
@@ -46,18 +50,20 @@ export const FlowmapContext = createContext<FlowmapContextType>({
  * @param type - Which simulation to return.
  *   - `'flowmap'` (default) -- lightweight velocity-field displacement.
  *   - `'fluid'` -- full Navier-Stokes fluid simulation.
- * @returns The requested simulation instance (`Fluid` or `Flowmap`).
+ * @returns A ref to the requested simulation instance (`Fluid` or `Flowmap`).
+ *   Read `.current` inside an effect, event handler, or `useFrame` callback —
+ *   never during render.
  *
  * @example
  * ```tsx
  * function DistortedImage() {
- *   const flowmap = useFlowmap('flowmap')
- *   // Use flowmap.texture as a uniform in a custom shader
+ *   const flowmapRef = useFlowmap('flowmap')
+ *   // Use flowmapRef.current?.texture as a uniform in a custom shader
  * }
  *
  * function FluidBackground() {
- *   const fluid = useFlowmap('fluid')
- *   // Use fluid.density / fluid.velocity textures
+ *   const fluidRef = useFlowmap('fluid')
+ *   // Use fluidRef.current?.density / fluidRef.current?.velocity textures
  * }
  * ```
  */

--- a/lib/webgl/components/image/webgl.tsx
+++ b/lib/webgl/components/image/webgl.tsx
@@ -75,6 +75,15 @@ function WebGLImageMesh({ src, rect, visible = true }: WebGLImageMeshProps) {
     texture.magFilter = texture.minFilter = LinearFilter
     texture.generateMipmaps = false
 
+    // `immutability` fires on these two writes because `material` came out of
+    // useState. It stays that way on purpose. The material has to exist during
+    // render (it is handed to <primitive object={material} /> below), so it
+    // cannot be built in an effect; and lazily instantiating it into a ref
+    // during render just trades this finding for a `refs` one, since that is a
+    // ref write during render. Assigning a Three.js material's map is
+    // imperative GPU work on an object React only stores — there is no React
+    // state to keep in sync, and the identity never changes.
+    // react-doctor-disable-next-line react-hooks-js/immutability
     material.map = texture
     material.needsUpdate = true
   })

--- a/lib/webgl/components/tunnel/index.tsx
+++ b/lib/webgl/components/tunnel/index.tsx
@@ -63,6 +63,15 @@ export function WebGLTunnel({ children }: PropsWithChildren) {
 
   return (
     <WebGLTunnel.In>
+      {/*
+        `static-components` fires because ContextBridge comes out of a hook, and
+        a component built during render would normally reset its state. It does
+        not here: drei wraps the returned component in `useMemo(..., [])`
+        (node_modules/@react-three/drei/core/useContextBridge.js), so it is
+        created once per hook instance and kept, with fresh context values read
+        through a ref. The `key` keeps identity stable across re-parents.
+      */}
+      {/* react-doctor-disable-next-line react-hooks-js/static-components */}
       <ContextBridge key={uuid}>{children}</ContextBridge>
     </WebGLTunnel.In>
   )

--- a/lib/webgl/hooks/use-webgl-rect.ts
+++ b/lib/webgl/hooks/use-webgl-rect.ts
@@ -2,7 +2,7 @@ import { useThree } from '@react-three/fiber'
 import type { Rect } from 'hamo'
 import { useTransform } from 'hamo'
 import { useLenis } from 'lenis/react'
-import { useEffect, useEffectEvent, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Euler, Vector3 } from 'three'
 
 /**
@@ -29,8 +29,8 @@ interface UseWebGLRectOptions {
 /**
  * Hook for positioning WebGL meshes based on DOM element rects.
  *
- * Uses useEffectEvent for stable callback references that always
- * access latest values without causing effect re-runs.
+ * Uses a ref-held callback for a stable function reference that always
+ * accesses latest values without causing effect re-runs.
  *
  * Pass `visible: false` to skip position computations when the element
  * is off-screen, improving performance for many WebGL elements.
@@ -83,53 +83,56 @@ export function useWebGLRect(
     isVisible: true,
   })
 
-  // useEffectEvent: callback always has access to latest values
-  // without being a dependency that triggers re-subscriptions
-  const handleUpdate = useEffectEvent(() => {
-    // Skip computations when not visible
-    if (!visible) return
+  // Holds the latest render's update logic. Reassigned in an effect (never
+  // during render, which would be unsafe under concurrent rendering) so the
+  // stable wrapper below always runs against fresh closures after commit.
+  const callbackRef = useRef<(() => void) | null>(null)
 
-    const { translate, scale } = getTransform()
-    const scroll = lenis ? Math.floor(lenis.scroll) : window.scrollY
-    const transform = transformRef.current
+  useEffect(() => {
+    callbackRef.current = () => {
+      // Skip computations when not visible
+      if (!visible) return
 
-    if (
-      rect.top === undefined ||
-      rect.height === undefined ||
-      rect.left === undefined ||
-      rect.width === undefined
-    ) {
-      // Expected during initial render before DOM measurement completes
-      return
+      const { translate, scale } = getTransform()
+      const scroll = lenis ? Math.floor(lenis.scroll) : window.scrollY
+      const transform = transformRef.current
+
+      if (
+        rect.top === undefined ||
+        rect.height === undefined ||
+        rect.left === undefined ||
+        rect.width === undefined
+      ) {
+        // Expected during initial render before DOM measurement completes
+        return
+      }
+
+      transform.isVisible =
+        scroll > rect.top - size.height + translate.y &&
+        scroll < rect.top + translate.y + rect.height
+
+      transform.position.x = -size.width / 2 + (rect.left + rect.width / 2)
+      transform.position.y =
+        size.height / 2 - (rect.top + rect.height / 2) + scroll - translate.y
+      transform.scale.x = rect.width * scale.x
+      transform.scale.y = rect.height * scale.y
+
+      onUpdate?.(transformRef.current)
     }
-
-    transform.isVisible =
-      scroll > rect.top - size.height + translate.y &&
-      scroll < rect.top + translate.y + rect.height
-
-    transform.position.x = -size.width / 2 + (rect.left + rect.width / 2)
-    transform.position.y =
-      size.height / 2 - (rect.top + rect.height / 2) + scroll - translate.y
-    transform.scale.x = rect.width * scale.x
-    transform.scale.y = rect.height * scale.y
-
-    onUpdate?.(transformRef.current)
   })
 
-  // NOTE: these two suppressions are not about hook ordering. Both calls are
-  // unconditional and at the top level of this hook. What the rule objects to
-  // is passing `handleUpdate` (a useEffectEvent function) into another hook at
-  // all, which React forbids because the identity is only valid inside the
-  // effect that owns it. It works here because useTransform/useLenis invoke it
-  // from within their own effects, but the proper fix is to drop useEffectEvent
-  // for a ref-held callback. Tracked as a follow-up, not silenced and forgotten.
+  // Stable wrapper, created once via lazy useState initialization, that
+  // always delegates to the latest callback held in callbackRef. Its
+  // identity never changes, so passing it to useTransform/useLenis never
+  // causes them to re-subscribe.
+  const [handleUpdate] = useState<() => void>(
+    () => () => callbackRef.current?.()
+  )
 
   // Subscribe to transform changes
-  // oxlint-disable-next-line react/rules-of-hooks -- see NOTE above
   useTransform(handleUpdate, [])
 
   // Subscribe to lenis scroll
-  // oxlint-disable-next-line react/rules-of-hooks -- see NOTE above
   useLenis(handleUpdate, [])
 
   // Fallback for non-lenis scroll
@@ -142,7 +145,7 @@ export function useWebGLRect(
     return () => {
       window.removeEventListener('scroll', handleUpdate, false)
     }
-  }, [lenis]) // handleUpdate is stable from useEffectEvent
+  }, [lenis, handleUpdate])
 
   function get() {
     return transformRef.current

--- a/lib/webgl/utils/flowmaps/index.tsx
+++ b/lib/webgl/utils/flowmaps/index.tsx
@@ -1,6 +1,6 @@
 import { useFrame, useThree } from '@react-three/fiber'
 import { types } from '@theatre/core'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { useCurrentSheet } from '@/dev/theatre'
 import { useTheatre } from '@/dev/theatre/hooks/use-theatre'
@@ -12,15 +12,18 @@ export function useFlowmapSim(resolution = 128) {
   const gl = useThree((state) => state.gl)
   const size = useThree((state) => state.size)
 
-  // Created/destroyed by the effect, keyed on gl + resolution.
-  const [flowmap, setFlowmap] = useState<Flowmap | null>(null)
+  // Created/destroyed by the effect, keyed on gl + resolution. Held in a ref
+  // (not state) because the instance is mutated imperatively below — the
+  // React Compiler cannot optimize a component that constructs-then-setStates
+  // an instance in an effect and later mutates that same state value.
+  const flowmapRef = useRef<Flowmap | null>(null)
 
   useEffect(() => {
     const flowmap = new Flowmap(gl, { size: resolution })
-    setFlowmap(flowmap)
+    flowmapRef.current = flowmap
     return () => {
       flowmap.destroy()
-      setFlowmap(null)
+      flowmapRef.current = null
     }
   }, [gl, resolution])
 
@@ -30,9 +33,10 @@ export function useFlowmapSim(resolution = 128) {
   const lastTimeRef = useRef<number | null>(null)
 
   // Mouse/touch input — drives the flowmap stamp position and velocity.
-  // The callback always reads the latest `size` and `flowmap`, because
-  // usePointerInput routes it through useEffectEvent.
+  // The callback always reads the latest `size` and `flowmapRef.current`,
+  // because usePointerInput routes it through useEffectEvent.
   usePointerInput((clientX, clientY, dx, dy) => {
+    const flowmap = flowmapRef.current
     if (!flowmap) return
 
     const now = performance.now()
@@ -52,10 +56,15 @@ export function useFlowmapSim(resolution = 128) {
   })
 
   // Aspect ratio so the cursor falloff stays round
+  // `gl` and `resolution` are dependencies even though they are not read here:
+  // they are what recreates the instance above, and a fresh Flowmap needs its
+  // aspect set. Before the instance moved into a ref, the old `flowmap` state
+  // value in this list did that job.
   useEffect(() => {
+    const flowmap = flowmapRef.current
     if (!flowmap) return
     flowmap.material.uniforms.uAspect.value = size.width / size.height
-  }, [flowmap, size])
+  }, [size, gl, resolution])
 
   useTheatre(
     sheet,
@@ -72,15 +81,21 @@ export function useFlowmapSim(resolution = 128) {
         falloff: number
         dissipation: number
       }) => {
+        const flowmap = flowmapRef.current
         if (!flowmap) return
         flowmap.falloff = falloff
         flowmap.dissipation = dissipation
       },
-      deps: [flowmap],
+      // Re-subscribe whenever the instance is rebuilt, so Theatre re-applies
+      // its current values to the new Flowmap. A ref's identity never changes,
+      // so listing `flowmapRef` here would mean never re-subscribing, and the
+      // initial values would be dropped on the floor.
+      deps: [gl, resolution],
     }
   )
 
   useFrame(() => {
+    const flowmap = flowmapRef.current
     if (flowmap && !movedRef.current) {
       // Pointer idle this frame: park off-screen + zero velocity so the
       // existing trail dissipates instead of stamping a fixed smear.
@@ -91,5 +106,5 @@ export function useFlowmapSim(resolution = 128) {
     flowmap?.update()
   }, -10)
 
-  return flowmap
+  return flowmapRef
 }

--- a/lib/webgl/utils/fluid/index.tsx
+++ b/lib/webgl/utils/fluid/index.tsx
@@ -1,6 +1,6 @@
 import { useFrame, useThree } from '@react-three/fiber'
 import { types } from '@theatre/core'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { useCurrentSheet } from '@/dev/theatre'
 import { useTheatre } from '@/dev/theatre/hooks/use-theatre'
@@ -12,37 +12,42 @@ export function useFluidSim(resolution = 128) {
   const gl = useThree((state) => state.gl)
   const size = useThree((state) => state.size)
 
-  // Created/destroyed by the effect, keyed on gl + resolution.
-  const [fluid, setFluid] = useState<null | Fluid>(null)
+  // Created/destroyed by the effect, keyed on gl + resolution. Held in a ref
+  // (not state) because the instance is mutated imperatively below — the
+  // React Compiler cannot optimize a component that constructs-then-setStates
+  // an instance in an effect and later mutates that same state value.
+  const fluidRef = useRef<null | Fluid>(null)
 
   useEffect(() => {
     const fluid = new Fluid(gl, { simRes: resolution })
-    setFluid(fluid)
+    fluidRef.current = fluid
     return () => {
       fluid.destroy()
-      setFluid(null)
+      fluidRef.current = null
     }
   }, [resolution, gl])
 
   // Normalize pointer input and queue splats. The callback always reads the
-  // latest `size` and `fluid`, because usePointerInput routes it through
-  // useEffectEvent.
+  // latest `size` and `fluidRef.current`, because usePointerInput routes it
+  // through useEffectEvent.
   usePointerInput((clientX, clientY, dx, dy) => {
     if (!(Math.abs(dx) || Math.abs(dy))) return
     const normalizedX = clientX / size.width
     const normalizedY = 1 - clientY / size.height
-    fluid?.addSplat(normalizedX, normalizedY, dx * 5, dy * -5)
+    fluidRef.current?.addSplat(normalizedX, normalizedY, dx * 5, dy * -5)
   })
 
-  // Update aspect ratio when viewport size changes
+  // Update aspect ratio when viewport size changes.
+  //
+  // `gl` and `resolution` are dependencies even though they are not read here:
+  // they are what recreates the instance above, and a fresh Fluid needs its
+  // aspect set. Before the instance moved into a ref, the old `fluid` state
+  // value in this list did that job.
   useEffect(() => {
+    const fluid = fluidRef.current
     if (!fluid) return
-    // Writing a Three.js shader uniform on the state-held Fluid instance. The
-    // `fluid` reference itself never changes, so this imperative WebGL update is
-    // invisible to React — react-hooks-js/immutability is a false positive here.
-    // react-doctor-disable-next-line react-hooks-js/immutability
     fluid.splatMaterial.uniforms.uAspect.value = size.width / size.height
-  }, [size, fluid])
+  }, [size, gl, resolution])
 
   // Theatre.js controls for fluid parameters
   useTheatre(
@@ -69,6 +74,7 @@ export function useFluidSim(resolution = 128) {
         curl: number
         radius: number
       }) => {
+        const fluid = fluidRef.current
         if (!fluid) return
         fluid.curlStrength = curl
         fluid.densityDissipation = density
@@ -76,15 +82,19 @@ export function useFluidSim(resolution = 128) {
         fluid.pressureDissipation = pressure
         fluid.radius = radius
       },
-      deps: [fluid],
+      // Re-subscribe whenever the instance is rebuilt, so Theatre re-applies
+      // its current values to the new Fluid. A ref's identity never changes,
+      // so listing `fluidRef` here would mean never re-subscribing, and the
+      // initial values would be dropped on the floor.
+      deps: [gl, resolution],
     }
   )
 
   // Drive the simulation with the real frame delta so it runs at the same
   // apparent speed regardless of display refresh rate.
   useFrame((_, delta) => {
-    fluid?.update(delta)
+    fluidRef.current?.update(delta)
   }, -10)
 
-  return fluid
+  return fluidRef
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "analyze:experimental": "next experimental-analyze",
     "dev:inspect": "bun ./lib/scripts/dev.ts --inspect",
     "lighthouse": "bunx @unlighthouse/cli --site http://localhost:3000",
+    "bench:rerender": "bun ./lib/scripts/bench-rerender.ts",
     "setup:project": "bun ./lib/scripts/setup-project.ts",
     "test": "bun test",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## What this does

Two real bug fixes, plus the react-doctor cleanup behind them, taken off the
Next 16.3 preview branch so they ship without waiting for 16.3 to go stable.

A form field given only a `placeholder` reached screen readers with no name at
all, so nobody using one could tell what it was for. And `onSuccess` /
`onError` could fire twice for a single submission, which means anything
non-idempotent behind them (an analytics event, a redirect, a toast) ran twice.

Neither of those has anything to do with Next 16.3. They were found while
working on #259, which is parked until 16.3 ships, and Vercel has not given a
date. This is the part that does not need to wait.

## Review order

1. `fix(form): fire onSuccess/onError from the action` and
   `a11y: give every form control an accessible name` are the two bug fixes.
   Start here.
2. `chore(react-doctor): stop the dead-code pass...` is a config decision worth
   a look: it turns off a whole analysis pass, with the reasoning in
   `doctor.config.ts`.
3. The four `perf(...)` commits are React Compiler bailout fixes. Correctness
   and hygiene, not speed. See the note below.
4. `feat(scripts): add a re-render cost benchmark` is additive.

## The perf commits do not make anything faster

Measured, rather than assumed. Reverting only `use-device-detection.ts` to its
pre-fix shape, 5 runs each, 30 viewport changes, 4x CPU throttle:

|         | pre-fix            | fixed              |
| ------- | ------------------ | ------------------ |
| script  | 115ms (106-122)    | 121ms (99-157)     |
| task    | 850ms              | 931ms              |

No improvement. A compiler bailout does cost auto-memoization for the whole
function, which is why these were worth fixing, but the magnitude is not there
when the function is a few media-query reads. The resize cascade is dominated
by style recalculation (~250ms of ~900ms) and the WebGL canvas.

They stay because they remove real cascading-render patterns and genuine
bailouts, and because `useSyncExternalStore` is the right shape for a
session-constant synchronous read. Framing them as speedups would be wrong, and
`bench-rerender.ts` says so in its header so nobody re-runs this experiment.

## react-doctor: 149 issues to 10, zero errors

The 85 that went away were a category error rather than a backlog. Its
dead-code pass assumes an application; satus is a template that ships opt-in
integrations and primitives the demo app deliberately does not import, and
`setup:project` strips whatever a project drops. It flagged the whole Shopify,
HubSpot and Mailchimp integrations, plus `components/ui/form`, `fold` and
`scrollbar`. It also called `happy-dom` unused, when `bunfig.toml` preloads the
test setup that registers it.

Cross-checked with `bun run deslop`, the repo's own dead-code and unused-export
scanner, which reports zero unused files here. That is what made it safe to
call them false positives.

The 10 that remain are deliberate decisions, each already documented in the
code. They are left visible on purpose rather than suppressed.

## What stayed on #259

The `varyParams` / `optimisticRouting` flags, the demo-route tweak, and the
`bench:nav` script. All three need either Next 16.3 or the instant-nav demo
routes. `main` also has no client-side navigation surface to measure: the only
internal `<Link>`s are in `error.tsx` and `not-found.tsx`.

The `<output>` conversions from the a11y commit stayed there too, since none of
that markup exists here. Two were demo routes, and `main`'s `app/loading.tsx`
is still the `Cooking...` placeholder rather than the accessible skeleton the
preview branch introduced.

## Test plan

- [x] `bun run check` exits 0 (oxlint, oxfmt, type-aware lint, tsc, 385 tests, manifest)
- [x] `bun run build` exits 0 from a cleared `.next`
- [x] `bunx react-doctor@0.4.2` reports 10 issues, 0 errors
- [ ] Submit a form with a `placeholder` and no `label`, confirm a screen reader announces it
- [ ] Submit a form with an `onSuccess` handler, confirm it fires exactly once
