### PR TITLE
perf: variable fonts, cart thumbnail sizing, shopify env drift

### DIFF
--- a/lib/integrations/shopify/cart/modal/index.tsx
+++ b/lib/integrations/shopify/cart/modal/index.tsx
@@ -125,6 +125,12 @@ function InnerCart() {
               <Image
                 src={merchandise.product.featuredImage?.url ?? ''}
                 alt={merchandise.product.featuredImage?.altText ?? ''}
+                // The drawer is 75vw (mobile) / 50vw (desktop) and `.media`
+                // spans 2 of its 6 columns — without this the 100vw default
+                // makes the browser fetch a full-viewport-width candidate for
+                // a thumbnail.
+                mobileSize="25vw"
+                desktopSize="17vw"
                 {...(merchandise.product.featuredImage?.width &&
                 merchandise.product.featuredImage?.height
                   ? {

--- a/lib/integrations/shopify/cart/modal/modal.module.css
+++ b/lib/integrations/shopify/cart/modal/modal.module.css
@@ -110,7 +110,12 @@
       width: 100%;
       height: mobile-vw(150px);
 
+      /* Both axes must be bound for object-fit to apply — the Image
+         wrapper's block style is width: auto, so height alone let a
+         product image render at its intrinsic aspect and spill out of
+         the grid cell. */
       img {
+        width: 100%;
         height: 100%;
         object-fit: contain;
       }

--- a/lib/integrations/shopify/index.ts
+++ b/lib/integrations/shopify/index.ts
@@ -1,6 +1,6 @@
 // USAGE — Shopify Storefront API
 // 1. Set env vars: SHOPIFY_STORE_DOMAIN, SHOPIFY_STOREFRONT_ACCESS_TOKEN
-//    Optionally: SHOPIFY_CUSTOMER_ACCOUNT_API_CLIENT_ID, SHOPIFY_CUSTOMER_ACCOUNT_API_URL
+//    Optionally: SHOPIFY_REVALIDATION_SECRET (to secure the webhook route)
 //
 // 2. Fetch products in a Server Component:
 //

--- a/lib/scripts/integration-bundles.ts
+++ b/lib/scripts/integration-bundles.ts
@@ -243,11 +243,12 @@ export const INTEGRATION_BUNDLES = defineBundles({
     devDependencies: [],
     folders: ['lib/integrations/shopify'],
     files: [],
+    // Keep in sync with the SHOPIFY_* keys in lib/env.ts — that schema is the
+    // source of truth for what the integration actually reads.
     envVars: [
       'SHOPIFY_STORE_DOMAIN',
       'SHOPIFY_STOREFRONT_ACCESS_TOKEN',
-      'SHOPIFY_CUSTOMER_ACCOUNT_API_CLIENT_ID',
-      'SHOPIFY_CUSTOMER_ACCOUNT_API_URL',
+      'SHOPIFY_REVALIDATION_SECRET',
     ],
     barrelExports: [],
     codeTransforms: [

--- a/lib/styles/fonts.ts
+++ b/lib/styles/fonts.ts
@@ -1,7 +1,10 @@
 import { Oswald, Spline_Sans_Mono } from 'next/font/google'
 
+// No `weight` — both families ship a variable `wght` axis (Oswald 200–700,
+// Spline Sans Mono 300–700), so one file per family covers every weight the
+// styles use. Pinning explicit weights would download a separate static file
+// each and snap in-between weights (500, 600) to the nearest loaded one.
 const display = Oswald({
-  weight: ['400', '700'],
   subsets: ['latin'],
   display: 'swap',
   variable: '--next-font-display',
@@ -9,7 +12,6 @@ const display = Oswald({
 })
 
 const mono = Spline_Sans_Mono({
-  weight: ['400', '500'],
   subsets: ['latin'],
   display: 'swap',
   variable: '--next-font-mono',


### PR DESCRIPTION
## What this does

Three small independent fixes that came out of a performance pass.

Fonts now ship as one variable file per family instead of a separate file per weight, so every page loads fewer font bytes. It also fixes a rendering detail: a few components ask for weight 500 and 600, and those were being snapped to the nearest weight we happened to load.

Cart thumbnails were spilling out of their column. The image had `object-fit: contain` and a fixed height, but nothing was constraining its width, so a square product image rendered wider than the cell it sits in and the contain never kicked in. Now it fits, and the browser stops downloading a full-screen-width image for a thumbnail.

The setup script's list of Shopify env vars had drifted from the ones the code actually reads. Nothing breaks today, but it was quietly wrong and would have bitten whoever touched that flow next.

## Summary

- `lib/styles/fonts.ts` — drop the `weight` arrays on Oswald and Spline Sans Mono. Both expose a variable `wght` axis (200-700 and 300-700) covering every weight the styles use, so `next/font` serves one file per family.
- `lib/integrations/shopify/cart/modal/modal.module.css` — bind `width` on the thumbnail so `object-fit: contain` applies. The `Image` wrapper's `block` style sets `width: auto`, and the module only overrode `height`.
- `lib/integrations/shopify/cart/modal/index.tsx` — set `mobileSize="25vw"` / `desktopSize="17vw"`. The drawer is 75vw mobile / 50vw desktop and the media area spans 2 of 6 columns. Previously fell through to the wrapper's `100vw` default.
- `lib/scripts/integration-bundles.ts` — the Shopify bundle listed `SHOPIFY_CUSTOMER_ACCOUNT_API_CLIENT_ID` and `_URL`, which nothing reads, and omitted `SHOPIFY_REVALIDATION_SECRET`, which `revalidate.ts` checks. Now matches `lib/env.ts`.
- `lib/integrations/shopify/index.ts` — same correction in the usage comment.

## Test Plan

- [x] `bun run check` passes: lint, type-aware lint, tsc, 385 tests, manifest check
- [x] Variable-font selection confirmed against `next/font` types, where `weight` is optional only for families that ship a variable axis
- [ ] Open the cart drawer against a real store and confirm thumbnails sit inside their column on mobile and desktop
