### PR TITLE
feat(gsap): add the official React hook for scoped animations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ export function MyComponent({
 ### Animation
 
 - **Reveal-on-scroll / entrance** → `useReveal` (`lib/hooks/use-reveal.ts`). CSS-driven, runs on the compositor thread so it stays smooth through hydration. Mark staggered children `data-reveal-item`; tune per container with `--reveal-transform`, `--reveal-stagger`, `--reveal-duration`. Degrades to visible with JS off; short-circuits under reduced-motion. The mechanism lives once in `global.css`.
-- **Orchestration / scrubbing / pinning** → GSAP (timelines, ScrollTrigger via the Lenis bridge in `components/layout/lenis/`). GSAP's ticker is synced to Tempus (`components/effects/gsap.tsx`), so there's a single RAF loop. Don't reach for GSAP for simple reveals — that's main-thread work CSS does better off-thread.
+- **Orchestration / scrubbing / pinning** → GSAP (timelines, ScrollTrigger via the Lenis bridge in `components/layout/lenis/`). GSAP's ticker is synced to Tempus (`components/effects/gsap.tsx`), so there's a single RAF loop. Don't reach for GSAP for simple reveals — that's main-thread work CSS does better off-thread. Write component animations with `useGSAP` from `@gsap/react`, passing `{ scope: ref }` — it scopes selector strings to that ref and reverts everything created inside it on unmount. Use its `contextSafe` wrapper for animations kicked off from event handlers, which otherwise run outside the scope. A bare `useEffect` + `gsap.to()` leaks tweens and ScrollTriggers across navigations.
 - **Micro-interactions** (hover, toggle, ≤200ms) → CSS transitions.
 - **Smooth scroll** → Lenis; **RAF scheduling** → Tempus.
 - Honor reduced-motion: the global neutralizer in `global.css` zeroes CSS animation; JS/WebGL gates via `usePreferredReducedMotion`.

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@darkroom.engineering/satus",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
+        "@gsap/react": "^2.1.2",
         "@portabletext/react": "^7.0.1",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.6.1",
@@ -582,6 +583,8 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.9", "", { "dependencies": { "@floating-ui/dom": "^1.8.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
+
+    "@gsap/react": ["@gsap/react@2.1.2", "", { "peerDependencies": { "gsap": "^3.12.5", "react": ">=17" } }, "sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw=="],
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.11.1" } }, "sha512-1C0wwHiyMlEdsbrJqff5ORE2PwaXBOam5rMqkZVOReAezd5nt6Tl/WGg28UAo75Ziuwchs0KaF8lvnn2oAtvJA=="],
 

--- a/components/effects/gsap.tsx
+++ b/components/effects/gsap.tsx
@@ -16,10 +16,56 @@
  *   {children}
  * </body>
  * ```
+ *
+ * To write an animation in a component, use `useGSAP` from `@gsap/react`
+ * rather than a bare `useEffect`. It scopes selector strings to a ref and
+ * reverts every tween, timeline, and ScrollTrigger created inside it on
+ * unmount, so there is no cleanup to forget:
+ *
+ * ```tsx
+ * 'use client'
+ * import { useGSAP } from '@gsap/react'
+ * import gsap from 'gsap'
+ * import { useRef } from 'react'
+ *
+ * export function Section() {
+ *   const ref = useRef<HTMLDivElement>(null)
+ *
+ *   useGSAP(
+ *     () => {
+ *       // '.card' only matches inside `ref`
+ *       gsap.to('.card', { y: 0, opacity: 1, stagger: 0.1 })
+ *     },
+ *     { scope: ref }
+ *   )
+ *
+ *   return <div ref={ref}>…</div>
+ * }
+ * ```
+ *
+ * Animations started from an event handler run outside the hook's scope, so
+ * wrap them in `contextSafe` to keep them under the same cleanup:
+ *
+ * ```tsx
+ * const { contextSafe } = useGSAP({ scope: ref })
+ * const onClick = contextSafe(() => gsap.to('.card', { x: 100 }))
+ * ```
+ *
+ * Reduced motion is not handled for you here. Gate motion with
+ * `gsap.matchMedia()` on `(prefers-reduced-motion: reduce)` so elements still
+ * reach their final state rather than being stranded mid-animation.
  */
 
+import { useGSAP } from '@gsap/react'
 import gsap from 'gsap'
 import { useTempus } from 'tempus/react'
+
+// `useGSAP` declares itself headless, so it registers in either environment —
+// unlike the ticker config below, which touches browser-only APIs. Registering
+// is what GSAP's React guide prescribes: it binds the hook to this copy of the
+// core and keeps it from being tree-shaken. It only manages animation
+// lifecycle, so it leaves the Tempus-driven ticker alone.
+gsap.registerPlugin(useGSAP)
 
 if (typeof window !== 'undefined') {
   gsap.defaults({ ease: 'none' })

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
+    "@gsap/react": "^2.1.2",
     "@portabletext/react": "^7.0.1",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.6.1",


### PR DESCRIPTION
## What this does

If you wanted to animate something in a component, the starter gave you nothing to start from. The only GSAP in the repo was plumbing: the Tempus ticker sync and the ScrollTrigger-to-Lenis bridge. So the natural move was a `useEffect` with some `gsap.to()` calls in it, which leaks tweens and ScrollTriggers every time you navigate away.

This adds GSAP's own React hook and points at it from the two places someone would actually look.

The hook is worth having over a hand-rolled one: it scopes selector strings to a ref, so `'.card'` only matches inside your component, and it reverts everything created inside it on unmount without you writing cleanup. It also handles animations started from event handlers, which run outside the scope and would otherwise escape cleanup.

## Summary

- Adds `@gsap/react` (~2KB, same vendor as `gsap`) and calls `gsap.registerPlugin(useGSAP)` in `components/effects/gsap.tsx`, next to the existing runtime config.
- Registration sits outside the `typeof window` guard on purpose. `useGSAP` sets `headless = true`, meaning it does not need a window, unlike the ticker config below it which touches browser-only APIs.
- Documents the pattern in the runtime module's JSDoc and in the animation section of `AGENTS.md`, including `contextSafe` for event handlers.
- Reduced motion stays the caller's job via `gsap.matchMedia()`. A blanket skip would strand elements in whatever initial state the animation was going to move them out of, which is worse than animating.

Considered writing our own `useGsapContext` instead, in keeping with how the repo owns its other hooks. Not worth it here: the official hook does the same thing plus `contextSafe` and StrictMode handling, and it is one less thing to maintain against future GSAP releases.

## Test Plan

- [x] `bun run check` passes: lint, type-aware lint, tsc, 385 tests, manifest check
- [x] `bun run build` compiles successfully
- [x] Confirmed `useGSAP` exposes `register` and `headless` in its source, so `registerPlugin` accepts it rather than warning
- [ ] Write one real animation with it and confirm tweens revert on navigation
