### PR TITLE
docs(gsap): add a worked example of scoped animation

### DIFF
--- a/app/(examples)/gsap/_components/scoped-animation/index.tsx
+++ b/app/(examples)/gsap/_components/scoped-animation/index.tsx
@@ -9,15 +9,12 @@ import s from './scoped-animation.module.css'
 const CARDS = ['one', 'two', 'three', 'four']
 
 /**
- * Demonstrates the three things `useGSAP` gives you over a bare `useEffect`.
+ * Scoped GSAP animation.
  *
- * 1. Selector strings resolve against `scope`, so `.card` only matches inside
- *    this component. The control card below sits outside the scope with the
- *    same class and must never move.
- * 2. Everything created inside the hook is reverted on unmount, so navigating
- *    away leaves no live tweens behind.
- * 3. `contextSafe` pulls animations started from an event handler back into
- *    that same cleanup — without it they outlive the component.
+ * `useGSAP` resolves selector strings against `scope`, so `.card` matches only
+ * inside this component, and reverts every tween it creates on unmount.
+ * Animations started from an event handler run outside that scope unless you
+ * wrap them in `contextSafe`, as `nudge` does below.
  */
 export function ScopedAnimation() {
   const scope = useRef<HTMLDivElement>(null)
@@ -47,7 +44,7 @@ export function ScopedAnimation() {
 
   return (
     <div className={s.root}>
-      <div className={s.scope} ref={scope} data-testid="scope">
+      <div className={s.scope} ref={scope}>
         {CARDS.map((label) => (
           <div className={`card ${s.card}`} key={label}>
             {label}
@@ -56,13 +53,8 @@ export function ScopedAnimation() {
       </div>
 
       <button className={s.button} onClick={nudge} type="button">
-        nudge (contextSafe)
+        nudge
       </button>
-
-      {/* Outside the scope, same class. If this ever moves, scoping broke. */}
-      <div className={`card ${s.control}`} data-testid="control">
-        control — outside scope
-      </div>
     </div>
   )
 }

--- a/app/(examples)/gsap/_components/scoped-animation/index.tsx
+++ b/app/(examples)/gsap/_components/scoped-animation/index.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useGSAP } from '@gsap/react'
+import gsap from 'gsap'
+import { useRef } from 'react'
+
+import s from './scoped-animation.module.css'
+
+const CARDS = ['one', 'two', 'three', 'four']
+
+/**
+ * Demonstrates the three things `useGSAP` gives you over a bare `useEffect`.
+ *
+ * 1. Selector strings resolve against `scope`, so `.card` only matches inside
+ *    this component. The control card below sits outside the scope with the
+ *    same class and must never move.
+ * 2. Everything created inside the hook is reverted on unmount, so navigating
+ *    away leaves no live tweens behind.
+ * 3. `contextSafe` pulls animations started from an event handler back into
+ *    that same cleanup — without it they outlive the component.
+ */
+export function ScopedAnimation() {
+  const scope = useRef<HTMLDivElement>(null)
+
+  const { contextSafe } = useGSAP(
+    () => {
+      gsap.from('.card', {
+        y: 40,
+        opacity: 0,
+        duration: 0.6,
+        stagger: 0.12,
+        ease: 'power2.out',
+      })
+    },
+    { scope }
+  )
+
+  const nudge = contextSafe(() => {
+    gsap.to('.card', {
+      x: 'random(-24, 24)',
+      rotation: 'random(-8, 8)',
+      duration: 0.4,
+      stagger: 0.04,
+      ease: 'power2.inOut',
+    })
+  })
+
+  return (
+    <div className={s.root}>
+      <div className={s.scope} ref={scope} data-testid="scope">
+        {CARDS.map((label) => (
+          <div className={`card ${s.card}`} key={label}>
+            {label}
+          </div>
+        ))}
+      </div>
+
+      <button className={s.button} onClick={nudge} type="button">
+        nudge (contextSafe)
+      </button>
+
+      {/* Outside the scope, same class. If this ever moves, scoping broke. */}
+      <div className={`card ${s.control}`} data-testid="control">
+        control — outside scope
+      </div>
+    </div>
+  )
+}

--- a/app/(examples)/gsap/_components/scoped-animation/scoped-animation.module.css
+++ b/app/(examples)/gsap/_components/scoped-animation/scoped-animation.module.css
@@ -26,13 +26,3 @@
   border: 1px solid var(--color-secondary);
   border-radius: 100px;
 }
-
-.control {
-  display: grid;
-  place-items: center;
-  width: 240px;
-  height: 96px;
-  border: 1px dashed var(--color-secondary);
-  border-radius: 8px;
-  opacity: 0.6;
-}

--- a/app/(examples)/gsap/_components/scoped-animation/scoped-animation.module.css
+++ b/app/(examples)/gsap/_components/scoped-animation/scoped-animation.module.css
@@ -1,0 +1,38 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 48px 24px;
+}
+
+.scope {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.card {
+  display: grid;
+  place-items: center;
+  width: 96px;
+  height: 96px;
+  border: 1px solid var(--color-secondary);
+  border-radius: 8px;
+}
+
+.button {
+  align-self: flex-start;
+  padding: 12px 20px;
+  border: 1px solid var(--color-secondary);
+  border-radius: 100px;
+}
+
+.control {
+  display: grid;
+  place-items: center;
+  width: 240px;
+  height: 96px;
+  border: 1px dashed var(--color-secondary);
+  border-radius: 8px;
+  opacity: 0.6;
+}

--- a/app/(examples)/gsap/page.tsx
+++ b/app/(examples)/gsap/page.tsx
@@ -1,0 +1,19 @@
+import { Wrapper } from '@/components/layout/wrapper'
+import { Link } from '@/components/ui/link'
+
+import { ScopedAnimation } from './_components/scoped-animation'
+
+export const metadata = {
+  title: 'GSAP',
+  description: 'Scoped GSAP animation with useGSAP',
+}
+
+export default function GsapPage() {
+  return (
+    <Wrapper theme="dark">
+      <h1 className="dr-h1">gsap</h1>
+      <ScopedAnimation />
+      <Link href="/">back home</Link>
+    </Wrapper>
+  )
+}


### PR DESCRIPTION
## What this does

Adds a working example of a GSAP animation in a component, at `/gsap`.

The `useGSAP` wiring shipped with a paragraph of documentation and nothing using it. This gives you a file to copy instead.

It shows the two things worth knowing: selector strings resolve against the ref, so `.card` matches only inside the component, and an animation started from a click needs `contextSafe` to stay inside that same cleanup.

## Summary

- `app/(examples)/gsap/page.tsx` — server component, follows the existing `(examples)/sanity` layout.
- `_components/scoped-animation/` — client component. Entrance stagger on mount, a `contextSafe` nudge on click.

## How this was verified

An earlier revision carried test scaffolding: a control card outside the ref with the same class, plus testids. It confirmed all three behaviours against the running app, then came out because it read as apparatus rather than something worth copying.

- **Scoping** — after the nudge, all 4 in-scope cards had a changed transform matrix; the control outside the ref stayed at `transform: none`
- **Cleanup on unmount** — held a node reference across a client-side navigation. Its inline style went from `translate: none; rotate: none; scale: none; opacity: 1; transform: translate(-9.27px, 0px) rotate(4.36deg)` to empty
- **contextSafe** — the styles cleared above came from the click-triggered animation, so the event-handler tween was inside the scope. Without `contextSafe` those would have survived

## Test Plan

- [x] `bun run check` passes: lint, type-aware lint, tsc, 385 tests, manifest check
- [x] Re-verified after stripping the scaffolding: 4 cards render, entrance settles to opacity 1, nudge animates all 4
- [x] No console errors, and no GSAP "invalid plugin" warning from `registerPlugin(useGSAP)`
