### PR TITLE
fix: never disable draft mode on a prefetch

### DIFF
--- a/app/api/draft-mode/disable/route.ts
+++ b/app/api/draft-mode/disable/route.ts
@@ -2,6 +2,22 @@ import { draftMode } from 'next/headers'
 import { type NextRequest, NextResponse } from 'next/server'
 
 export async function GET(request: NextRequest) {
+  // Route handlers execute on router prefetches too. A speculative fetch of
+  // this route must never disable draft mode — that strips the bypass cookie
+  // out from under an open Presentation preview, and every subsequent request
+  // from the iframe bounces to the gate or sign-in. Only a real document
+  // navigation (a click on the pill) may disable. Document navigations carry
+  // none of these headers; prefetch/RSC fetches always carry at least one.
+  const isPrefetch =
+    request.headers.has('next-router-prefetch') ||
+    request.headers.has('rsc') ||
+    request.headers.get('sec-purpose')?.includes('prefetch') === true ||
+    request.headers.get('purpose') === 'prefetch'
+
+  if (isPrefetch) {
+    return new NextResponse(null, { status: 204 })
+  }
+
   // Exit-preview links are same-origin navigations (absent/same-origin/same-site/
   // none Sec-Fetch-Site), including direct address-bar navigation where the
   // header is omitted entirely. A cross-site GET (e.g. an <img> or link on a

--- a/app/api/draft-mode/disable/route.ts
+++ b/app/api/draft-mode/disable/route.ts
@@ -2,6 +2,17 @@ import { draftMode } from 'next/headers'
 import { type NextRequest, NextResponse } from 'next/server'
 
 export async function GET(request: NextRequest) {
+  // Exit-preview links are same-origin navigations (absent/same-origin/same-site/
+  // none Sec-Fetch-Site), including direct address-bar navigation where the
+  // header is omitted entirely. A cross-site GET (e.g. an <img> or link on a
+  // third-party page) shouldn't be able to flip draft mode off, so reject it
+  // before anything else — including before the prefetch check, so cross-site
+  // requests always see 403 regardless of what headers they carry.
+  const secFetchSite = request.headers.get('sec-fetch-site')
+  if (secFetchSite === 'cross-site') {
+    return new Response('Forbidden', { status: 403 })
+  }
+
   // Route handlers execute on router prefetches too. A speculative fetch of
   // this route must never disable draft mode — that strips the bypass cookie
   // out from under an open Presentation preview, and every subsequent request
@@ -16,16 +27,6 @@ export async function GET(request: NextRequest) {
 
   if (isPrefetch) {
     return new NextResponse(null, { status: 204 })
-  }
-
-  // Exit-preview links are same-origin navigations (absent/same-origin/same-site/
-  // none Sec-Fetch-Site), including direct address-bar navigation where the
-  // header is omitted entirely. A cross-site GET (e.g. an <img> or link on a
-  // third-party page) shouldn't be able to flip draft mode off, so reject it
-  // before touching draftMode.
-  const secFetchSite = request.headers.get('sec-fetch-site')
-  if (secFetchSite === 'cross-site') {
-    return new Response('Forbidden', { status: 403 })
   }
 
   ;(await draftMode()).disable()

--- a/lib/integrations/sanity/components/disable-draft-mode.tsx
+++ b/lib/integrations/sanity/components/disable-draft-mode.tsx
@@ -3,17 +3,26 @@
 import { useVisualEditingEnvironment } from 'next-sanity/hooks'
 import { usePathname } from 'next/navigation'
 
-import { Link } from '@/components/ui/link'
-
 export function DisableDraftMode() {
   const environment = useVisualEditingEnvironment()
   const pathname = usePathname()
 
-  // Hide the disable draft mode button when inside the Presentation tool (it owns its own controls there).
-  if (
-    environment === 'presentation-iframe' ||
-    environment === 'presentation-window'
-  ) {
+  // Render ONLY once the environment has settled on 'standalone'. The hook
+  // reports `null` until the Presentation comlink handshake resolves — inside
+  // the Presentation iframe that means the pill would mount briefly before
+  // the 'presentation-iframe' value arrives, so anything but an explicit
+  // 'standalone' must render nothing.
+  if (environment !== 'standalone') {
+    return null
+  }
+
+  // 'standalone' alone doesn't rule out Presentation: the hook falls back to
+  // 'standalone' after 1s in an iframe/popup whose handshake is still pending
+  // (@sanity/visual-editing). A framed or opened context never legitimately
+  // needs the pill, so hide it there regardless. Safe to read `window` here:
+  // the hook returns null on the server and on first paint, so this line only
+  // ever runs client-side after hydration.
+  if (window.self !== window.top || window.opener !== null) {
     return null
   }
 
@@ -21,13 +30,16 @@ export function DisableDraftMode() {
     return null
   }
 
+  // Plain <a>, never a router Link: prefetching this href executes the route
+  // handler and silently strips the draft cookies out from under an open
+  // preview. Disabling draft mode must only ever happen on a real click.
   return (
-    <Link
+    // oxlint-disable-next-line react/forbid-elements, nextjs/no-html-link-for-pages -- deliberate bare anchor: the Link component prefetches, and a prefetch of this route handler disables draft mode (see comment above)
+    <a
       href="/api/draft-mode/disable"
-      scroll={false}
       className="text-sm fixed top-safe right-safe z-50 bg-red dr-p-4 font-mono text-primary uppercase"
     >
       Disable Draft Mode
-    </Link>
+    </a>
   )
 }


### PR DESCRIPTION
## What this does

Draft-mode previews stop randomly losing their session. The "Disable Draft Mode" pill was a prefetching Link, and the router's speculative fetch of `/api/draft-mode/disable` actually ran the handler, deleting the draft cookies out from under an open preview. Reloads only sometimes recovered because it was a race.

## Summary

- `/api/draft-mode/disable` answers prefetch/RSC fetches with 204; only a real document navigation disables. The existing cross-site 403 guard stays on top.
- `DisableDraftMode` renders only once the visual-editing environment settles on `standalone`, and stays hidden in iframe/popup contexts. The hook falls back to `standalone` after 1s when the Presentation handshake is slow, so `standalone` alone does not rule out Presentation.
- The pill is a plain `<a>` instead of the prefetching `Link` primitive, so nothing can prefetch the disable route from the component side either.

## Test Plan

- [ ] `bun run check`, expect exit 0 (473 tests pass)
- [ ] With Sanity configured, open Presentation in Studio: the pill never appears inside the iframe and the preview keeps draft mode
- [ ] Open a draft-mode page standalone: the pill shows, clicking it disables draft mode and redirects to `/`