### PR TITLE
ci: assert the homepage keeps its static shell, and stop lying about gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,13 @@ jobs:
       - name: Run checks
         run: bun run check
 
+      # Advisory — a starter intentionally exports things nothing imports (see
+      # doctor.config.ts's deadCode note), so findings here are signal for
+      # humans to review, not a merge gate.
+      - name: deslop (advisory)
+        continue-on-error: true
+        run: bun run deslop
+
   e2e:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -15,13 +15,11 @@ jobs:
   react-doctor:
     runs-on: ubuntu-latest
 
-    # Advisory for now. The step below surfaces React Doctor findings on the
-    # files a PR changes, but does not block the merge — this lets new PRs stay
-    # visible while the existing backlog is paid down incrementally. To turn the
-    # gate on once the backlog is clear, delete this line. The `--diff` scope
-    # already keeps pre-existing issues out of the PR gate (only files the PR
-    # actually touches are scanned), so enforcing later won't retroactively fail
-    # unrelated PRs.
+    # Advisory only — never blocks a PR. Scores and diffs here are informational,
+    # same stance as the Lighthouse workflow (see lighthouse-to-slack.yml). The
+    # `--diff` scope below still keeps pre-existing issues out of the noise (only
+    # files the PR actually touches are scanned), but nothing in this job can
+    # fail the check.
     continue-on-error: true
 
     steps:
@@ -39,11 +37,12 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # --diff <base>   : only scan files changed vs the PR base — keeps the
-      #                   existing backlog out of the gate; new code stays clean.
-      # --blocking error: error-severity findings set a non-zero exit (shown as a
-      #                   failed step; non-blocking today via continue-on-error above).
-      # --no-telemetry  : no score upload / share URL / crash reporting in CI.
+      # --diff <base>  : only scan files changed vs the PR base — keeps the
+      #                  existing backlog out of the report; new code stays clean.
+      # --no-telemetry : no score upload / share URL / crash reporting in CI.
+      # No --blocking flag: this job is advisory only (continue-on-error above),
+      # so a blocking exit code would be inert anyway — dropped to stop implying
+      # enforcement that isn't there.
       # Pinned to 0.4.2 for reproducible runs — bump deliberately.
       - name: Run React Doctor on changed files
-        run: bunx react-doctor@0.4.2 --diff origin/${{ github.base_ref }} --verbose --blocking error --no-telemetry
+        run: bunx react-doctor@0.4.2 --diff origin/${{ github.base_ref }} --verbose --no-telemetry

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -23,15 +23,16 @@ pre-commit:
       run: bun node_modules/typescript7/bin/tsc --noEmit
       stage_fixed: false
 
-# NOTE: Build checks happen in CI, not pre-push (too slow for dev workflow)
-# Uncomment if you want local build verification:
-# pre-push:
-#   commands:
-#     build-check:
-#       run: bun run build
-#       skip:
-#         - merge
-#         - rebase
+# Build stays CI-only (too slow for a local pre-push gate). Tests (~4s) and
+# the manifest check (~1s) are cheap enough to run here, so a push can't land
+# with a broken suite or a stale COMPONENTS.md.
+pre-push:
+  commands:
+    test-and-manifest:
+      run: bun test && bun run manifest:check
+      skip:
+        - merge
+        - rebase
 
 # Branch switches leave the previous branch's generated route types in
 # .next/types (tsconfig includes them), producing ghost tsc errors about

--- a/lib/scripts/prerender-manifest.test.ts
+++ b/lib/scripts/prerender-manifest.test.ts
@@ -1,0 +1,68 @@
+/**
+ * PPR (Partial Prerendering) regression invariant
+ *
+ * `cacheComponents: true` is on globally (`next.config.ts`), so `/` is
+ * expected to render as a partially-static shell: static HTML around
+ * dynamic holes, generated at build time and served instantly. Any uncached
+ * dynamic read anywhere in the homepage's component tree — a bare `fetch`,
+ * `cookies()`, `headers()`, an un-cached DB call — silently flips the whole
+ * route to fully dynamic. Nothing else in CI catches this: the build
+ * succeeds either way, lint and typecheck don't know about rendering mode,
+ * and the page still looks correct in a browser. This happened for real in
+ * this repo (see PR #324) and was only caught by a human reading build output.
+ *
+ * `bun run build` writes `.next/prerender-manifest.json`, which records the
+ * actual rendering mode Next.js chose per route. This test reads that file
+ * so the regression fails CI instead of shipping silently.
+ *
+ * Only `/` is asserted on. Other routes (studio, api routes) legitimately
+ * render in other modes, and forks add/remove routes — asserting on those
+ * would make this test fight every fork instead of protecting the one
+ * route it exists for.
+ */
+
+import { describe, expect, it } from 'bun:test'
+
+interface PrerenderManifest {
+  version: number
+  routes: Record<string, { renderingMode?: string; experimentalPPR?: boolean }>
+}
+
+const manifestPath = '.next/prerender-manifest.json'
+const manifestFile = Bun.file(manifestPath)
+const manifestExists = await manifestFile.exists()
+
+// No prior `bun run build` (e.g. running `bun test` locally without one) —
+// skip quietly rather than failing. CI always builds before `bun run check`
+// (which runs this suite), so the assertion is live exactly where it matters.
+describe.skipIf(!manifestExists)(
+  'prerender manifest (.next/prerender-manifest.json)',
+  () => {
+    it('homepage ("/") renders PARTIALLY_STATIC', async () => {
+      const manifest: PrerenderManifest = await manifestFile.json()
+      const homeRoute = manifest.routes['/']
+
+      expect(
+        homeRoute,
+        'Route "/" is missing from the prerender manifest entirely — the build output shape changed, or the route was removed.'
+      ).toBeDefined()
+
+      expect(
+        homeRoute?.renderingMode,
+        'The homepage lost its static shell — some component in its tree performs an uncached ' +
+          "dynamic read; find what changed and either wrap it in 'use cache' or gate it behind a Suspense boundary."
+      ).toBe('PARTIALLY_STATIC')
+    })
+
+    it('manifest parsed a plausible number of routes (sanity check)', async () => {
+      const manifest: PrerenderManifest = await manifestFile.json()
+      const routeCount = Object.keys(manifest.routes).length
+
+      expect(
+        routeCount,
+        `Only ${routeCount} route(s) found in the prerender manifest — this likely means the manifest ` +
+          'failed to parse correctly rather than the app genuinely shrinking to almost no routes.'
+      ).toBeGreaterThanOrEqual(3)
+    })
+  }
+)

--- a/lib/scripts/prerender-manifest.test.ts
+++ b/lib/scripts/prerender-manifest.test.ts
@@ -54,15 +54,17 @@ describe.skipIf(!manifestExists)(
       ).toBe('PARTIALLY_STATIC')
     })
 
-    it('manifest parsed a plausible number of routes (sanity check)', async () => {
+    // Deliberately ≥ 1, not a higher bar: forks strip routes, and the real
+    // assertion above already fails if `/` is missing. This only proves the
+    // manifest parsed into a non-empty shape at all.
+    it('manifest parsed at least one route (sanity check)', async () => {
       const manifest: PrerenderManifest = await manifestFile.json()
       const routeCount = Object.keys(manifest.routes).length
 
       expect(
         routeCount,
-        `Only ${routeCount} route(s) found in the prerender manifest — this likely means the manifest ` +
-          'failed to parse correctly rather than the app genuinely shrinking to almost no routes.'
-      ).toBeGreaterThanOrEqual(3)
+        'The prerender manifest parsed to zero routes — the file format likely changed.'
+      ).toBeGreaterThanOrEqual(1)
     })
   }
 )

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "format": "oxfmt",
     "typecheck": "bun node_modules/typescript7/bin/tsc --noEmit",
     "typecheck:watch": "bun node_modules/typescript7/bin/tsc --noEmit --watch",
-    "deslop": "deslop",
+    "deslop": "deslop --ignore 'storybook-static/**'",
     "analyze": "ANALYZE=true bun run build",
     "analyze:experimental": "next experimental-analyze",
     "dev:inspect": "bun ./lib/scripts/dev.ts --inspect",


### PR DESCRIPTION
## What this does

Four fixes from evaluating the CI pipeline as its own thing.

The big one: CI built the app on every run and nobody ever looked at the output. The worst silent regression this repo has had is a route dropping out of static rendering under Cache Components, and catching it took a human reading the route table by hand. A new test reads the prerender manifest after the build and fails if the homepage loses its static shell, with a message saying what to look for. Locally it skips when there is no build, so `bun test` stays instant.

The rest: pushes now run the test suite and manifest check before leaving your machine, about five seconds, so an invariant break costs you seconds instead of a CI round-trip. react-doctor claimed `--blocking error` inside a job with `continue-on-error: true`, a flag that could never fire — it is now labelled what it always was, advisory. And deslop, which the react-doctor config defers dead-code detection to, was defined but called by nothing; it now runs as an advisory CI step with findings visible and exit code ignored.

## Summary

- `lib/scripts/prerender-manifest.test.ts` — asserts `routes["/"]` is `PARTIALLY_STATIC` in `.next/prerender-manifest.json`; skips quietly when no build exists. In CI the build precedes `bun run check`, so it is always live there.
- `lefthook.yml` — pre-push runs `bun test && bun run manifest:check`. Builds stay CI-only, same reasoning as before.
- `.github/workflows/react-doctor.yml` — `--blocking error` removed, comment states advisory-only, same stance as the Lighthouse workflow.
- `.github/workflows/ci.yml` — `deslop (advisory)` step after `bun run check`, `continue-on-error` at step level. Current findings: 46 unused files / 20 unused exports, expected for a starter that intentionally exports things nothing imports yet.

Deliberately not done: `paths-ignore` filters. `ci` and `e2e` are required checks, and a workflow that never triggers leaves required checks stuck as "expected" forever.

## Test Plan

- [x] `bun run check` green: 414 tests, 0 fail, manifest current
- [x] PPR test proven to fire: with the manifest edited to `"STATIC"`, it fails with "The homepage lost its static shell..." naming the fix; skips cleanly with `.next` removed; passes after a fresh build
- [x] `lefthook run pre-push --force` runs the suite + manifest check in ~5s
- [x] Both workflow files parse as YAML
- [ ] After merge: confirm the deslop step shows advisory (yellow-ok) in the first CI run rather than failing the job
