### PR TITLE
fix(shopify): stop cropping cart thumbnails

### DIFF
--- a/lib/integrations/shopify/cart/modal/index.tsx
+++ b/lib/integrations/shopify/cart/modal/index.tsx
@@ -131,6 +131,10 @@ function InnerCart() {
                 // a thumbnail.
                 mobileSize="25vw"
                 desktopSize="17vw"
+                // Product shots vary in aspect and must not be cropped in the
+                // cart. This has to be the prop, not CSS: Image writes
+                // object-fit inline, which outranks any stylesheet rule.
+                objectFit="contain"
                 {...(merchandise.product.featuredImage?.width &&
                 merchandise.product.featuredImage?.height
                   ? {

--- a/lib/integrations/shopify/cart/modal/modal.module.css
+++ b/lib/integrations/shopify/cart/modal/modal.module.css
@@ -110,14 +110,14 @@
       width: 100%;
       height: mobile-vw(150px);
 
-      /* Both axes must be bound for object-fit to apply — the Image
-         wrapper's block style is width: auto, so height alone let a
-         product image render at its intrinsic aspect and spill out of
-         the grid cell. */
+      /* Both axes must be bound or the image renders at its intrinsic
+         aspect and spills out of the grid cell — the Image wrapper's
+         block style is width: auto, so height alone is not enough.
+         object-fit is set via the component's prop, since it writes that
+         one inline where a rule here could never win. */
       img {
         width: 100%;
         height: 100%;
-        object-fit: contain;
       }
 
       @media (--desktop) {


### PR DESCRIPTION
## What this does

Cart thumbnails were cropping about a third off every product image. Found by opening the cart against the real store rather than reading the code.

The cart line CSS asks for `object-fit: contain`, which is the right intent for product shots that vary in aspect. It never took effect. The `Image` component writes `object-fit` inline from its `objectFit` prop, and an inline style beats a stylesheet rule, so every thumbnail rendered with the component's `cover` default no matter what the module said.

Measured on a live cart: a 97x258 product shot in an 89x156 cell lost 81px of height. A skateboard deck showed as a cropped middle slice with both ends gone.

## Summary

- `cart/modal/index.tsx` — pass `objectFit="contain"` on the thumbnail. It has to be the prop; a CSS rule can never win against the inline style.
- `cart/modal/modal.module.css` — drop the `object-fit: contain` line that was doing nothing. `width`/`height` stay, since both axes still need binding or the image renders at its intrinsic aspect and spills out of the grid cell.

## Test Plan

- [x] `bun run check` passes: lint, type-aware lint, tsc, 385 tests, manifest check
- [x] Verified in the browser against the live store, mobile 390px and desktop 1440px: computed `object-fit` is now `contain`, image box matches its grid cell exactly on both, no overflow
- [x] Both a wide product (cap) and a tall one (deck) render whole instead of cropped
- [x] Confirmed the served image size tracks the `sizes` values landed earlier: 244px served for a 233px box at desktop
