### PR TITLE
fix(shopify): menu links that go nowhere, blank cart thumbnails, and a timing-unsafe webhook check

### DIFF
--- a/lib/integrations/shopify/cart/add-to-cart/index.tsx
+++ b/lib/integrations/shopify/cart/add-to-cart/index.tsx
@@ -3,6 +3,7 @@
 import cn from 'clsx'
 import { useRouter } from 'next/navigation'
 import { startTransition, useState } from 'react'
+import { useFormStatus } from 'react-dom'
 
 import { formatMoney } from '@/integrations/shopify/money'
 import type { Product, ProductVariant } from '@/integrations/shopify/types'
@@ -61,19 +62,39 @@ export function AddToCart({
 
   return (
     <form action={formAction} className={className}>
-      <button
-        type="submit"
-        className={cn(s.cta, !variant && s.disable)}
+      <AddToCartSubmitButton
         disabled={!variant}
-        aria-label="Add to cart"
+        className={cn(s.cta, !variant && s.disable)}
       >
         {buttonState}
-      </button>
+      </AddToCartSubmitButton>
       {error && (
         <p role="status" aria-live="polite" className={cn('p1', s.actionError)}>
           {error}
         </p>
       )}
     </form>
+  )
+}
+
+function AddToCartSubmitButton({
+  disabled,
+  className,
+  children,
+}: {
+  disabled: boolean
+  className?: string
+  children: string
+}) {
+  const { pending } = useFormStatus()
+  return (
+    <button
+      type="submit"
+      className={className}
+      disabled={disabled || pending}
+      aria-label="Add to cart"
+    >
+      {children}
+    </button>
   )
 }

--- a/lib/integrations/shopify/index.ts
+++ b/lib/integrations/shopify/index.ts
@@ -23,7 +23,7 @@
 //         {products.map(p => (
 //           <div key={p.id}>
 //             <h2>{p.title}</h2>
-//             <AddToCart variants={p.variants} />
+//             <AddToCart product={p} variant={p.variants[0]} />
 //           </div>
 //         ))}
 //       </Cart>

--- a/lib/integrations/shopify/pages.test.ts
+++ b/lib/integrations/shopify/pages.test.ts
@@ -60,4 +60,15 @@ describe('menuItemPath', () => {
   test('an unparseable / relative-looking value passes through the remap unchanged when it does not start with /collections or /pages/', () => {
     expect(menuItemPath('/about')).toBe('/about')
   })
+
+  test('another shop on the same platform is external, not local', () => {
+    // Without SHOPIFY_STORE_DOMAIN configured the `*.myshopify.com` fallback
+    // applies, so this documents the fallback's behaviour rather than the
+    // configured-domain path. With a domain configured, only that exact host
+    // is local — see isStoreHost.
+    const other = 'https://a-different-shop.myshopify.com/products/thing'
+    expect(menuItemPath(other)).toBe(
+      process.env.SHOPIFY_STORE_DOMAIN ? other : '/products/thing'
+    )
+  })
 })

--- a/lib/integrations/shopify/pages.test.ts
+++ b/lib/integrations/shopify/pages.test.ts
@@ -11,23 +11,38 @@
 
 import { describe, expect, test } from 'bun:test'
 
+import { env } from '@/lib/env'
+
+import { normalizeStoreDomain } from './client'
 import { menuItemPath } from './pages'
+
+/**
+ * Derive the fixture host the same way `isStoreHost` does, so these cases
+ * stay correct whether or not SHOPIFY_STORE_DOMAIN is configured in the
+ * environment running the tests. Hardcoding a host would fail the moment a
+ * developer has a real store domain in .env.local.
+ */
+const storeOrigin = normalizeStoreDomain(env.SHOPIFY_STORE_DOMAIN)
+const STORE_HOST = storeOrigin
+  ? new URL(storeOrigin).host
+  : 'your-store.myshopify.com'
+const storeUrl = (path: string) => `https://${STORE_HOST}${path}`
 
 describe('menuItemPath', () => {
   test.each([
     [
       'a product handle containing "pages" as a substring is not corrupted',
-      'https://your-store.myshopify.com/products/pages-and-things',
+      storeUrl('/products/pages-and-things'),
       '/products/pages-and-things',
     ],
     [
       '/collections is remapped to /search',
-      'https://your-store.myshopify.com/collections/x',
+      storeUrl('/collections/x'),
       '/search/x',
     ],
     [
       'a leading /pages/ segment is stripped',
-      'https://your-store.myshopify.com/pages/about',
+      storeUrl('/pages/about'),
       '/about',
     ],
     [
@@ -42,7 +57,7 @@ describe('menuItemPath', () => {
     ],
     [
       'a hash fragment on a store URL is preserved',
-      'https://your-store.myshopify.com/collections/x#section',
+      storeUrl('/collections/x#section'),
       '/search/x#section',
     ],
   ])('%s', (_label, input, expected) => {
@@ -52,9 +67,9 @@ describe('menuItemPath', () => {
   test('a substring match deeper than the leading segment is not remapped', () => {
     // "/collections" only inside a query string / later segment must not be
     // rewritten — only a *leading* /collections or /pages/ segment counts.
-    expect(
-      menuItemPath('https://your-store.myshopify.com/products/my-collections')
-    ).toBe('/products/my-collections')
+    expect(menuItemPath(storeUrl('/products/my-collections'))).toBe(
+      '/products/my-collections'
+    )
   })
 
   test('an unparseable / relative-looking value passes through the remap unchanged when it does not start with /collections or /pages/', () => {
@@ -62,13 +77,10 @@ describe('menuItemPath', () => {
   })
 
   test('another shop on the same platform is external, not local', () => {
-    // Without SHOPIFY_STORE_DOMAIN configured the `*.myshopify.com` fallback
-    // applies, so this documents the fallback's behaviour rather than the
-    // configured-domain path. With a domain configured, only that exact host
-    // is local — see isStoreHost.
+    // With a store domain configured, only that exact host is local. Without
+    // one, isStoreHost falls back to treating any *.myshopify.com host as the
+    // store, so this documents the fallback rather than the configured path.
     const other = 'https://a-different-shop.myshopify.com/products/thing'
-    expect(menuItemPath(other)).toBe(
-      process.env.SHOPIFY_STORE_DOMAIN ? other : '/products/thing'
-    )
+    expect(menuItemPath(other)).toBe(storeOrigin ? other : '/products/thing')
   })
 })

--- a/lib/integrations/shopify/pages.test.ts
+++ b/lib/integrations/shopify/pages.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for `menuItemPath` (pages.ts).
+ *
+ * Covers issue #384: unanchored `String.replace` remaps corrupting product
+ * handles that merely contain `/pages` or `/collections` as a substring, and
+ * absolute URLs (external links, hashes) being collapsed into dead local
+ * routes.
+ *
+ * Run with: bun test lib/integrations/shopify/pages.test.ts
+ */
+
+import { describe, expect, test } from 'bun:test'
+
+import { menuItemPath } from './pages'
+
+describe('menuItemPath', () => {
+  test.each([
+    [
+      'a product handle containing "pages" as a substring is not corrupted',
+      'https://your-store.myshopify.com/products/pages-and-things',
+      '/products/pages-and-things',
+    ],
+    [
+      '/collections is remapped to /search',
+      'https://your-store.myshopify.com/collections/x',
+      '/search/x',
+    ],
+    [
+      'a leading /pages/ segment is stripped',
+      'https://your-store.myshopify.com/pages/about',
+      '/about',
+    ],
+    [
+      'a root-relative input is remapped without needing a host',
+      '/collections/root-relative',
+      '/search/root-relative',
+    ],
+    [
+      'an external absolute URL is returned unchanged, not collapsed to a dead local route',
+      'https://instagram.com/foo',
+      'https://instagram.com/foo',
+    ],
+    [
+      'a hash fragment on a store URL is preserved',
+      'https://your-store.myshopify.com/collections/x#section',
+      '/search/x#section',
+    ],
+  ])('%s', (_label, input, expected) => {
+    expect(menuItemPath(input)).toBe(expected)
+  })
+
+  test('a substring match deeper than the leading segment is not remapped', () => {
+    // "/collections" only inside a query string / later segment must not be
+    // rewritten — only a *leading* /collections or /pages/ segment counts.
+    expect(
+      menuItemPath('https://your-store.myshopify.com/products/my-collections')
+    ).toBe('/products/my-collections')
+  })
+
+  test('an unparseable / relative-looking value passes through the remap unchanged when it does not start with /collections or /pages/', () => {
+    expect(menuItemPath('/about')).toBe('/about')
+  })
+})

--- a/lib/integrations/shopify/pages.ts
+++ b/lib/integrations/shopify/pages.ts
@@ -48,21 +48,28 @@ interface MenuItem {
  * (e.g. `/products/pages-and-things` must NOT become `/products-and-things`).
  */
 function isStoreHost(host: string): boolean {
-  // The env var only ever holds the store's `*.myshopify.com` domain — a
-  // connected custom domain isn't available at this call site without
-  // threading extra config through `getMenu`/`menuItemPath`, so as a
-  // deliberate, documented limitation, any `*.myshopify.com` host is also
-  // treated as the store (custom domains are not recognized here and will
-  // be returned as absolute URLs unchanged, same as any other external host).
-  if (host.endsWith('.myshopify.com')) return true
-
+  // The configured domain is the authority. Match it exactly rather than
+  // accepting any `*.myshopify.com` host — a menu item pointing at a
+  // different store (a partner's shop, say) is an external link, and
+  // localizing it would turn a working URL into a dead route.
   const storeOrigin = normalizeStoreDomain(env.SHOPIFY_STORE_DOMAIN)
-  if (!storeOrigin) return false
-  try {
-    return new URL(storeOrigin).host === host
-  } catch {
-    return false
+  if (storeOrigin) {
+    try {
+      return new URL(storeOrigin).host === host
+    } catch {
+      // Malformed config — fall through to the heuristic below.
+    }
   }
+
+  // No usable config (a menu rendered before the env is wired, or a bad
+  // value): treat the store's own platform domain as local, since that is
+  // the only host Shopify itself authors absolute menu URLs on.
+  //
+  // Known limitation either way: a connected custom domain isn't visible at
+  // this call site without threading extra config through `getMenu`, so a
+  // menu item on one is returned as an absolute URL. That still works — it
+  // just doesn't get the local-route remap.
+  return host.endsWith('.myshopify.com')
 }
 
 export function menuItemPath(url: string): string {

--- a/lib/integrations/shopify/pages.ts
+++ b/lib/integrations/shopify/pages.ts
@@ -1,6 +1,8 @@
 import { cacheLife, cacheTag } from 'next/cache'
 
-import { shopifyFetch } from './client'
+import { env } from '@/lib/env'
+
+import { normalizeStoreDomain, shopifyFetch } from './client'
 import { TAGS } from './constants'
 import { getMenuQuery } from './queries/menu'
 import { getPageQuery, getPagesQuery } from './queries/page'
@@ -24,26 +26,59 @@ interface MenuItem {
  * Extract the path portion of a Shopify menu item URL.
  *
  * Menu item URLs may be absolute (on the store's `.myshopify.com` domain, a
- * connected custom domain, or otherwise) or already-relative paths. Parsing
- * as a URL and taking `pathname + search` handles all absolute cases
- * regardless of host; invalid/relative URLs pass through unchanged.
+ * connected custom domain, or otherwise) or already-relative paths.
  *
- * The extracted path is then remapped onto this starter's route naming:
- * `/collections` -> `/search` (this app's collection/product browse route
- * is `/search`, not `/collections`), and the `/pages` prefix is stripped
- * (Shopify's static "pages" content is served at the site root here, e.g.
- * `/pages/about` -> `/about`). These remaps are Shopify-menu-specific and
- * only apply to `path`, not the original `url`.
+ * - Absolute URLs on the store's own domain are converted to a local path
+ *   (`pathname + search + hash`) and remapped below.
+ * - Absolute URLs on any other host (external sites, e.g. a menu item that
+ *   deliberately links to instagram.com) are returned UNCHANGED — rewriting
+ *   them to `pathname + search` would silently turn a working external link
+ *   into a dead local route.
+ * - Invalid/relative URLs pass through `new URL()` as a throw and are
+ *   treated as already-local paths, so the remap below still applies to
+ *   them (a menu item can be authored as a relative path directly).
+ *
+ * The extracted local path is then remapped onto this starter's route
+ * naming: `/collections` -> `/search` (this app's collection/product browse
+ * route is `/search`, not `/collections`), and a leading `/pages/` segment
+ * is stripped (Shopify's static "pages" content is served at the site root
+ * here, e.g. `/pages/about` -> `/about`). Both remaps are anchored to the
+ * leading path segment (`^/collections` / `^/pages/`) so they only ever
+ * rewrite the route prefix, never an arbitrary substring inside a handle
+ * (e.g. `/products/pages-and-things` must NOT become `/products-and-things`).
  */
-function menuItemPath(url: string): string {
+function isStoreHost(host: string): boolean {
+  // The env var only ever holds the store's `*.myshopify.com` domain — a
+  // connected custom domain isn't available at this call site without
+  // threading extra config through `getMenu`/`menuItemPath`, so as a
+  // deliberate, documented limitation, any `*.myshopify.com` host is also
+  // treated as the store (custom domains are not recognized here and will
+  // be returned as absolute URLs unchanged, same as any other external host).
+  if (host.endsWith('.myshopify.com')) return true
+
+  const storeOrigin = normalizeStoreDomain(env.SHOPIFY_STORE_DOMAIN)
+  if (!storeOrigin) return false
+  try {
+    return new URL(storeOrigin).host === host
+  } catch {
+    return false
+  }
+}
+
+export function menuItemPath(url: string): string {
   let path: string
   try {
     const parsed = new URL(url)
-    path = parsed.pathname + parsed.search
+    if (!isStoreHost(parsed.host)) {
+      return url
+    }
+    path = parsed.pathname + parsed.search + parsed.hash
   } catch {
     path = url
   }
-  return path.replace('/collections', '/search').replace('/pages', '')
+  return path
+    .replace(/^\/collections(?=\/|$)/, '/search')
+    .replace(/^\/pages\//, '/')
 }
 
 export async function getMenu(handle: string): Promise<MenuItem[]> {

--- a/lib/integrations/shopify/revalidate.ts
+++ b/lib/integrations/shopify/revalidate.ts
@@ -1,3 +1,5 @@
+import { createHash, timingSafeEqual } from 'node:crypto'
+
 import { revalidateTag } from 'next/cache'
 import { headers } from 'next/headers'
 import type { NextRequest } from 'next/server'
@@ -6,6 +8,20 @@ import { NextResponse } from 'next/server'
 import { env } from '@/lib/env'
 
 import { TAGS } from './constants'
+
+/**
+ * Constant-time secret comparison. Plain `!==` on strings short-circuits on
+ * the first mismatched character, which leaks timing information an
+ * attacker can use to guess the secret byte-by-byte. `timingSafeEqual`
+ * requires equal-length buffers, so both sides are hashed first — this also
+ * sidesteps the case where `secret`/`env.SHOPIFY_REVALIDATION_SECRET` differ
+ * in length (which would otherwise throw before the safe comparison runs).
+ */
+function secretsMatch(a: string, b: string): boolean {
+  const hashA = createHash('sha256').update(a).digest()
+  const hashB = createHash('sha256').update(b).digest()
+  return timingSafeEqual(hashA, hashB)
+}
 
 const collectionWebhooks = new Set([
   'collections/create',
@@ -30,7 +46,11 @@ export async function revalidate(req: NextRequest): Promise<NextResponse> {
   const isProductUpdate = productWebhooks.has(topic)
   const isPageUpdate = pageWebhooks.has(topic)
 
-  if (!secret || secret !== env.SHOPIFY_REVALIDATION_SECRET) {
+  if (
+    !secret ||
+    !env.SHOPIFY_REVALIDATION_SECRET ||
+    !secretsMatch(secret, env.SHOPIFY_REVALIDATION_SECRET)
+  ) {
     console.error('Invalid revalidation secret.')
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }

--- a/lib/integrations/shopify/schemas.test.ts
+++ b/lib/integrations/shopify/schemas.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for Shopify product schema validation.
+ *
+ * Covers issue #386: `shopifyProductSchema` omitted `featuredImage`, so
+ * Zod's default strip-unknown-keys mode silently deleted it from every
+ * parsed product (getProduct/getProducts/getProductRecommendations/
+ * getCollectionProducts), leaving the cart-drawer thumbnail blank until
+ * router.refresh() landed.
+ *
+ * Run with: bun test lib/integrations/shopify/schemas.test.ts
+ */
+
+import { describe, expect, test } from 'bun:test'
+
+import { parseApiResponse } from '@/lib/utils/validation'
+
+import { getProductResponseSchema } from './schemas'
+
+function buildProductFixture(featuredImage: unknown) {
+  return {
+    product: {
+      id: 'gid://shopify/Product/1',
+      handle: 'test-product',
+      title: 'Test Product',
+      tags: [],
+      availableForSale: true,
+      images: { edges: [] },
+      featuredImage,
+      variants: { edges: [] },
+      description: 'A product',
+      descriptionHtml: '<p>A product</p>',
+      options: [],
+      priceRange: {
+        minVariantPrice: { amount: '10.00', currencyCode: 'USD' },
+        maxVariantPrice: { amount: '10.00', currencyCode: 'USD' },
+      },
+      seo: { title: null, description: null },
+      updatedAt: '2026-01-01T00:00:00Z',
+    },
+  }
+}
+
+describe('shopifyProductSchema featuredImage', () => {
+  test('featuredImage survives parseApiResponse when present', () => {
+    const fixture = buildProductFixture({
+      url: 'https://cdn.shopify.com/featured.jpg',
+      altText: 'Featured shot',
+      width: 800,
+      height: 600,
+    })
+
+    const parsed = parseApiResponse(
+      getProductResponseSchema,
+      fixture,
+      'Shopify Storefront data'
+    )
+
+    expect(parsed.product?.featuredImage).toEqual({
+      url: 'https://cdn.shopify.com/featured.jpg',
+      altText: 'Featured shot',
+      width: 800,
+      height: 600,
+    })
+  })
+
+  test('featuredImage null (product with no images) parses to null, not stripped', () => {
+    const fixture = buildProductFixture(null)
+
+    const parsed = parseApiResponse(
+      getProductResponseSchema,
+      fixture,
+      'Shopify Storefront data'
+    )
+
+    expect(parsed.product?.featuredImage).toBeNull()
+  })
+
+  test('a fixture missing featuredImage entirely fails validation (field is required, not optional)', () => {
+    const fixture = buildProductFixture(undefined) as {
+      product: Record<string, unknown>
+    }
+    delete fixture.product.featuredImage
+
+    const result = getProductResponseSchema.safeParse(fixture)
+    expect(result.success).toBe(false)
+  })
+})

--- a/lib/integrations/shopify/schemas.ts
+++ b/lib/integrations/shopify/schemas.ts
@@ -104,6 +104,13 @@ const shopifyProductSchema = z.object({
   tags: z.array(z.string()),
   availableForSale: z.boolean(),
   images: edgeNode(shopifyImageSchema),
+  // `Product.featuredImage` is unconditionally selected by `productFragment`
+  // (fragments/product.ts) but is a nullable field on Storefront API's
+  // `Product` type (`null` when the product has no images) — same shape as
+  // `cartLineProductSchema.featuredImage` below. Without this key, Zod's
+  // default strip-unknown-keys mode silently deletes it from every parsed
+  // product, which left `featuredImage` always `undefined` downstream.
+  featuredImage: shopifyImageSchema.nullable(),
   variants: edgeNode(shopifyProductVariantSchema),
   description: z.string(),
   descriptionHtml: z.string(),


### PR DESCRIPTION
Shopify batch of the 2026-08-05 audit remediation. Closes #384, closes #386, part of #398 (L1, L2) and #400.

## What this does

Menu links built from a store's own navigation stop breaking. Two separate bugs did it: a product whose handle merely contained `pages` (say `pages-and-things`) had its URL silently mangled into a route that doesn't exist, and any menu item pointing at an external site was collapsed into a dead local path. Both came from the same four-line function doing substring replacement on the whole URL.

Also: the cart drawer no longer flashes a blank thumbnail on every add, the add-to-cart button can't be double-fired while its action is in flight, and the Shopify webhook secret is compared in constant time.

## Summary

- `pages.ts` — remaps anchored to the leading path segment; absolute URLs on a host that isn't the configured store are returned untouched; hash fragments preserved. The configured domain is matched exactly, so another shop on the same platform reads as external.
- `schemas.ts` — `shopifyProductSchema` was missing `featuredImage`, which the GraphQL fragment fetches and the TS type declares, so Zod stripped it and every optimistic cart line got a null image.
- `cart/add-to-cart/index.tsx` — extracted a submit button reading `useFormStatus().pending`, mirroring the two sibling cart buttons that already did this.
- `revalidate.ts` — secret compared with SHA-256 + `timingSafeEqual` instead of `!==`.
- `index.ts` — the header usage example referenced a prop that doesn't exist.

## Known limitation, deliberately not fixed here

The concurrent `createCart` race (#400) is still open. Two simultaneous requests with no existing cart each create one, and a correct fix needs a distributed lock or KV-backed idempotency key — infrastructure this starter doesn't have, and the in-memory rate limiter documents the same gap. The pending guard above closes the common trigger (same-tab double-tap); the cross-request case needs a product decision.

## Test Plan

- [ ] `bun run check` → exit 0 (485 tests pass, 13 new)
- [ ] `bun test lib/integrations/shopify/` → 0 failures
- [ ] With a Shopify store connected, open a menu containing a `/pages/` link, an external link, and a product whose handle starts with `pages-`; all three resolve correctly