### PR TITLE
test: cover /ai and the 404 path in e2e, pin the create-darkroom contract

### DIFF
--- a/e2e/routes.e2e.ts
+++ b/e2e/routes.e2e.ts
@@ -1,0 +1,120 @@
+import AxeBuilder from '@axe-core/playwright'
+import { expect, test } from '@playwright/test'
+
+/**
+ * No cart test here (or anywhere in e2e/): nothing in the starter mounts
+ * `<Cart>` — it ships as a library primitive for forks to wire up — so there
+ * is no cart UI to drive without first adding a demo shop page, which the
+ * starter deliberately does not have. See `lib/integrations/shopify/README.md`.
+ */
+
+test.describe('/ai machine view', () => {
+  test('renders, has no console errors, passes a11y', async ({ page }) => {
+    const consoleErrors: string[] = []
+    const pageErrors: string[] = []
+
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text())
+      }
+    })
+
+    page.on('pageerror', (error) => {
+      pageErrors.push(error.message)
+    })
+
+    await page.goto('/ai')
+
+    // `networkidle` never settles here — the WebGL scene and the dev HMR
+    // socket keep the connection busy — so anchor on web assertions instead.
+    // Page renders: assert a non-empty document title (auto-waits).
+    await expect(page).toHaveTitle(/.+/)
+    await expect(page.locator('body')).toBeVisible()
+
+    // No console errors or uncaught exceptions during load
+    expect(consoleErrors).toEqual([])
+    expect(pageErrors).toEqual([])
+
+    // Basic a11y: scoped to critical + serious violations only.
+    // Minor/moderate issues in third-party assets are excluded to keep
+    // the baseline stable; tighten to all violations once the starter is
+    // confirmed clean at the full severity level.
+    const results = await new AxeBuilder({ page }).analyze()
+    const seriousViolations = results.violations.filter(
+      (v) => v.impact === 'critical' || v.impact === 'serious'
+    )
+    expect(seriousViolations).toEqual([])
+  })
+})
+
+test.describe('branded 404', () => {
+  test('renders, returns 404, has no console errors, passes a11y', async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = []
+    const pageErrors: string[] = []
+
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text())
+      }
+    })
+
+    page.on('pageerror', (error) => {
+      pageErrors.push(error.message)
+    })
+
+    const response = await page.goto('/this-route-does-not-exist-e2e')
+
+    // Empirically verified (both `next dev` and a `next build && next start`
+    // production run, via curl and Playwright): this route's top-level
+    // document response is HTTP 200, not 404. Cache Components (PPR, enabled
+    // globally — see AGENTS.md "Next.js 16 Cache Components") prerenders the
+    // route's static shell and flushes its 200 status before the dynamic
+    // hole resolves; `notFound()` runs inside that hole, so by the time it's
+    // known the response is a 404, the status line was already sent. This is
+    // a genuine soft-404 (curl shows a `NEXT_HTTP_ERROR_FALLBACK;404` marker
+    // and a `<meta name="robots" content="noindex">` tag in the same
+    // response), not a test bug — assert the real status plus the noindex
+    // signal, rather than the 404 status this route cannot produce.
+    expect(response?.status()).toBe(200)
+
+    // `networkidle` never settles here — the WebGL scene and the dev HMR
+    // socket keep the connection busy — so anchor on web assertions instead.
+    // Page renders: assert a non-empty document title (auto-waits).
+    await expect(page).toHaveTitle(/.+/)
+    await expect(page.locator('body')).toBeVisible()
+
+    // The noindex signal Next.js injects for a page resolved via notFound() —
+    // the actual "this is a 404" marker crawlers see, since the HTTP status
+    // itself can't carry it (see comment above).
+    await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+      'content',
+      'noindex'
+    )
+
+    // Branded not-found copy from components/ui/not-found-view/index.tsx —
+    // rendered as sentence-case text nodes ("404" heading, "Page not found"
+    // message) that CSS uppercases visually via `text-transform: uppercase`.
+    // Assert on the actual DOM text, not the rendered case.
+    await expect(page.getByRole('heading', { name: '404' })).toBeVisible()
+    await expect(page.getByText('Page not found')).toBeVisible()
+
+    // Verified empirically: this 404 navigation logs zero console errors and
+    // zero pageerrors (Chromium's "Failed to load resource" console message
+    // only fires for a genuinely non-200 document response, and this route's
+    // document response is 200 — see comment above).
+    expect(consoleErrors).toEqual([])
+    expect(pageErrors).toEqual([])
+
+    // Basic a11y: scoped to critical + serious violations only.
+    // Minor/moderate issues in third-party assets are excluded to keep
+    // the baseline stable; tighten to all violations once the starter is
+    // confirmed clean at the full severity level.
+    const results = await new AxeBuilder({ page }).analyze()
+    const seriousViolations = results.violations.filter(
+      (v) => v.impact === 'critical' || v.impact === 'serious'
+    )
+    expect(seriousViolations).toEqual([])
+  })
+})

--- a/lib/scripts/create-darkroom-contract.test.ts
+++ b/lib/scripts/create-darkroom-contract.test.ts
@@ -1,0 +1,100 @@
+/**
+ * create-darkroom flag-contract canary
+ *
+ * `create-darkroom` (the scaffolder CLI, a separate repo) clones satus `main`
+ * and invokes `bun run setup:project` with pass-through flags. It has no
+ * version pin on satus. This file mirrors that invocation exactly — its
+ * ground truth is `create-darkroom`'s `src/index.ts`, verbatim:
+ *
+ *   235	    const setupArgs = ['run', 'setup:project']
+ *   236	    if (args.preset !== undefined) setupArgs.push('--preset', args.preset)
+ *   237	    if (args.keep !== undefined) setupArgs.push('--keep', args.keep)
+ *   238	    if (args.cleanHomepage) setupArgs.push('--clean-homepage')
+ *   239
+ *   240	    if (!run('bun', setupArgs, projectPath)) {
+ *   241	      fail('setup:project failed — the clone is intact, re-run it manually')
+ *
+ * Note it does NOT pass `--yes` — it relies on `setup-project.ts`'s non-TTY
+ * skip (see `shouldSkipConfirm`) to avoid hanging on a confirm prompt.
+ *
+ * If a satus PR renames or changes the semantics of any of these flags — and
+ * updates satus's own tests in the same PR — everything here stays green
+ * while every future `create-darkroom` scaffold breaks silently. A failure
+ * in this file means exactly that: a change here breaks scaffolding for
+ * every new project created via `create-darkroom`. The fix is a coordinated
+ * change in BOTH repos (this one, and create-darkroom), never editing this
+ * test to match a renamed/removed flag.
+ *
+ * Prune-safety: this file derives presets/ids from the live
+ * `PROJECT_PRESETS` / `getIntegrationNames()` exports rather than hardcoding
+ * integration names (beyond asserting the universally-present `blank`
+ * preset exists), so it survives `setup:project` stripping integrations out
+ * of a scaffolded project. (This file itself ships only in the satus repo,
+ * not in scaffolded projects — see `SELF_PRUNE_KEEP_TEST_FILES` in
+ * `setup-project.ts` for the self-prune allowlist that governs which test
+ * files DO ship; this one isn't in it, matching `env-drift.test.ts`.)
+ */
+
+import { describe, expect, it } from 'bun:test'
+
+import { getIntegrationNames } from './integration-bundles'
+import {
+  PROJECT_PRESETS,
+  resolveKeepFromFlags,
+  shouldSkipConfirm,
+} from './setup-project'
+
+describe('create-darkroom flag contract', () => {
+  it('the literal argv strings create-darkroom depends on are wired into the actual argv-parsing mechanism', async () => {
+    const source = await Bun.file('lib/scripts/setup-project.ts').text()
+
+    // setup-project.ts parses process.argv manually (via `getFlagValue` /
+    // `argv.includes`), not `util.parseArgs`. Anchor each assertion to that
+    // exact call shape — not to a comment mentioning the flag — so a rename
+    // of the flag string here fails this test even if a comment still
+    // mentions the old name.
+    expect(source).toContain(`getFlagValue(argv, '--preset')`)
+    expect(source).toContain(`getFlagValue(argv, '--keep')`)
+    expect(source).toContain(`argv.includes('--clean-homepage')`)
+    expect(source).toContain(`argv.includes('--yes')`)
+  })
+
+  it("--preset resolves to that preset's integrations, for every preset key", () => {
+    const presetKeys = Object.keys(PROJECT_PRESETS)
+
+    // create-darkroom offers the preset list dynamically — don't hardcode
+    // beyond asserting the universal 'blank' preset is among them.
+    expect(presetKeys).toContain('blank')
+
+    for (const key of presetKeys) {
+      const expected =
+        PROJECT_PRESETS[key as keyof typeof PROJECT_PRESETS].integrations
+      expect(resolveKeepFromFlags(key, undefined)).toEqual([...expected])
+    }
+  })
+
+  it('--keep \'\' resolves to an empty array (the documented "lean build"), not undefined and not a throw', () => {
+    const result = resolveKeepFromFlags(undefined, '')
+    expect(result).toEqual([])
+  })
+
+  it('--preset and --keep together still throw — create-darkroom never sends both, and the throw is the guard', () => {
+    expect(() => resolveKeepFromFlags('blank', '')).toThrow()
+  })
+
+  it('a create-darkroom invocation (flags present, non-TTY, no --yes) skips the confirm prompt', () => {
+    expect(
+      shouldSkipConfirm({ yes: false, hasFlags: true, isTTY: false })
+    ).toBe(true)
+  })
+
+  it('the same invocation at an interactive terminal (TTY) still confirms — the human-abort path the contract preserves', () => {
+    expect(shouldSkipConfirm({ yes: false, hasFlags: true, isTTY: true })).toBe(
+      false
+    )
+  })
+
+  it('sanity: getIntegrationNames() stays a live, non-empty read (guards against the derivation itself going stale)', () => {
+    expect(getIntegrationNames().length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## What this does

Closes the two loose ends from the CI evaluation.

The e2e suite covered one page. It now also covers `/ai` and the branded 404 catch-all — the two routes that actually changed this month. No cart test, deliberately: nothing in the starter mounts the cart. It ships as a library for forks, so there is no cart UI to drive without inventing a demo shop page the starter chose not to have.

And the scaffolder contract is now pinned. `create-darkroom` clones satus `main` unpinned and forwards `--preset`, `--keep`, and `--clean-homepage` to `setup:project`, relying on the non-TTY confirm skip. Until now a satus PR could rename a flag, update satus's own tests in the same PR, stay fully green, and silently break every future scaffold. A contract test makes that impossible to do unknowingly.

## The finding worth reading

Writing the 404 test surfaced real behavior: **the 404 page is a soft 404.** Under Cache Components the static shell's HTTP 200 is flushed before `notFound()` resolves inside the dynamic hole, so the status line can never be rewritten. What actually ships is a 200 carrying `<meta name="robots" content="noindex">` and the `NEXT_HTTP_ERROR_FALLBACK;404` digest — which is the signal crawlers actually consume. Confirmed with curl on a production build, not just Playwright. The test asserts that reality and documents it inline rather than asserting the 404 status that never happens.

## Summary

- `e2e/routes.e2e.ts` — `/ai` gets the same five-assertion treatment as home (renders, no console errors, no pageerrors, no critical/serious axe violations); the 404 path additionally asserts the soft-404 signals. Verified empirically that a 404 navigation logs zero console errors, so no filtering was needed.
- `lib/scripts/create-darkroom-contract.test.ts` — pins the verbatim flag strings to the argv-parsing mechanism (not comments — an assertion a comment could satisfy is worthless), plus semantics: every preset key resolves, `--keep ''` means lean build, `--preset`+`--keep` still throws, and the non-TTY/no-`--yes` shape create-darkroom actually sends skips the confirm while a human TTY still gets the abort prompt. Header states the only correct fix for a failure is a coordinated change in both repos, never editing the test to match.

## Test Plan

- [x] `bun run check` green: 421 tests, 0 fail
- [x] `bun run test:e2e` green in both dev and `CI=1` (real build + start) modes: 3 passed
- [x] Contract canary proven to fire: renamed `--preset` in the parsing code, test failed pointing at the wired flag string; reverted clean
- [x] Soft-404 behavior confirmed with curl against the prod server, headers and body markers both
