### PR TITLE
fix(image): make rendered width explicit instead of guessing 100vw

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -87,7 +87,7 @@ Built on [Base UI](https://base-ui.com/) for accessibility.
 ```tsx
 // ✅ Always use custom Image
 import { Image } from '@/components/ui/image'
-<Image src="/photo.jpg" alt="Photo" aspectRatio={16/9} />
+<Image src="/photo.jpg" alt="Photo" aspectRatio={16/9} mobileSize="100vw" desktopSize="50vw" />
 
 // ✅ Always use custom Link
 import { Link } from '@/components/ui/link'

--- a/components/ui/image/README.md
+++ b/components/ui/image/README.md
@@ -9,20 +9,26 @@ explicit `width` + `height`, or `aspectRatio`. There is no dimension-less
 fallback — the type system enforces this at compile time so a missing size
 can't silently ship as a layout-shift bug.
 
+`sizes` is required too: every render must supply **either** `mobileSize` +
+`desktopSize` together, **or** a raw `sizes` string. There is no `100vw`
+fallback — a wrong-by-default `sizes` doesn't error or warn, it just makes the
+browser fetch a full-viewport-width candidate for what might be a thumbnail,
+and nothing short of measuring network requests catches it.
+
 ```tsx
 import { Image } from '@/components/ui/image'
 
 // Basic — aspectRatio derives placeholder dimensions and reserves the box
-<Image src="/hero.jpg" alt="Hero" aspectRatio={16/9} />
+<Image src="/hero.jpg" alt="Hero" aspectRatio={16/9} mobileSize="100vw" desktopSize="100vw" />
 
 // LCP images — preload
-<Image src="/hero.jpg" alt="Hero" aspectRatio={16/9} preload />
+<Image src="/hero.jpg" alt="Hero" aspectRatio={16/9} mobileSize="100vw" desktopSize="100vw" preload />
 
 // Fill the nearest positioned ancestor (the ancestor owns sizing)
-<Image src="/hero.jpg" alt="Hero" fill />
+<Image src="/hero.jpg" alt="Hero" fill mobileSize="100vw" desktopSize="100vw" />
 
 // Explicit intrinsic dimensions
-<Image src="/product.jpg" alt="Product" width={800} height={600} />
+<Image src="/product.jpg" alt="Product" width={800} height={600} mobileSize="100vw" desktopSize="50vw" />
 
 // Responsive
 <Image
@@ -32,6 +38,9 @@ import { Image } from '@/components/ui/image'
   mobileSize="100vw"
   desktopSize="33vw"
 />
+
+// Raw sizes string, for layouts mobileSize/desktopSize can't express
+<Image src="/product.jpg" alt="Product" aspectRatio={1} sizes="(min-width: 1024px) 400px, 80vw" />
 ```
 
 ## Props
@@ -42,10 +51,12 @@ import { Image } from '@/components/ui/image'
 | `fill`                       | Fill the nearest positioned ancestor. Mutually exclusive with `width`/`height`.                                                                                          |
 | `width` / `height`           | Explicit intrinsic pixel dimensions. Required together (unless `aspectRatio` is provided instead).                                                                       |
 | `preload`                    | Ergonomic alias for next/image's native `preload` prop (LCP images) — also sets `loading="eager"`. Prefer this over passing next/image's deprecated `priority` directly. |
-| `mobileSize` / `desktopSize` | Responsive sizing                                                                                                                                                        |
+| `mobileSize` / `desktopSize` | Rendered width below / at-and-above the desktop breakpoint (e.g. `"50vw"`). **Required together**, unless `sizes` is passed instead.                                     |
+| `sizes`                      | Raw `sizes` attribute, for layouts `mobileSize`/`desktopSize` can't express. **Required** unless `mobileSize`+`desktopSize` are given.                                   |
 
 ## Best Practices
 
 - Sizing is mandatory: pick `fill`, `width`+`height`, or `aspectRatio` — the type won't compile otherwise
+- `sizes` is mandatory too: pick `mobileSize`+`desktopSize`, or a raw `sizes` string — same reasoning, same enforcement
 - Use `preload` for LCP images
 - Never use `next/image` directly

--- a/components/ui/image/index.tsx
+++ b/components/ui/image/index.tsx
@@ -51,6 +51,30 @@ type ImageSizingProps =
     }
 
 /**
+ * `sizes` variants. Every render must declare how wide the image actually
+ * renders — there is no `100vw` fallback. A wrong-by-default `sizes` doesn't
+ * error or warn; it just tells the browser to fetch a full-viewport-width
+ * candidate for what might be an 89px thumbnail, and nothing short of
+ * measuring network requests in a browser catches it. Pick one:
+ * - `mobileSize` + `desktopSize`: the common two-breakpoint case
+ * - `sizes`: a raw sizes string, for layouts the two-breakpoint form can't express
+ */
+type ImageSizesProps =
+  | {
+      /** Rendered width below the desktop breakpoint (e.g. "50vw"). */
+      mobileSize: `${number}vw`
+      /** Rendered width at/above the desktop breakpoint (e.g. "33vw"). */
+      desktopSize: `${number}vw`
+      sizes?: never
+    }
+  | {
+      mobileSize?: never
+      desktopSize?: never
+      /** Raw `sizes` attribute, for layouts `mobileSize`/`desktopSize` can't express. */
+      sizes: string
+    }
+
+/**
  * Enhanced Image component props extending Next.js Image.
  *
  * Adds responsive sizing, aspect ratio support, and automatic blur placeholders.
@@ -60,24 +84,24 @@ type ImageSizingProps =
  * There is no dimension-less fallback — an image with no reserved box causes
  * layout shift when it loads, so the type system enforces one of these paths
  * instead of silently faking dimensions.
+ *
+ * `sizes` is required too: pass `mobileSize`+`desktopSize`, or a raw `sizes`
+ * string. There is no `100vw` fallback — see `ImageSizesProps`.
  */
 export type ImageProps = Omit<
   NextImageProps,
-  'objectFit' | 'alt' | 'width' | 'height' | 'fill'
+  'objectFit' | 'alt' | 'width' | 'height' | 'fill' | 'sizes'
 > & {
   /** CSS object-fit property for image positioning */
   objectFit?: CSSProperties['objectFit']
   /** Display as block element (adds display: block) */
   block?: boolean
-  /** Size on mobile devices (e.g., "100vw", "50vw") */
-  mobileSize?: `${number}vw`
-  /** Size on desktop devices (e.g., "33vw", "25vw") */
-  desktopSize?: `${number}vw`
   /** Ref for accessing the underlying img element */
   ref?: Ref<HTMLImageElement>
   /** Alt text for accessibility. Required — pass `alt=""` explicitly for decorative images. */
   alt: string
-} & ImageSizingProps
+} & ImageSizingProps &
+  ImageSizesProps
 
 // Base64 encoding for blur placeholders (works in browser and Node.js)
 function toBase64(str: string): string {
@@ -170,8 +194,8 @@ function getFinalPlaceholder(
  *
  * @param props - Image props extending Next.js Image
  * @param props.aspectRatio - Aspect ratio for layout stability and blur placeholder
- * @param props.mobileSize - Size on mobile (e.g., "100vw")
- * @param props.desktopSize - Size on desktop (e.g., "50vw")
+ * @param props.mobileSize - Rendered width below the desktop breakpoint (e.g. "50vw"). Required together with `desktopSize`, unless `sizes` is passed instead.
+ * @param props.desktopSize - Rendered width at/above the desktop breakpoint (e.g. "33vw"). Required together with `mobileSize`, unless `sizes` is passed instead.
  * @param props.block - Display as block element
  * @param props.preload - Ergonomic alias for next/image's native `preload` prop
  *   (the modern replacement for the deprecated `priority` prop). Also sets
@@ -184,6 +208,8 @@ function getFinalPlaceholder(
  *   src="/hero.jpg"
  *   alt="Hero image"
  *   aspectRatio={16/9}
+ *   mobileSize="100vw"
+ *   desktopSize="100vw"
  * />
  * ```
  *
@@ -194,6 +220,8 @@ function getFinalPlaceholder(
  *   src="/hero.jpg"
  *   alt="Hero image"
  *   aspectRatio={16/9}
+ *   mobileSize="100vw"
+ *   desktopSize="100vw"
  *   preload // Preloads image for LCP
  * />
  * ```
@@ -221,8 +249,8 @@ export function Image({
   block = !fill,
   width,
   height,
-  mobileSize = '100vw',
-  desktopSize = '100vw',
+  mobileSize,
+  desktopSize,
   sizes,
   src,
   unoptimized,
@@ -235,9 +263,9 @@ export function Image({
   // Determine loading strategy
   const finalLoading = loading ?? (preload ? 'eager' : 'lazy')
 
-  // Generate responsive sizes if not provided
+  // Compute `sizes` from whichever branch of ImageSizesProps was supplied.
   const finalSizes =
-    sizes || `(max-width: ${breakpoints.dt}px) ${mobileSize}, ${desktopSize}`
+    sizes ?? `(max-width: ${breakpoints.dt}px) ${mobileSize}, ${desktopSize}`
 
   // Early return after hooks
   if (!src) return null

--- a/components/ui/image/index.tsx
+++ b/components/ui/image/index.tsx
@@ -265,7 +265,7 @@ export function Image({
 
   // Compute `sizes` from whichever branch of ImageSizesProps was supplied.
   const finalSizes =
-    sizes ?? `(max-width: ${breakpoints.dt}px) ${mobileSize}, ${desktopSize}`
+    sizes ?? `(min-width: ${breakpoints.dt}px) ${desktopSize}, ${mobileSize}`
 
   // Early return after hooks
   if (!src) return null

--- a/components/ui/sanity-image/index.tsx
+++ b/components/ui/sanity-image/index.tsx
@@ -8,14 +8,23 @@ import type {
 import { urlForImage } from '@/integrations/sanity/utils/image'
 
 // Sizing is fully owned by this component (it always derives aspectRatio
-// from the Sanity asset), so fill/width/height are omitted alongside
-// src/aspectRatio — Omit over ImageProps' discriminated sizing union
-// collapses to the union of each branch's key types, so leaving
-// fill/width/height in would let a caller pass a combination that no longer
-// matches any single ImageProps branch.
+// from the Sanity asset and always sets `sizes` itself below), so
+// fill/width/height and mobileSize/desktopSize/sizes are all omitted —
+// Omit over ImageProps' discriminated unions collapses each union to a
+// single flattened object type, so leaving any of these in would let a
+// caller pass a combination that no longer matches any single ImageProps
+// branch.
 interface SanityImageProps extends Omit<
   ImageProps,
-  'src' | 'aspectRatio' | 'fill' | 'width' | 'height' | 'alt'
+  | 'src'
+  | 'aspectRatio'
+  | 'fill'
+  | 'width'
+  | 'height'
+  | 'alt'
+  | 'mobileSize'
+  | 'desktopSize'
+  | 'sizes'
 > {
   image: {
     asset?: {

--- a/lib/integrations/shopify/cart/modal/index.tsx
+++ b/lib/integrations/shopify/cart/modal/index.tsx
@@ -126,9 +126,7 @@ function InnerCart() {
                 src={merchandise.product.featuredImage?.url ?? ''}
                 alt={merchandise.product.featuredImage?.altText ?? ''}
                 // The drawer is 75vw (mobile) / 50vw (desktop) and `.media`
-                // spans 2 of its 6 columns — without this the 100vw default
-                // makes the browser fetch a full-viewport-width candidate for
-                // a thumbnail.
+                // spans 2 of its 6 columns, so a third of each.
                 mobileSize="25vw"
                 desktopSize="17vw"
                 // Product shots vary in aspect and must not be cropped in the


### PR DESCRIPTION
## What this does

`mobileSize` and `desktopSize` both defaulted to `100vw`. So any caller who forgot them was telling the browser the image filled the whole viewport, and the browser fetched a source to match.

Of the two call sites in this repo, one passed them and one didn't. The one that didn't was the cart thumbnail: an 89px image downloading a full-viewport-width file. Nothing caught it. Not types, not lint, not tests, not review. It took opening the cart in a browser and measuring the element.

That is a bad trade for a starter. A wrong default gets cloned into every project built on this and nobody goes looking for it, because it looks like it works.

So callers now have to say what width the image actually renders at. Either the two-breakpoint pair, or a raw `sizes` string when the layout needs something the pair can't express.

## Summary

- `components/ui/image/index.tsx` — new `ImageSizesProps` discriminated union: `mobileSize` + `desktopSize` together, or `sizes` alone. `sizes` had to be added to the existing `Omit<NextImageProps, ...>` or the inherited optional would defeat the union. Defaults removed, no fallback string.
- `components/ui/sanity-image/index.tsx` — it hardcodes `sizes` internally, so it now omits all three from its public props. Follows the same pattern the file already uses for `fill`/`width`/`height`.
- Docs updated where examples would no longer compile: `image/README.md`, `components/README.md`.
- `shopify/cart/modal/index.tsx` — comment only. It already passed both props; its rationale referenced "the 100vw default" which no longer exists.

This mirrors what the component already does for dimensions. `ImageSizingProps` forces a choice between `fill`, `width`+`height`, or `aspectRatio`, and its comment says there is no dimension-less fallback because an image with no reserved box shifts layout. Same argument applies to width.

## Test Plan

- [x] `bun run check` passes: lint, type-aware lint, tsc, 385 tests, manifest check
- [x] The type actually rejects what it should, verified against the compiler:
  - no sizing at all → error, `Property 'sizes' is missing`
  - only `mobileSize` → error, `Property 'desktopSize' is missing`
  - `mobileSize` + `desktopSize` → compiles
  - `sizes` alone → compiles
- [ ] Worth a look at the cart drawer and any Sanity image after merge, to confirm nothing regressed visually
