### PR TITLE
test(e2e): scope the noindex assertion to the noindex meta

### DIFF
--- a/e2e/not-found.e2e.ts
+++ b/e2e/not-found.e2e.ts
@@ -49,11 +49,12 @@ test.describe('branded 404', () => {
 
     // The noindex signal Next.js injects for a page resolved via notFound() —
     // the actual "this is a 404" marker crawlers see, since the HTTP status
-    // itself can't carry it (see comment above).
-    await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
-      'content',
-      'noindex'
-    )
+    // itself can't carry it (see comment above). Scoped to the noindex meta
+    // rather than all robots metas: the layout's SEO defaults can emit their
+    // own robots tag, and matching the pair trips Playwright's strict mode.
+    await expect(
+      page.locator('meta[name="robots"][content*="noindex"]').first()
+    ).toBeAttached()
 
     // Branded not-found copy from components/ui/not-found-view/index.tsx —
     // rendered as sentence-case text nodes ("404" heading, "Page not found"


### PR DESCRIPTION
## What this does

Fixes a one-retry flake in the 404 spec. The layout's SEO defaults can emit their own robots meta alongside the noindex one Next injects for `notFound()`, and the old locator matched the pair — a strict-mode violation. The assertion now targets what the test actually cares about: a robots meta carrying noindex exists.

## Test Plan

- [x] `bun run test:e2e` 5/5, no retries