### PR TITLE
ci(e2e-gate): fetch the base ref instead of trusting checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,20 @@ jobs:
             exit 0
           fi
 
-          changed_files=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          # Fetch the base explicitly instead of trusting the checkout to have
+          # created origin/<base> — a fork that trims fetch-depth for checkout
+          # speed would otherwise hit "unknown revision" here, and under the
+          # runner's bash -e that turns a docs-only PR's required check red.
+          # Any failure in the pipeline fails OPEN: e2e runs.
+          if ! git fetch --quiet origin "${{ github.base_ref }}"; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! changed_files=$(git diff --name-only "FETCH_HEAD...HEAD"); then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if [ -z "$changed_files" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           # speed would otherwise hit "unknown revision" here, and under the
           # runner's bash -e that turns a docs-only PR's required check red.
           # Any failure in the pipeline fails OPEN: e2e runs.
-          if ! git fetch --quiet origin "${{ github.base_ref }}"; then
+          if ! git fetch --quiet origin -- "${{ github.base_ref }}"; then
             echo "run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
## What this does

Hardens the e2e gate from #333 against a failure mode Copilot flagged two minutes after that PR merged.

The gate diffed against `origin/<base>`, which exists today because checkout runs with `fetch-depth: 0` — three live runs proved that. But a fork that trims fetch-depth for checkout speed would hit "unknown revision", and under the runner's `bash -e` that fails the step, which fails the job, which turns a **docs-only PR's required check red**. Fail-closed in exactly the wrong place.

The gate now fetches the base ref itself and diffs against `FETCH_HEAD`, and every failure in that pipeline fails open: when the gate can't decide, e2e runs. The skip is the optimization; the run is the safe default.

## Test Plan

- [x] YAML parses
- [x] Fetch + `FETCH_HEAD...HEAD` diff pipeline exercised locally against origin/main
- [x] Both failure branches (fetch fails, diff fails) fall through to `run=true`