### PR TITLE
fix(a11y): finish the unconfigured-variant contrast pass

### DIFF
--- a/components/layout/header/header.module.css
+++ b/components/layout/header/header.module.css
@@ -74,7 +74,10 @@
 }
 
 .navLinkDim {
-  opacity: 0.5;
+  /* Same dual-polarity fix as .brandPath above (see its comment for the math):
+     0.5 rendered #808080 on white — 3.94:1, under WCAG AA. 0.55 clears 4.5:1
+     on both white and black. */
+  opacity: 0.55;
 }
 
 /* Mobile menu toggle button — only shown on mobile */

--- a/components/ui/not-configured/not-configured.module.css
+++ b/components/ui/not-configured/not-configured.module.css
@@ -92,6 +92,16 @@
 .instructions {
   padding: calc(24 / 375 * 100vw) calc(24 / 375 * 100vw);
   border-bottom: 1px solid var(--line);
+  /* var(--color-contrast) (the red token, #e9161a) is 4.08:1 on the panel's
+     --surface (#f2f2f2) and only 3.59:1 on the envBlock's --surface-2
+     (#e4e4e4) — both under WCAG AA's 4.5:1 (e2e axe pass on /sanity's
+     unconfigured variant). The red is meaningful here (the shared accent
+     used on .accent, .instructionsLabel, and .envVar), so darken it locally
+     rather than dropping the color. #c41317 is 5.43:1 on #f2f2f2 and 4.78:1
+     on #e4e4e4 — both clear 4.5. Scoped here (not on .instructionsLabel
+     alone) so .envVar, a sibling descendant of this container, can use it
+     too. The global --color-red token is untouched. */
+  --accent-readable: oklch(52.16% 0.2047 27.69);
 
   @media (--desktop) {
     padding: calc(28 / 1440 * 100vw) calc(32 / 1440 * 100vw);
@@ -104,15 +114,7 @@
   font-weight: 400;
   letter-spacing: 0.15em;
   text-transform: uppercase;
-  /* var(--color-contrast) (the red token, #e9161a) is 4.08:1 on the panel's
-     --surface (#f2f2f2) at this ~9px size — under WCAG AA's 4.5:1 (e2e axe
-     pass). The red is meaningful here (it's the same accent used on .accent
-     and .envVar elsewhere in this component), so darken it locally rather
-     than dropping the color or bumping size past the large-text bar and
-     disturbing this label's layout. #c41317 is 5.43:1 on #f2f2f2 — the
-     global --color-red token is untouched. */
-  --instructions-label-accent: oklch(52.16% 0.2047 27.69);
-  color: var(--instructions-label-accent);
+  color: var(--accent-readable);
   margin-bottom: calc(14 / 375 * 100vw);
 
   @media (--desktop) {
@@ -176,7 +178,10 @@
 .envVar {
   font-family: var(--font-mono);
   font-size: calc(10 / 375 * 100vw);
-  color: var(--color-contrast);
+  /* See --accent-readable comment on .instructions above: var(--color-contrast)
+     is 3.59:1 on this element's envBlock (--surface-2, #e4e4e4) — under
+     WCAG AA. --accent-readable is 4.78:1 on #e4e4e4. */
+  color: var(--accent-readable);
 
   @media (--desktop) {
     font-size: calc(12 / 1440 * 100vw);
@@ -210,7 +215,14 @@
 .hint {
   font-family: var(--font-mono);
   font-size: calc(10 / 375 * 100vw);
-  opacity: 0.45;
+  /* Sits on .footer's --surface-2 (#e4e4e4), darker than the --surface
+     (#f2f2f2) .label/.description are tuned against above — 0.45 rendered
+     #7d7d7d here, 3.23:1, under WCAG AA (e2e axe pass; this also darkens
+     the nested .code child via the same opacity blend, since opacity
+     composites the whole subtree). 0.56 renders ~#646464 on #e4e4e4 —
+     5.17:1, still muted. Tuned independently for this surface; not coupled
+     to .label/.description's 0.56 even though the number matches. */
+  opacity: 0.56;
   line-height: 1.5;
 
   @media (--desktop) {


### PR DESCRIPTION
## What this does

Closes out the contrast failures on /sanity's unconfigured variant — the third and, this time verifiably, final round.

The reason rounds kept coming: the previous env-hidden verification passed against a stale build. NEXT_PUBLIC vars are inlined at build time, so hiding .env.local without wiping .next still rendered the configured page. Every fix was real; every verification was measuring the wrong variant. This round reproduced the exact CI failure locally on a clean build before touching anything, and re-verified on clean builds in both variants after.

## Summary

- Dimmed header nav links: opacity 0.5 → 0.55, same dual-polarity math as the brand path (4.74:1 white / 6.25:1 black).
- NotConfigured hint/footer text: its surface computes to #e4e4e4, darker than the panel's #f2f2f2, so it gets its own opacity (renders ~5.17:1). The label/description values from last round sit on the lighter surface and are untouched.
- Env var code tags: were brand red at 3.59:1. The darker accent from last round is renamed `--accent-readable`, hoisted to the shared `.instructions` parent (custom properties don't cross sibling boundaries), and applied here too (4.78:1).
- Swept both files for further sub-AA text: none. The remaining red heading is large text where 3:1 applies and passes.

## Test Plan

- [x] Reproduced the CI failure first: all three violation classes present locally on a clean env-hidden build
- [x] Env hidden, clean build: 5/5 e2e
- [x] Env configured, clean build: 5/5 e2e, no retries
- [x] `bun run check` green, 421 tests; token-level contrast ratchet untouched
- [x] .env.local restored checksum-identical