### PR TITLE
docs: record the stale-build trap for env-absent verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -509,6 +509,8 @@ Pre-commit hook (lefthook) runs on staged files: oxfmt + oxlint --fix (sequentia
 
 Route smoke coverage is automatic: `e2e/route-sweep.e2e.ts` discovers every `app/**/page.tsx` at test-collection time and runs the five-assertion smoke against it — creating the page is the only step. Write a bespoke `*.e2e.ts` only for behavior beyond the smoke (see `e2e/not-found.e2e.ts` for the soft-404 example).
 
+When verifying behavior that depends on env vars being _absent_ (e.g. an integration's unconfigured fallback), wipe `.next` before building: `NEXT_PUBLIC_*` values are inlined at build time, so hiding `.env.local` against a stale build still renders the configured page and your verification silently measures the wrong variant. This burned a real review round — three contrast fixes "passed" env-hidden e2e against a build that had the env baked in.
+
 ---
 
 ## Documentation Map


### PR DESCRIPTION
## What this does

Documents the trap that cost a review round on #335: `NEXT_PUBLIC_*` values are inlined at build time, so hiding `.env.local` against a stale `.next` build still renders the configured page — the verification silently measures the wrong variant. One paragraph in AGENTS.md's testing section, next to the route-sweep note.

This PR is also deliberately docs-only: it is the first exercise of the e2e gate's skip path from #333. Its e2e job should go green via "e2e skipped, no UI-affecting changes" instead of building and running the suite.

## Test Plan

- [ ] The e2e check on this PR passes WITHOUT running Playwright — the job log shows the skip line