### PR TITLE
test: guard the failure modes a starter propagates silently

### DIFF
--- a/lib/integrations/cache-invariant.test.ts
+++ b/lib/integrations/cache-invariant.test.ts
@@ -39,7 +39,12 @@ import type {
   SourceFile,
 } from 'ts-morph'
 
-const NETWORK_READ_PATTERNS = [/\bfetch\(/, /shopifyFetch/, /sanityFetch/]
+const NETWORK_READ_PATTERNS = [
+  /\bfetch\(/,
+  /fetchWithTimeout/,
+  /shopifyFetch/,
+  /sanityFetch/,
+]
 const CACHE_EXEMPT_PATTERN = /\/\/\s*cache-exempt:/
 
 /** Is `'use server'` the first statement in the file? */

--- a/lib/integrations/cache-invariant.test.ts
+++ b/lib/integrations/cache-invariant.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Cache Components invariant
+ *
+ * `next.config.ts` sets `cacheComponents: true`. Under it, an uncached async
+ * data read inside a Server Component silently opts the *entire route* out
+ * of static rendering — no build error, no test failure, no typecheck
+ * failure. That is exactly what was wrong with the Shopify data layer here:
+ * `products.ts`/`collections.ts`/`pages.ts` read the storefront catalog
+ * without `'use cache'`, so every page that rendered a product silently
+ * became fully dynamic.
+ *
+ * The invariant: every exported `async` function under `lib/integrations/**`
+ * that performs a network read (references `fetch(`, `shopifyFetch`, or
+ * `sanityFetch`) must either contain a `'use cache'` directive, or be
+ * exempt for one of three reasons, in this precedence:
+ *
+ *  1. The file has `'use server'` at the top — Server Actions and mutations
+ *     must never be cached.
+ *  2. The call passes `cache: 'no-store'` — a deliberate per-user or
+ *     mutation read (e.g. `lib/integrations/shopify/cart-operations.ts`).
+ *  3. The function (or file) carries a `// cache-exempt: <reason>` comment
+ *     — a conscious, documented opt-out (e.g. the shared `shopifyFetch`
+ *     wrapper in `lib/integrations/shopify/client.ts`, used by both cached
+ *     and uncached callers).
+ *
+ * This walks the AST (via ts-morph) rather than hardcoding file/function
+ * names, so it survives `setup:project` pruning whole integrations: if
+ * `lib/integrations/shopify/` doesn't exist, its functions simply aren't in
+ * the scan, and the test has nothing to say about it.
+ */
+
+import { describe, expect, it } from 'bun:test'
+
+import { Project, SyntaxKind } from 'ts-morph'
+import type {
+  ArrowFunction,
+  FunctionDeclaration,
+  FunctionExpression,
+  SourceFile,
+} from 'ts-morph'
+
+const NETWORK_READ_PATTERNS = [/\bfetch\(/, /shopifyFetch/, /sanityFetch/]
+const CACHE_EXEMPT_PATTERN = /\/\/\s*cache-exempt:/
+
+/** Is `'use server'` the first statement in the file? */
+function fileHasUseServerDirective(sourceFile: SourceFile): boolean {
+  const first = sourceFile.getStatements()[0]
+  if (!first || !first.isKind(SyntaxKind.ExpressionStatement)) return false
+  const text = first.getText().trim()
+  return text === "'use server'" || text === '"use server"'
+}
+
+/** Does the very first (top-of-file) comment carry a file-level exemption? */
+function fileHasCacheExemptHeader(sourceFile: SourceFile): boolean {
+  const first = sourceFile.getStatements()[0]
+  if (!first) return false
+  // getFullText() on the first statement includes any leading trivia
+  // (comments) that sit before it — i.e. a top-of-file comment block.
+  return CACHE_EXEMPT_PATTERN.test(first.getFullText())
+}
+
+type FunctionLike = FunctionDeclaration | ArrowFunction | FunctionExpression
+
+interface CandidateFunction {
+  name: string
+  fn: FunctionLike
+}
+
+/** Every exported, async, top-level function in the file (declarations and `export const x = async (...) => {}`). */
+function getExportedAsyncFunctions(
+  sourceFile: SourceFile
+): CandidateFunction[] {
+  const candidates: CandidateFunction[] = []
+
+  for (const fn of sourceFile.getFunctions()) {
+    if (fn.isExported() && fn.isAsync()) {
+      const name = fn.getName()
+      if (name) candidates.push({ name, fn })
+    }
+  }
+
+  for (const varStatement of sourceFile.getVariableStatements()) {
+    if (!varStatement.isExported()) continue
+    for (const decl of varStatement.getDeclarations()) {
+      const initializer = decl.getInitializer()
+      if (!initializer) continue
+      const isFunctionLike =
+        initializer.isKind(SyntaxKind.ArrowFunction) ||
+        initializer.isKind(SyntaxKind.FunctionExpression)
+      if (isFunctionLike && initializer.isAsync()) {
+        candidates.push({ name: decl.getName(), fn: initializer })
+      }
+    }
+  }
+
+  return candidates
+}
+
+/** First statement of the function body is the `'use cache'` directive. */
+function hasUseCacheDirective(fn: FunctionLike): boolean {
+  const body = fn.getBody()
+  if (!body || !body.isKind(SyntaxKind.Block)) return false
+  const first = body.getStatements()[0]
+  if (!first || !first.isKind(SyntaxKind.ExpressionStatement)) return false
+  const text = first.getText().trim()
+  return text === "'use cache'" || text === '"use cache"'
+}
+
+function bodyText(fn: FunctionLike): string {
+  return fn.getBody()?.getText() ?? ''
+}
+
+function performsNetworkRead(fn: FunctionLike): boolean {
+  // Full text (not just the body) so a wrapper whose *own name* is
+  // shopifyFetch/sanityFetch — the thing that actually issues the
+  // request — counts as a network read, not just its callers.
+  const text = fn.getFullText()
+  return NETWORK_READ_PATTERNS.some((pattern) => pattern.test(text))
+}
+
+/**
+ * A read that's genuinely, permanently uncached (a per-user or mutation
+ * read like cart-operations.ts) never calls `cacheTag`/`cacheLife` — those
+ * are the Cache Components APIs a function reaches for specifically to
+ * declare caching intent.
+ *
+ * A `'use cache'`-wrapped catalog read (products.ts et al.) also passes
+ * `cache: 'no-store'` to its inner fetch call — deliberately, to avoid the
+ * fetch-level cache holding a second, independently-stale copy alongside
+ * the outer Cache Components entry (see PR #324). Treating that
+ * `cache: 'no-store'` as an automatic exemption would make removing
+ * `'use cache'` from such a function invisible to this test — exactly the
+ * silent regression this test exists to catch. So exemption 2 only counts
+ * when the function shows no other caching intent.
+ */
+function passesNoStore(fn: FunctionLike): boolean {
+  const text = bodyText(fn)
+  const hasNoStore = /cache:\s*['"]no-store['"]/.test(text)
+  const declaresCachingIntent = /\bcacheTag\(|\bcacheLife\(/.test(text)
+  return hasNoStore && !declaresCachingIntent
+}
+
+/** Comment directly attached to this function (leading trivia) or inside its body. */
+function hasFunctionCacheExemptComment(fn: FunctionLike): boolean {
+  return (
+    CACHE_EXEMPT_PATTERN.test(fn.getFullText()) ||
+    CACHE_EXEMPT_PATTERN.test(bodyText(fn))
+  )
+}
+
+describe('Cache Components invariant (uncached network reads under lib/integrations/**)', () => {
+  const project = new Project({ skipAddingFilesFromTsConfig: true })
+  project.addSourceFilesAtPaths([
+    'lib/integrations/**/*.ts',
+    'lib/integrations/**/*.tsx',
+    '!lib/integrations/**/*.test.ts',
+    '!lib/integrations/**/*.test.tsx',
+  ])
+  const sourceFiles = project.getSourceFiles()
+
+  // Sanity check on the scan itself — if this is ever 0, the glob broke and
+  // every assertion below would trivially (and silently) pass.
+  it('scans at least one source file', () => {
+    expect(sourceFiles.length).toBeGreaterThan(0)
+  })
+
+  for (const sourceFile of sourceFiles) {
+    const relativePath =
+      sourceFile.getFilePath().split('/satus/').at(-1) ??
+      sourceFile.getFilePath()
+    const candidates = getExportedAsyncFunctions(sourceFile)
+    if (candidates.length === 0) continue
+
+    const fileIsServerAction = fileHasUseServerDirective(sourceFile)
+    const fileHasHeaderExemption = fileHasCacheExemptHeader(sourceFile)
+
+    for (const { name, fn } of candidates) {
+      if (!performsNetworkRead(fn)) continue
+
+      it(`${relativePath}: ${name}() is cached or exempt`, () => {
+        const exempt =
+          fileIsServerAction ||
+          fileHasHeaderExemption ||
+          passesNoStore(fn) ||
+          hasFunctionCacheExemptComment(fn)
+
+        expect(
+          hasUseCacheDirective(fn) || exempt,
+          `${relativePath}: exported async function "${name}" performs a network read ` +
+            "but has neither a 'use cache' directive nor a documented exemption " +
+            "('use server' at the top of the file, cache: 'no-store', or a " +
+            '// cache-exempt: comment). Under cacheComponents, this silently opts ' +
+            'the whole route out of static rendering.'
+        ).toBe(true)
+      })
+    }
+  }
+})

--- a/lib/integrations/shopify/client.ts
+++ b/lib/integrations/shopify/client.ts
@@ -35,6 +35,10 @@ const shopifyEnvelopeSchema = z.object({
   errors: z.array(z.object({ message: z.string() })).optional(),
 })
 
+// cache-exempt: shared low-level wrapper used by both cached callers (which
+// wrap it in 'use cache', e.g. products.ts) and uncached per-user/mutation
+// callers (which pass cache: 'no-store', e.g. cart-operations.ts) — caching
+// policy belongs to the caller, not this wrapper.
 export async function shopifyFetch<T = Record<string, unknown>>({
   cache = 'force-cache',
   headers: customHeaders,

--- a/lib/integrations/turnstile/index.ts
+++ b/lib/integrations/turnstile/index.ts
@@ -23,6 +23,10 @@ export interface TurnstileValidationResult {
   errors: string[]
 }
 
+// cache-exempt: reads headers() for the requester's IP and verifies a
+// one-time challenge token with Cloudflare — inherently per-request, so
+// 'use cache' would both be illegal (headers() is banned inside it) and
+// wrong (a cached verdict would replay the verification for other visitors).
 export async function validateTurnstile(
   token: string
 ): Promise<TurnstileValidationResult> {

--- a/lib/scripts/env-drift.test.ts
+++ b/lib/scripts/env-drift.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Env-var drift invariant
+ *
+ * `lib/scripts/integration-bundles.ts` declares each integration's `envVars`,
+ * which `setup:project` uses to strip lines from `.env.example` when that
+ * integration is removed. Two silent-drift classes are possible here, and
+ * both happened for real in this repo:
+ *
+ *  (a) A bundle declares a var that no schema key backs — `.env.example`
+ *      would strip a line for a var nothing reads (this happened with two
+ *      dead `SHOPIFY_CUSTOMER_ACCOUNT_API_*` entries).
+ *  (b) A schema key that clearly belongs to an integration (by name prefix)
+ *      is missing from that integration's `envVars` — removing the
+ *      integration then orphans a real env var in `.env.example` forever
+ *      (this happened with `NEXT_PUBLIC_SANITY_API_VERSION` and
+ *      `HUBSPOT_ALLOWED_FORM_IDS`).
+ *
+ * The source of truth for "what env vars exist" is the Zod schema in
+ * `lib/env.ts`, parsed as text (never imported/hardcoded) so this test can
+ * never itself drift from the schema.
+ *
+ * This test intentionally does NOT assert every schema key is owned by some
+ * bundle — a handful of keys (NODE_ENV, NEXT_PUBLIC_BASE_URL, analytics,
+ * Turnstile) are registry entries with no removable bundle, and that's a
+ * legitimate, permanent state, not drift.
+ */
+
+import { describe, expect, it } from 'bun:test'
+
+import { getIntegrationEntries } from './integration-bundles'
+
+/** Extract schema keys from the two-space-indented `KEY: z...` lines in lib/env.ts. */
+async function getSchemaKeys(): Promise<string[]> {
+  const source = await Bun.file('lib/env.ts').text()
+  const keys: string[] = []
+  for (const line of source.split('\n')) {
+    const match = /^ {2}([A-Z0-9_]+):/.exec(line)
+    if (match?.[1]) keys.push(match[1])
+  }
+  return keys
+}
+
+/**
+ * Does `bundleId` own `key`, by case-insensitive prefix match on the bundle
+ * id, allowing an optional `NEXT_PUBLIC_` prefix on the key?
+ * e.g. bundle "sanity" owns "SANITY_REVALIDATE_SECRET" and
+ * "NEXT_PUBLIC_SANITY_DATASET".
+ */
+function ownsKey(bundleId: string, key: string): boolean {
+  const bare = key.startsWith('NEXT_PUBLIC_')
+    ? key.slice('NEXT_PUBLIC_'.length)
+    : key
+  return bare.toUpperCase().startsWith(`${bundleId.toUpperCase()}_`)
+}
+
+describe('env-var drift (lib/env.ts <-> integration-bundles.ts)', () => {
+  it('(a) no bundle declares an envVar that does not exist in the lib/env.ts schema', async () => {
+    const schemaKeys = new Set(await getSchemaKeys())
+
+    for (const [name, bundle] of getIntegrationEntries()) {
+      for (const envVar of bundle.envVars) {
+        expect(
+          schemaKeys.has(envVar),
+          `Bundle "${name}" declares envVar "${envVar}" which does not exist in lib/env.ts — ` +
+            'removing this integration would strip a line for a var nothing reads.'
+        ).toBe(true)
+      }
+    }
+  })
+
+  it('(b) every schema key that matches a bundle’s name prefix is declared by that bundle', async () => {
+    const schemaKeys = await getSchemaKeys()
+
+    for (const [name, bundle] of getIntegrationEntries()) {
+      const declared = new Set(bundle.envVars)
+      const owned = schemaKeys.filter((key) => ownsKey(name, key))
+
+      for (const key of owned) {
+        expect(
+          declared.has(key),
+          `Schema key "${key}" belongs to bundle "${name}" (by name prefix) but is not in its envVars — ` +
+            'removing this integration would orphan the var in .env.example.'
+        ).toBe(true)
+      }
+    }
+  })
+})

--- a/lib/scripts/integration-bundles.ts
+++ b/lib/scripts/integration-bundles.ts
@@ -117,6 +117,7 @@ export const INTEGRATION_BUNDLES = defineBundles({
     envVars: [
       'NEXT_PUBLIC_SANITY_PROJECT_ID',
       'NEXT_PUBLIC_SANITY_DATASET',
+      'NEXT_PUBLIC_SANITY_API_VERSION',
       'NEXT_PUBLIC_SANITY_API_READ_TOKEN',
       'SANITY_API_READ_TOKEN',
       'SANITY_PRIVATE_TOKEN',
@@ -323,7 +324,11 @@ export const INTEGRATION_BUNDLES = defineBundles({
     devDependencies: [],
     folders: ['lib/integrations/hubspot'],
     files: [],
-    envVars: ['HUBSPOT_ACCESS_TOKEN', 'NEXT_PUBLIC_HUBSPOT_PORTAL_ID'],
+    envVars: [
+      'HUBSPOT_ACCESS_TOKEN',
+      'NEXT_PUBLIC_HUBSPOT_PORTAL_ID',
+      'HUBSPOT_ALLOWED_FORM_IDS',
+    ],
     barrelExports: [],
     codeTransforms: [],
   },

--- a/lib/styles/fonts.test.ts
+++ b/lib/styles/fonts.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Font variable-axis invariant
+ *
+ * `lib/styles/fonts.ts` calls `next/font/google` loaders. Passing an explicit
+ * `weight` array to a family that ships a variable `wght` axis makes Next
+ * download a separate static file per weight instead of one variable file,
+ * and makes in-between weights snap to the nearest loaded one. That was a
+ * real, silent bug here — it broke no build, test, lint, or typecheck.
+ *
+ * This test parses `lib/styles/fonts.ts` as text (never imported — importing
+ * `next/font/google` outside a Next build fails) and cross-references each
+ * font family against Next's own font metadata: if the family ships a
+ * "variable" weight, the call must not pass an explicit `weight` option.
+ */
+
+import { describe, expect, it } from 'bun:test'
+
+const FONT_DATA_PATH =
+  'node_modules/next/dist/compiled/@next/font/dist/google/font-data.json'
+
+type FontMetadata = Record<string, { weights: string[] }>
+
+/** `Spline_Sans_Mono` -> `Spline Sans Mono` (the next/font/google JSON key). */
+function identifierToFamily(identifier: string): string {
+  return identifier.replace(/_/g, ' ')
+}
+
+async function loadFontMetadata(): Promise<FontMetadata | undefined> {
+  const file = Bun.file(FONT_DATA_PATH)
+  if (!(await file.exists())) return undefined
+  return (await file.json()) as FontMetadata
+}
+
+/** One `SomeFont({ ... })` call site extracted from lib/styles/fonts.ts. */
+interface FontCall {
+  identifier: string
+  optionsText: string
+}
+
+/**
+ * Extract every `Identifier({ ... })` call from the imported next/font/google
+ * bindings, matching balanced braces so a nested object option (e.g. a future
+ * `fallback: [...]`) doesn't truncate the match early.
+ */
+function extractFontCalls(source: string, identifiers: string[]): FontCall[] {
+  const calls: FontCall[] = []
+
+  for (const identifier of identifiers) {
+    const callRegex = new RegExp(`${identifier}\\(\\s*\\{`, 'g')
+    let match: RegExpExecArray | null
+    // biome-ignore lint: while-assign is the clearest way to iterate global regex matches
+    while ((match = callRegex.exec(source))) {
+      const openBraceIndex = match.index + match[0].length - 1
+      let depth = 1
+      let index = openBraceIndex + 1
+      while (index < source.length && depth > 0) {
+        if (source[index] === '{') depth++
+        else if (source[index] === '}') depth--
+        index++
+      }
+      calls.push({
+        identifier,
+        optionsText: source.slice(openBraceIndex + 1, index - 1),
+      })
+    }
+  }
+
+  return calls
+}
+
+describe('font variable-axis invariant (lib/styles/fonts.ts)', () => {
+  it('never passes an explicit weight[] to a family that ships a variable axis', async () => {
+    const metadata = await loadFontMetadata()
+    if (!metadata) return // font-data.json absent — skip, not a real failure
+
+    const source = await Bun.file('lib/styles/fonts.ts').text()
+
+    // Import identifiers come from `import { A, B } from 'next/font/google'`
+    const importMatch =
+      /import\s*\{([^}]+)\}\s*from\s*['"]next\/font\/google['"]/.exec(source)
+    expect(importMatch).not.toBeNull()
+    const identifiers = (importMatch?.[1] ?? '')
+      .split(',')
+      .map((name) => name.trim())
+      .filter(Boolean)
+    expect(identifiers.length).toBeGreaterThan(0)
+
+    const calls = extractFontCalls(source, identifiers)
+    expect(calls.length).toBeGreaterThan(0)
+
+    for (const call of calls) {
+      const family = identifierToFamily(call.identifier)
+      const familyMetadata = metadata[family]
+      if (!familyMetadata) continue // unknown family — not this test's concern
+
+      const isVariable = familyMetadata.weights.includes('variable')
+      if (!isVariable) continue
+
+      expect(
+        /\bweight\s*:/.test(call.optionsText),
+        `"${family}" ships a variable axis (weights: ${familyMetadata.weights.join(', ')}) ` +
+          `but ${call.identifier}({ ... }) in lib/styles/fonts.ts passes an explicit weight — ` +
+          'this downloads a static file per weight instead of one variable file.'
+      ).toBe(false)
+    }
+  })
+})

--- a/lib/styles/fonts.test.ts
+++ b/lib/styles/fonts.test.ts
@@ -47,9 +47,9 @@ function extractFontCalls(source: string, identifiers: string[]): FontCall[] {
 
   for (const identifier of identifiers) {
     const callRegex = new RegExp(`${identifier}\\(\\s*\\{`, 'g')
-    let match: RegExpExecArray | null
-    // biome-ignore lint: while-assign is the clearest way to iterate global regex matches
-    while ((match = callRegex.exec(source))) {
+    while (true) {
+      const match = callRegex.exec(source)
+      if (!match) break
       const openBraceIndex = match.index + match[0].length - 1
       let depth = 1
       let index = openBraceIndex + 1


### PR DESCRIPTION
## What this does

Five bugs were fixed in this repo over the last few days. Every one of them failed silently: no build error, no failing test, no lint warning, clean typecheck. Fonts shipping four files instead of two. The Shopify layer rendering every storefront fully dynamic. An env list that had drifted. A cart cropping a third off every product photo.

That matters more here than in a normal app. Client projects are cloned from this repo, so a silent bug gets inherited by people who have no reason to question it.

So rather than fix more bugs, this makes those three failure classes loud.

## Summary

Three invariant tests, written in the same shape as the existing bundle tests in `setup-project.test.ts`:

- **`lib/scripts/env-drift.test.ts`** — a bundle cannot declare an env var that nothing reads, and cannot omit one its own integration owns. Both directions had already drifted.
- **`lib/styles/fonts.test.ts`** — a `next/font` family that ships a variable axis cannot be pinned to explicit weights. That downloads a separate file per weight and makes the weights in between snap to the nearest one loaded.
- **`lib/integrations/cache-invariant.test.ts`** — an exported async function under `lib/integrations` that hits the network must be cached, or be a server action, or be a deliberate `no-store` read, or carry a written `// cache-exempt:` reason. The escape hatch is the point: it turns a silent omission into a documented decision.

Also fixes the two drifts the first test found. `NEXT_PUBLIC_SANITY_API_VERSION` and `HUBSPOT_ALLOWED_FORM_IDS` are read by their integrations but were claimed by neither bundle, so removing either integration left an orphaned line in `.env.example`.

## The constraint that shaped these

Guards have to survive `setup:project`. A test asserting "Shopify does X" would fail the moment someone scaffolds without Shopify, which is worse than the bug it prevents. So each test derives its targets from what is on disk or from the bundle list, never a hardcoded name. Remove an integration and its assertions leave with it.

The cache test also asserts it scanned at least one file, so a broken glob fails loudly instead of passing everything.

## Test Plan

- [x] `bun run check` passes: 408 tests, 0 failures, up from 385
- [x] Each guard was verified to actually fire, not just pass. Removed `'use cache'` from `getProduct` and the cache test failed naming the function and the consequence; reverted one env var and the drift test named the bundle; added a `weight` array back to `Oswald` and the font test named the family
- [x] One false-negative found and fixed while building: the first version of the `no-store` exemption let a genuinely broken function pass, because our catalog readers legitimately pass `no-store` to the inner fetch to avoid double-caching. Narrowed to functions showing no other caching intent
