### PR TITLE
fix(shopify): opt catalog reads into Cache Components

### DIFF
--- a/lib/integrations/shopify/README.md
+++ b/lib/integrations/shopify/README.md
@@ -69,8 +69,8 @@ The GraphQL _envelope_ (`data` / `errors` fields) is always validated at the bou
 
 ## Caching
 
-- **Cart data**: Never cached (user-specific)
-- **Products**: Cached with `revalidateTag('products')`
+- **Cart data**: Never cached (user-specific) — every `cart-operations.ts` fetch passes `cache: 'no-store'`
+- **Products, collections, pages**: Every exported reader in `products.ts`, `collections.ts`, and `pages.ts` is wrapped in `'use cache'` with a one-hour `cacheLife`, required under Cache Components (`cacheComponents: true` in `next.config.ts`) so pages that call them can render statically instead of opting into fully dynamic rendering. The `'use cache'` entry is the only cache layer — the inner `shopifyFetch` call passes `cache: 'no-store'` so the Data Cache doesn't hold its own indefinitely-cached copy underneath it. Invalidated by tag via `revalidateTag('products')` / `revalidateTag('collections')` / `revalidateTag('pages')` — see Webhooks below.
 
 ## Webhooks
 
@@ -88,4 +88,4 @@ webhook (see `app/api/README.md`); Shopify and Sanity requests are distinguished
 so no separate endpoint is needed.
 
 Events: `products/create`, `products/update`, `products/delete`, `collections/create`,
-`collections/update`, `collections/delete`
+`collections/update`, `collections/delete`, `pages/create`, `pages/update`, `pages/delete`

--- a/lib/integrations/shopify/collections.ts
+++ b/lib/integrations/shopify/collections.ts
@@ -1,3 +1,5 @@
+import { cacheLife, cacheTag } from 'next/cache'
+
 import { shopifyFetch } from './client'
 import { TAGS } from './constants'
 import {
@@ -42,9 +44,13 @@ const reshapeCollections = (
 export async function getCollection(
   handle: string
 ): Promise<Collection | undefined> {
+  'use cache'
+  cacheTag(TAGS.collections)
+  cacheLife('hours')
+
   const res = await shopifyFetch<GetCollectionResponseData>({
     query: getCollectionQuery,
-    tags: [TAGS.collections],
+    cache: 'no-store',
     variables: {
       handle,
     },
@@ -65,9 +71,13 @@ export async function getCollectionProducts({
   reverse,
   sortKey,
 }: GetCollectionProductsOptions): Promise<Product[]> {
+  'use cache'
+  cacheTag(TAGS.collections, TAGS.products)
+  cacheLife('hours')
+
   const res = await shopifyFetch<GetCollectionProductsResponseData>({
     query: getCollectionProductsQuery,
-    tags: [TAGS.collections, TAGS.products],
+    cache: 'no-store',
     variables: {
       handle: collection,
       reverse,
@@ -85,9 +95,13 @@ export async function getCollectionProducts({
 }
 
 export async function getCollections(): Promise<Collection[]> {
+  'use cache'
+  cacheTag(TAGS.collections)
+  cacheLife('hours')
+
   const res = await shopifyFetch<GetCollectionsResponseData>({
     query: getCollectionsQuery,
-    tags: [TAGS.collections],
+    cache: 'no-store',
     dataSchema: getCollectionsResponseSchema,
   })
   const shopifyCollections = removeEdgesAndNodes(res.body.data.collections)

--- a/lib/integrations/shopify/constants.ts
+++ b/lib/integrations/shopify/constants.ts
@@ -43,6 +43,7 @@ export const sorting: SortOption[] = [
 export const TAGS = {
   collections: 'collections',
   products: 'products',
+  pages: 'pages',
   cart: 'cart',
 } as const
 

--- a/lib/integrations/shopify/index.ts
+++ b/lib/integrations/shopify/index.ts
@@ -31,6 +31,17 @@
 //   }
 //
 // Full walkthrough: see the manual (app/page.tsx) step 5 "Add a plugin".
+//
+// 4. Catalog reads (products.ts, collections.ts, pages.ts) are wrapped in
+//    'use cache' with a one-hour cacheLife — required under Cache Components
+//    so the pages calling them can render statically instead of opting into
+//    fully dynamic rendering. That 'use cache' entry is the only cache layer:
+//    the underlying shopifyFetch call passes cache: 'no-store' so the Data
+//    Cache doesn't also hold its own indefinitely-cached copy underneath it.
+//    The Shopify webhook route invalidates via revalidateTag() on
+//    product/collection/page changes (see revalidate.ts). Cart operations
+//    (cart-operations.ts) are per-user and deliberately left uncached
+//    (cache: 'no-store') with no 'use cache' wrapper at all.
 
 export * from './cart-operations'
 export * from './client'

--- a/lib/integrations/shopify/pages.ts
+++ b/lib/integrations/shopify/pages.ts
@@ -1,3 +1,5 @@
+import { cacheLife, cacheTag } from 'next/cache'
+
 import { shopifyFetch } from './client'
 import { TAGS } from './constants'
 import { getMenuQuery } from './queries/menu'
@@ -45,9 +47,13 @@ function menuItemPath(url: string): string {
 }
 
 export async function getMenu(handle: string): Promise<MenuItem[]> {
+  'use cache'
+  cacheTag(TAGS.collections)
+  cacheLife('hours')
+
   const res = await shopifyFetch<GetMenuResponseData>({
     query: getMenuQuery,
-    tags: [TAGS.collections],
+    cache: 'no-store',
     variables: {
       handle,
     },
@@ -63,8 +69,13 @@ export async function getMenu(handle: string): Promise<MenuItem[]> {
 }
 
 export async function getPage(handle: string): Promise<Page | null> {
+  'use cache'
+  cacheTag(TAGS.pages)
+  cacheLife('hours')
+
   const res = await shopifyFetch<GetPageResponseData>({
     query: getPageQuery,
+    cache: 'no-store',
     variables: { handle },
     dataSchema: getPageResponseSchema,
   })
@@ -73,8 +84,13 @@ export async function getPage(handle: string): Promise<Page | null> {
 }
 
 export async function getPages(): Promise<Page[]> {
+  'use cache'
+  cacheTag(TAGS.pages)
+  cacheLife('hours')
+
   const res = await shopifyFetch<GetPagesResponseData>({
     query: getPagesQuery,
+    cache: 'no-store',
     dataSchema: getPagesResponseSchema,
   })
 

--- a/lib/integrations/shopify/products.ts
+++ b/lib/integrations/shopify/products.ts
@@ -1,3 +1,5 @@
+import { cacheLife, cacheTag } from 'next/cache'
+
 import { shopifyFetch } from './client'
 import { TAGS } from './constants'
 import {
@@ -22,9 +24,13 @@ export async function getProduct({
 }: { handle: string; id?: string } | { id: string; handle?: string }): Promise<
   Product | undefined
 > {
+  'use cache'
+  cacheTag(TAGS.products)
+  cacheLife('hours')
+
   const res = await shopifyFetch<GetProductResponseData>({
     query: getProductQuery,
-    tags: [TAGS.products],
+    cache: 'no-store',
     variables: {
       handle,
       id,
@@ -38,9 +44,13 @@ export async function getProduct({
 export async function getProductRecommendations(
   productId: string
 ): Promise<Product[]> {
+  'use cache'
+  cacheTag(TAGS.products)
+  cacheLife('hours')
+
   const res = await shopifyFetch<GetProductRecommendationsResponseData>({
     query: getProductRecommendationsQuery,
-    tags: [TAGS.products],
+    cache: 'no-store',
     variables: {
       productId,
     },
@@ -61,9 +71,13 @@ export async function getProducts({
   reverse,
   sortKey,
 }: GetProductsOptions): Promise<Product[]> {
+  'use cache'
+  cacheTag(TAGS.products)
+  cacheLife('hours')
+
   const res = await shopifyFetch<GetProductsResponseData>({
     query: getProductsQuery,
-    tags: [TAGS.products],
+    cache: 'no-store',
     variables: {
       query,
       reverse,

--- a/lib/integrations/shopify/revalidate.ts
+++ b/lib/integrations/shopify/revalidate.ts
@@ -17,6 +17,7 @@ const productWebhooks = new Set([
   'products/delete',
   'products/update',
 ])
+const pageWebhooks = new Set(['pages/create', 'pages/delete', 'pages/update'])
 
 // This is called from `app/api/revalidate/route.ts` so providers can control revalidation logic.
 export async function revalidate(req: NextRequest): Promise<NextResponse> {
@@ -27,13 +28,14 @@ export async function revalidate(req: NextRequest): Promise<NextResponse> {
   const secret = req.nextUrl.searchParams.get('secret')
   const isCollectionUpdate = collectionWebhooks.has(topic)
   const isProductUpdate = productWebhooks.has(topic)
+  const isPageUpdate = pageWebhooks.has(topic)
 
   if (!secret || secret !== env.SHOPIFY_REVALIDATION_SECRET) {
     console.error('Invalid revalidation secret.')
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  if (!(isCollectionUpdate || isProductUpdate)) {
+  if (!(isCollectionUpdate || isProductUpdate || isPageUpdate)) {
     // We don't need to revalidate anything for any other topics.
     return NextResponse.json({ status: 200 })
   }
@@ -44,6 +46,10 @@ export async function revalidate(req: NextRequest): Promise<NextResponse> {
 
   if (isProductUpdate) {
     revalidateTag(TAGS.products, {})
+  }
+
+  if (isPageUpdate) {
+    revalidateTag(TAGS.pages, {})
   }
 
   return NextResponse.json({ status: 200, revalidated: true, now: Date.now() })


### PR DESCRIPTION
## What this does

Storefront pages built on this starter would have rendered fully dynamic, on every request, and nothing would have told you.

Cache Components is on. Under it, any uncached data read inside a Server Component drops the whole route out of static rendering. Sanity already handles this correctly. Shopify did not, so the first product or collection page anyone builds here loses the static shell and the caching that the rest of the starter is set up for.

Nothing was broken today because no page calls these readers yet. That is exactly why it was worth fixing now rather than after someone ships a store on it.

## Summary

- Every catalog read in `products.ts`, `collections.ts` and `pages.ts` now runs inside `'use cache'` with `cacheTag(...)` and `cacheLife('hours')`. Put in the data layer rather than at call sites, so consumers get it by default. Sanity wraps at call sites because draft mode has to branch per request; Shopify has no equivalent.
- Removed the fetch-level `cache: 'force-cache'` and `tags` from those readers and passed `cache: 'no-store'` instead, so `'use cache'` is the only cache layer. Next's Cache Components migration guide replaces the fetch options with `cacheTag`/`cacheLife`, and keeping both meant the inner fetch kept its own copy with no expiry and could hand stale data back after the outer entry aged out. `no-store` inside `'use cache'` is supported and still caches through the directive.
- Added a `pages` tag plus the `pages/create|update|delete` webhook topics, so Shopify page content is invalidated the same way products and collections already were. It previously had no tag at all.
- `cart-operations.ts` is untouched and stays `cache: 'no-store'` throughout. Carts are per-user and caching them would leak one shopper's cart to another.

## Test Plan

- [x] `bun run check` passes: lint, type-aware lint, tsc, 385 tests, manifest check
- [x] `bun run build` exits 0, which is what proves the `'use cache'` directives are legal in every function they were added to
- [ ] Point a real store at it and confirm a product change invalidates within the webhook, and that the cart still updates immediately after add/remove
