### PR TITLE
ci(e2e): cache .next/cache so the e2e job's build isn't always cold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,18 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
 
+      # This job runs its own `next build` (playwright.config.ts webServer in
+      # CI), so it needs the same .next/cache step as the ci job — that path
+      # includes Turbopack's persistent build cache (.next/cache/turbopack).
+      - name: Cache Next.js build
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/cache@v6
+        with:
+          path: .next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('bun.lock') }}-${{ hashFiles('**/*.ts', '**/*.tsx') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('bun.lock') }}-
+
       - name: Install Playwright browsers
         if: steps.gate.outputs.run == 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
         run: bunx playwright install --with-deps chromium


### PR DESCRIPTION
## What this does
The e2e job runs its own \`next build\` (playwright's webServer boots the prod server in CI) but had no build cache, so that second build started cold on every run. This adds the same \`.next/cache\` step the ci job already has, which also covers Turbopack's persistent build cache (\`.next/cache/turbopack\`, default-on since Next 16.3).

On this repo the saving is modest since the starter builds in ~30s. The step matters for forks: this workflow ships to client projects where the build is the dominant cost of the e2e job.

Surfaced by the #340 verification pass.

## Test Plan
- [ ] e2e job green on this PR
- [ ] next run on main shows a cache restore in the e2e job log