### PR TITLE
fix(scripts): make setup:project fail loudly instead of pruning itself on a bad run

### DIFF
--- a/lib/scripts/ast-transforms.test.ts
+++ b/lib/scripts/ast-transforms.test.ts
@@ -16,7 +16,11 @@
 import { describe, expect, it } from 'bun:test'
 
 import type { AstOperation } from './ast-operation-types'
-import { applyOpsToText } from './ast-transforms'
+import {
+  applyCodeTransforms,
+  applyOpsToText,
+  RequiredOpMatchError,
+} from './ast-transforms'
 
 /** Number of times `needle` occurs in `haystack`. */
 function count(haystack: string, needle: string): number {
@@ -988,5 +992,51 @@ export default nextConfig
 
     expect(count(result, "from 'next'")).toBe(1)
     expect(result).toContain('NextConfig')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applyCodeTransforms — missing target file (issue #381)
+//
+// The disk-writing orchestrator used to `continue` past a nonexistent target
+// file before ever calling `applyOpsToText`, so a `required: true` op was
+// silently skipped instead of failing loudly — defeating the whole point of
+// `required` (see ast-operation-types.ts's `RequiredMatchOp` docstring).
+// ---------------------------------------------------------------------------
+
+describe('applyCodeTransforms — missing target file (issue #381)', () => {
+  const missingFile = 'lib/scripts/__fixtures__/does-not-exist.ts'
+
+  it('throws RequiredOpMatchError when a required op targets a nonexistent file', async () => {
+    await expect(
+      applyCodeTransforms(
+        [
+          {
+            file: missingFile,
+            ops: [
+              {
+                kind: 'removeVariableStatement',
+                name: 'doesNotMatter',
+                required: true,
+              },
+            ],
+          },
+        ],
+        true // dryRun — no writes either way, the file doesn't exist
+      )
+    ).rejects.toThrow(RequiredOpMatchError)
+  })
+
+  it('a transform with no required ops still silently skips a missing file (legacy semantics preserved)', async () => {
+    const result = await applyCodeTransforms(
+      [
+        {
+          file: missingFile,
+          ops: [{ kind: 'removeVariableStatement', name: 'doesNotMatter' }],
+        },
+      ],
+      true
+    )
+    expect(result).toEqual({ changes: 0, changedFiles: [], failures: [] })
   })
 })

--- a/lib/scripts/ast-transforms/index.ts
+++ b/lib/scripts/ast-transforms/index.ts
@@ -271,6 +271,13 @@ export interface TransformFailure {
  * there) — that must stop the run before `setup()` reaches self-prune, not
  * just get reported alongside everything else at the end.
  *
+ * A missing target file is silently skipped (`continue`, no failure entry)
+ * UNLESS the transform contains at least one `required: true` op — a missing
+ * file can't possibly satisfy a required match, so that's the same drifted-
+ * source signal as a required op matching nothing on a file that DOES exist,
+ * and is handled identically: `RequiredOpMatchError` is thrown and aborts
+ * the batch, same as above.
+ *
  * `changedFiles` (relative paths, deduped, one entry per transform that
  * actually wrote — a single file can appear once even if two transforms in
  * `transforms` both touch it) lets callers reformat exactly the files this
@@ -293,7 +300,15 @@ export async function applyCodeTransforms(
       const fullPath = resolvePath(transform.file)
       const file = Bun.file(fullPath)
 
-      if (!(await file.exists())) continue
+      if (!(await file.exists())) {
+        const requiredOps = transform.ops.filter((op) => op.required)
+        if (requiredOps.length > 0) {
+          throw new RequiredOpMatchError(
+            `target file does not exist (required op(s): ${requiredOps.map(describeOp).join(', ')})`
+          )
+        }
+        continue
+      }
 
       const original = await file.text()
       const transformed = applyOpsToText(original, transform.ops)

--- a/lib/scripts/bundle-installer.ts
+++ b/lib/scripts/bundle-installer.ts
@@ -13,7 +13,6 @@ import * as p from '@clack/prompts'
 
 import {
   applyCodeTransforms,
-  applyOpsToText,
   type TransformFailure,
 } from './ast-transforms/index'
 import { findBarrelLine, insertBarrelLine } from './barrel-file'
@@ -91,51 +90,38 @@ export const copyBundleFiles = async (
 
 /**
  * Copy the bundle's integration-owned `overwriteFiles` wholesale from the
- * payload source. A local file is only overwritten when it matches either
- * the payload version (already wired — no-op) or the expected lean state
- * (the payload version with this bundle's removal codeTransforms applied).
- * Anything else means local modifications — skip with a warning unless
- * --force.
+ * payload source, unconditionally. `setup:project` (the sole caller, via
+ * `installBundle`) always strips every integration to lean core (step 6 of
+ * `setup()`) before re-adding the kept set, so by the time this runs there
+ * is nothing locally modified left to preserve — the file on disk is either
+ * already the payload version (a cheap no-op check below) or the lean/absent
+ * version the strip pass just produced. A no-op check against the payload
+ * text avoids a redundant write when the file already matches.
  */
 export const applyOverwriteFiles = async (
   source: PayloadSource,
   bundle: IntegrationBundle,
-  options: { dryRun: boolean; force: boolean }
-): Promise<{ written: string[]; skipped: string[] }> => {
+  options: { dryRun: boolean }
+): Promise<{ written: string[] }> => {
   const written: string[] = []
-  const skipped: string[] = []
 
   for (const rel of bundle.overwriteFiles ?? []) {
     const payloadText = await readPayloadFile(source, rel)
     const dest = resolvePath(rel)
 
-    if (!(await pathExists(dest))) {
-      if (!options.dryRun) {
-        await mkdir(dirname(dest), { recursive: true })
-        await Bun.write(dest, payloadText)
-      }
-      written.push(rel)
-      continue
+    if (await pathExists(dest)) {
+      const localText = await Bun.file(dest).text()
+      if (localText === payloadText) continue // already wired
     }
 
-    const localText = await Bun.file(dest).text()
-    if (localText === payloadText) continue // already wired
-
-    const removalOps =
-      bundle.codeTransforms.find((t) => t.file === rel)?.ops ?? []
-    const expectedLean = applyOpsToText(payloadText, removalOps)
-
-    if (localText === expectedLean || options.force) {
-      if (!options.dryRun) {
-        await Bun.write(dest, payloadText)
-      }
-      written.push(rel)
-    } else {
-      skipped.push(rel)
+    if (!options.dryRun) {
+      await mkdir(dirname(dest), { recursive: true })
+      await Bun.write(dest, payloadText)
     }
+    written.push(rel)
   }
 
-  return { written, skipped }
+  return { written }
 }
 
 const sortRecord = (record: Record<string, string>): Record<string, string> =>
@@ -292,8 +278,6 @@ export const installBundle = async (
 ): Promise<{
   details: string[]
   depsAdded: string[]
-  overwriteSkipped: string[]
-  depsMissing: string[]
   changedFiles: string[]
   failures: TransformFailure[]
 }> => {
@@ -332,8 +316,6 @@ export const installBundle = async (
   return {
     details,
     depsAdded: deps.added,
-    overwriteSkipped: overwrite.skipped,
-    depsMissing: deps.missing,
     changedFiles: transformResult.changedFiles,
     failures: transformResult.failures,
   }

--- a/lib/scripts/integration-bundles.ts
+++ b/lib/scripts/integration-bundles.ts
@@ -81,13 +81,15 @@ export interface IntegrationBundle {
    */
   addTransforms?: CodeTransform[]
   /**
-   * Integration-owned files copied wholesale from the payload source on
-   * `satus add`, used where statement-level re-injection would be brittle
-   * (e.g. the Theatre wiring inside the webgl fluid/flowmap hooks, or the
-   * webgl Canvas wiring in the Wrapper). A local file is only overwritten
-   * when it matches the payload version (no-op) or the expected lean state
-   * (payload with this bundle's removal ops applied); anything else is
-   * treated as locally modified and skipped with a warning unless --force.
+   * Integration-owned files copied wholesale from the payload source when
+   * re-adding a bundle, used where statement-level re-injection would be
+   * brittle (e.g. the Theatre wiring inside the webgl fluid/flowmap hooks,
+   * or the webgl Canvas wiring in the Wrapper). `setup:project` (the only
+   * caller) always strips every integration to lean core before re-adding
+   * the kept set, so these are overwritten unconditionally by design — by
+   * the time this runs there is nothing locally modified left to preserve.
+   * A file already matching the payload version is left untouched (a no-op
+   * check, not a "don't clobber local changes" guard).
    */
   overwriteFiles?: string[]
 }

--- a/lib/scripts/setup-project.test.ts
+++ b/lib/scripts/setup-project.test.ts
@@ -1046,7 +1046,9 @@ describe('declaredBundlePaths / findMissingPaths (H8 preflight)', () => {
 
 describe('codeTransformTargetPaths (issue #389 preflight)', () => {
   it('collects the target file of every bundle codeTransform plus both Cache Components transforms', () => {
-    const paths = codeTransformTargetPaths()
+    // Empty keep-set: no CMS and no storefront, so the Cache Components
+    // opt-out pass will run and its targets are required.
+    const paths = codeTransformTargetPaths([])
 
     // A cross-bundle shared file: not in any bundle's folders/files, so
     // declaredBundlePaths alone would never notice it going missing.
@@ -1056,19 +1058,30 @@ describe('codeTransformTargetPaths (issue #389 preflight)', () => {
   })
 
   it('is deduplicated', () => {
-    const paths = codeTransformTargetPaths()
+    const paths = codeTransformTargetPaths([])
     expect(new Set(paths).size).toBe(paths.length)
   })
 
   it('findMissingPaths reports nothing missing against the real repo tree', async () => {
     // Runs against the actual repo tree (this IS the satus repo), so every
     // codeTransform's target file must be present.
-    const missing = await findMissingPaths(codeTransformTargetPaths())
+    const missing = await findMissingPaths(codeTransformTargetPaths([]))
     expect(missing).toEqual([])
   })
 
+  it('omits the Cache Components-only target when a CMS is kept, matching the run', () => {
+    // setupCacheComponentsOptOut returns early when a CMS/storefront
+    // survives, so requiring its targets would make the preflight stricter
+    // than the execution path. Only app/llms.txt/route.ts is unique to that
+    // pass — next.config.ts is a bundle codeTransform target too, so it is
+    // required either way.
+    const paths = codeTransformTargetPaths(['sanity'])
+    expect(paths).not.toContain(CACHE_COMPONENTS_LLMS_TXT_TRANSFORM.file)
+    expect(paths).toContain(CACHE_COMPONENTS_DISABLE_TRANSFORM.file)
+  })
+
   it('a deleted transform-target file fails the preflight before any mutation', async () => {
-    const paths = codeTransformTargetPaths()
+    const paths = codeTransformTargetPaths([])
     const deletedFile = paths[0]
     if (!deletedFile)
       throw new Error('expected at least one codeTransform path')

--- a/lib/scripts/setup-project.test.ts
+++ b/lib/scripts/setup-project.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { beforeAll, describe, expect, it } from 'bun:test'
-import { mkdtemp, rm, symlink } from 'node:fs/promises'
+import { chmod, mkdtemp, rm, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 
@@ -24,6 +24,8 @@ import {
 } from './integration-bundles'
 import {
   CACHE_COMPONENTS_DISABLE_TRANSFORM,
+  CACHE_COMPONENTS_LLMS_TXT_TRANSFORM,
+  codeTransformTargetPaths,
   collectSelfPruneTestFiles,
   declaredBundlePaths,
   findMissingPaths,
@@ -1035,6 +1037,52 @@ describe('declaredBundlePaths / findMissingPaths (H8 preflight)', () => {
 })
 
 // ---------------------------------------------------------------------------
+// issue #389 — preflight also covers codeTransform target files, not just
+// kept-bundle folders/files/overwriteFiles. codeTransforms run against the
+// tree unconditionally (setupLean's strip pass touches every bundle,
+// regardless of what's kept), so a shared file that's absent must fail the
+// preflight even when no bundle declares it in folders/files.
+// ---------------------------------------------------------------------------
+
+describe('codeTransformTargetPaths (issue #389 preflight)', () => {
+  it('collects the target file of every bundle codeTransform plus both Cache Components transforms', () => {
+    const paths = codeTransformTargetPaths()
+
+    // A cross-bundle shared file: not in any bundle's folders/files, so
+    // declaredBundlePaths alone would never notice it going missing.
+    expect(paths).toContain('app/api/revalidate/route.ts')
+    expect(paths).toContain(CACHE_COMPONENTS_DISABLE_TRANSFORM.file)
+    expect(paths).toContain(CACHE_COMPONENTS_LLMS_TXT_TRANSFORM.file)
+  })
+
+  it('is deduplicated', () => {
+    const paths = codeTransformTargetPaths()
+    expect(new Set(paths).size).toBe(paths.length)
+  })
+
+  it('findMissingPaths reports nothing missing against the real repo tree', async () => {
+    // Runs against the actual repo tree (this IS the satus repo), so every
+    // codeTransform's target file must be present.
+    const missing = await findMissingPaths(codeTransformTargetPaths())
+    expect(missing).toEqual([])
+  })
+
+  it('a deleted transform-target file fails the preflight before any mutation', async () => {
+    const paths = codeTransformTargetPaths()
+    const deletedFile = paths[0]
+    if (!deletedFile)
+      throw new Error('expected at least one codeTransform path')
+
+    const missing = await findMissingPaths(
+      paths,
+      async (rel) => rel !== deletedFile
+    )
+
+    expect(missing).toEqual([deletedFile])
+  })
+})
+
+// ---------------------------------------------------------------------------
 // L4 — duplicate CLI flags: first wins, but now with a warning
 // ---------------------------------------------------------------------------
 
@@ -1464,6 +1512,110 @@ describe("P-C3 regression: kept bundle deps survive selfPrune's package.json wri
       await rm(tmpRoot, { recursive: true, force: true })
     }
   }, 60000)
+})
+
+// ---------------------------------------------------------------------------
+// issue #382 — selfPrune must not run when steps 8/10 collected (non-thrown)
+// transform failures. `applyCodeTransforms` never throws on a single file's
+// failure (see its docstring) — it collects into `failures` so the batch can
+// finish — but selfPrune used to run regardless, deleting this script (and
+// its package.json entry) before the caller ever reported those failures,
+// breaking the "just re-run it" recovery the setup() docstring promises.
+//
+// This exercises the REAL script end-to-end (matching the P-C3 pattern
+// above): a throwaway rsync copy of the repo, with one Cache Components
+// target file made unreadable (EACCES) to force a genuine, non-required-
+// match transform failure — a plain fs error caught and collected by
+// `applyCodeTransforms`, not a `RequiredOpMatchError`.
+// ---------------------------------------------------------------------------
+
+describe('issue #382: selfPrune is gated on collected transform failures', () => {
+  // chmod 000 is a no-op permission check for uid 0 (root can read anything
+  // regardless of mode bits) — some CI containers run as root, where this
+  // wouldn't reproduce the failure it's testing for.
+  const isRoot = (process.getuid?.() ?? -1) === 0
+
+  it.skipIf(isRoot)(
+    'a collected (non-thrown) transform failure keeps setup-project.ts and its package.json script entry intact',
+    async () => {
+      const tmpRoot = await mkdtemp(join(tmpdir(), 'satus-collected-failure-'))
+      const targetFile = join(tmpRoot, 'app/llms.txt/route.ts')
+      try {
+        const rsync = Bun.spawnSync([
+          'rsync',
+          '-a',
+          '--exclude',
+          'node_modules',
+          '--exclude',
+          '.next',
+          '--exclude',
+          '.git',
+          `${projectRoot}/`,
+          `${tmpRoot}/`,
+        ])
+        expect(rsync.exitCode).toBe(0)
+
+        let nodeModulesSource: string | undefined
+        for (let dir = projectRoot; dir !== dirname(dir); dir = dirname(dir)) {
+          const candidate = join(dir, 'node_modules')
+          if (await pathExists(candidate)) {
+            nodeModulesSource = candidate
+            break
+          }
+        }
+        if (nodeModulesSource) {
+          await symlink(nodeModulesSource, join(tmpRoot, 'node_modules'))
+        }
+
+        // `--keep ''` (lean/blank) makes `setupCacheComponentsOptOut` run
+        // unconditionally (no CMS/storefront kept). Stripping read
+        // permission from its llms.txt target makes `applyCodeTransforms`
+        // hit a genuine EACCES from `file.text()` — a plain Error, collected
+        // into `failures` regardless of whether the op it never got to
+        // apply was `required`.
+        await chmod(targetFile, 0o000)
+
+        const proc = Bun.spawnSync(
+          [
+            'bun',
+            'run',
+            'lib/scripts/setup-project.ts',
+            '--keep',
+            '',
+            '--yes',
+            '--skip-install',
+          ],
+          { cwd: tmpRoot, stdout: 'pipe', stderr: 'pipe' }
+        )
+
+        // Exit code 3: code-transform failures were collected and reported —
+        // see main()'s exit-code contract.
+        if (proc.exitCode !== 3) {
+          console.error(proc.stdout.toString())
+          console.error(proc.stderr.toString())
+        }
+        expect(proc.exitCode).toBe(3)
+
+        // The whole point of the fix: the setup script and its package.json
+        // entry survive a collected-failure run, so it can simply be re-run.
+        expect(
+          await pathExists(join(tmpRoot, 'lib/scripts/setup-project.ts'))
+        ).toBe(true)
+
+        const pkg = JSON.parse(
+          await Bun.file(join(tmpRoot, 'package.json')).text()
+        ) as { scripts?: Record<string, string> }
+        expect(pkg.scripts?.['setup:project']).not.toBe(
+          SETUP_PROJECT_PRUNED_STUB
+        )
+        expect(pkg.scripts?.['test:setup']).toBeTruthy()
+      } finally {
+        await chmod(targetFile, 0o644).catch(() => undefined)
+        await rm(tmpRoot, { recursive: true, force: true })
+      }
+    },
+    60000
+  )
 })
 
 // ---------------------------------------------------------------------------

--- a/lib/scripts/setup-project.ts
+++ b/lib/scripts/setup-project.ts
@@ -816,6 +816,33 @@ export const CACHE_COMPONENTS_LLMS_TXT_TRANSFORM: CodeTransform = {
 }
 
 /**
+ * Collect the target file of every `codeTransform` across ALL bundles — not
+ * just kept ones. Unlike `declaredBundlePaths` (which only covers the kept
+ * bundles' folders/files/overwriteFiles), `codeTransforms` run against the
+ * tree unconditionally during `setupLean`'s strip pass (see `setup()`'s step
+ * 6: `allCodeTransforms` is built from every bundle regardless of what's
+ * kept), so a bundle NOT being kept doesn't make its codeTransform target
+ * files any less required to exist before that pass runs. Also includes the
+ * two Cache Components opt-out transforms (`setupCacheComponentsOptOut`
+ * likewise runs unconditionally whenever no CMS/storefront is kept — see
+ * `shouldDisableCacheComponents`). Deduplicated. Exported for unit testing.
+ */
+export const codeTransformTargetPaths = (): string[] => {
+  const paths = new Set<string>()
+
+  for (const bundle of Object.values(INTEGRATION_BUNDLES)) {
+    for (const transform of bundle.codeTransforms) {
+      paths.add(transform.file)
+    }
+  }
+
+  paths.add(CACHE_COMPONENTS_DISABLE_TRANSFORM.file)
+  paths.add(CACHE_COMPONENTS_LLMS_TXT_TRANSFORM.file)
+
+  return [...paths]
+}
+
+/**
  * Anchored doc-sentence replacements so a fork's docs don't claim Cache
  * Components is enabled after setup just disabled it. Each `anchor` is
  * matched as an exact substring; when absent (doc since reworded), the file
@@ -1080,10 +1107,11 @@ const selfPrune = async (
 /**
  * Main setup orchestration (additive model):
  *
- *   1. PREFLIGHT — validate every file/folder the kept bundles declare
- *      exists on disk. Exits loudly with zero mutations performed when
- *      anything is missing (H8) — must run before ANY of the mutating
- *      steps below.
+ *   1. PREFLIGHT — validate every file/folder the kept bundles declare,
+ *      PLUS every codeTransform target file across ALL bundles (they run
+ *      unconditionally in step 6 regardless of what's kept), exists on
+ *      disk. Exits loudly with zero mutations performed when anything is
+ *      missing (H8) — must run before ANY of the mutating steps below.
  *   2. ensureNextTypeStub
  *   3. cleanMarketing (if flagged)
  *   4. snapshot(kept) — capture kept integration files before stripping
@@ -1097,16 +1125,28 @@ const selfPrune = async (
  *  10. setupCacheComponentsOptOut — when the final kept set has neither
  *      sanity nor shopify, flip `cacheComponents` off in next.config.ts and
  *      patch the docs that claim it's enabled. No-op otherwise.
- *  11. selfPrune — re-reads package.json from disk (P-C3: step 8's
+ *  11. selfPrune — gated on zero collected failures from steps 8 and 10
+ *      (`addFailures.length + cacheResult.failures.length === 0`). Those
+ *      steps never throw on a single file's failure (see
+ *      `applyCodeTransforms`'s docstring) — they collect into `failures` so
+ *      the batch can finish — but an ungated selfPrune used to run anyway on
+ *      that collected-failure path, deleting this script (and test:setup)
+ *      before the caller ever reported the failures, breaking the "just
+ *      re-run it" recovery the step order below is supposed to guarantee.
+ *      When failures exist, this step is skipped entirely: nothing is
+ *      deleted, pkg.scripts is not touched, and the caller (main()) still
+ *      reports every failure and exits non-zero.
+ *      When it DOES run: re-reads package.json from disk (P-C3: step 8's
  *      `addDependencies` writes dependency pins straight to disk, which the
  *      step-5 `pkg` object never observes; reusing that stale object here
  *      would silently revert those pins), then deletes setup files
  *      (including this script) and mutates the freshly-read pkg.scripts,
  *      THEN a second package.json write to persist the scripts removal.
  *      This is deliberately the LAST mutating step: running it only after
- *      setupAddIntegrations has completed successfully means any failure in
- *      steps 3–8 leaves lib/scripts/setup-project.ts (and its package.json
- *      script entry) intact, so the run can simply be repeated (H8).
+ *      setupAddIntegrations has completed with zero failures means any
+ *      failure in steps 3–10 — thrown OR collected — leaves
+ *      lib/scripts/setup-project.ts (and its package.json script entry)
+ *      intact, so the run can simply be repeated (H8).
  *  12. bun install (unless --skip-install). Non-fatal on failure (M5): a
  *      registry/offline error is reported and surfaced to the caller via
  *      the returned `installFailed` flag, but does not undo or block the
@@ -1132,11 +1172,17 @@ const setup = async (
 }> => {
   const { dryRun, keepIntegrations, cleanMarketing, skipInstall } = options
 
-  // 1. PREFLIGHT: every kept bundle's declared folders/files/overwriteFiles
-  //    must exist before any mutation begins. Zero mutations performed here.
-  const missingPaths = await findMissingPaths(
-    declaredBundlePaths(keepIntegrations)
-  )
+  // 1. PREFLIGHT: every kept bundle's declared folders/files/overwriteFiles,
+  //    PLUS every codeTransform target file across ALL bundles (they run
+  //    unconditionally regardless of what's kept — see
+  //    `codeTransformTargetPaths`'s docstring), must exist before any
+  //    mutation begins. Zero mutations performed here.
+  const missingPaths = await findMissingPaths([
+    ...new Set([
+      ...declaredBundlePaths(keepIntegrations),
+      ...codeTransformTargetPaths(),
+    ]),
+  ])
   if (missingPaths.length > 0) {
     throw new Error(
       `Cannot set up — kept integration(s) reference missing files/folders:\n${missingPaths
@@ -1217,7 +1263,13 @@ const setup = async (
 
   // 11. Self-prune: delete setup files (including this script), mutate
   //     pkg.scripts in-memory, and persist that with a second package.json
-  //     write. Deliberately last — see the docstring above.
+  //     write. Deliberately last — see the docstring above. Gated on zero
+  //     collected failures from steps 8/10: those steps never throw on a
+  //     single file's failure, so an ungated selfPrune would delete this
+  //     script even when the caller is about to report failures and exit
+  //     non-zero — breaking the "just re-run it" recovery the docstring
+  //     promises. When failures exist, skip entirely and leave the setup
+  //     script in place so the run can be repeated after fixing the cause.
   //
   //     Re-read package.json from disk here rather than reusing the `pkg`
   //     object from step 5: `setupAddIntegrations` (step 8) calls
@@ -1229,10 +1281,18 @@ const setup = async (
   //     just made (P-C3: `--keep sanity` reported "N dependencies pinned"
   //     while package.json on disk ended up with none of them, and the
   //     resulting build failed on module-not-found).
-  const prunePkg = (await Bun.file(pkgPath).json()) as PackageJson
-  await selfPrune(prunePkg, dryRun)
-  if (!dryRun) {
-    await Bun.write(pkgPath, `${JSON.stringify(prunePkg, null, 2)}\n`)
+  const collectedFailureCount = addFailures.length + cacheResult.failures.length
+  if (collectedFailureCount === 0) {
+    const prunePkg = (await Bun.file(pkgPath).json()) as PackageJson
+    await selfPrune(prunePkg, dryRun)
+    if (!dryRun) {
+      await Bun.write(pkgPath, `${JSON.stringify(prunePkg, null, 2)}\n`)
+    }
+  } else {
+    p.log.warn(
+      `Skipping self-prune — ${collectedFailureCount} code-transform failure(s) above. ` +
+        'lib/scripts/setup-project.ts was kept so the run can be repeated after fixing the cause.'
+    )
   }
 
   // 12. Run bun install to update the lockfile. Non-fatal: an offline /

--- a/lib/scripts/setup-project.ts
+++ b/lib/scripts/setup-project.ts
@@ -822,12 +822,20 @@ export const CACHE_COMPONENTS_LLMS_TXT_TRANSFORM: CodeTransform = {
  * tree unconditionally during `setupLean`'s strip pass (see `setup()`'s step
  * 6: `allCodeTransforms` is built from every bundle regardless of what's
  * kept), so a bundle NOT being kept doesn't make its codeTransform target
- * files any less required to exist before that pass runs. Also includes the
- * two Cache Components opt-out transforms (`setupCacheComponentsOptOut`
- * likewise runs unconditionally whenever no CMS/storefront is kept — see
- * `shouldDisableCacheComponents`). Deduplicated. Exported for unit testing.
+ * files any less required to exist before that pass runs.
+ *
+ * The two Cache Components opt-out transforms are different: they only run
+ * when the kept set has neither a CMS nor a storefront (see
+ * `setupCacheComponentsOptOut`, which returns early otherwise), so they are
+ * included only when `keepIntegrations` says that pass will actually
+ * happen. Requiring them unconditionally would make the preflight stricter
+ * than the run — a fork that deleted `app/llms.txt/route.ts` while keeping
+ * a CMS would be refused setup over a transform that was never going to
+ * execute. Deduplicated. Exported for unit testing.
  */
-export const codeTransformTargetPaths = (): string[] => {
+export const codeTransformTargetPaths = (
+  keepIntegrations: RemovableId[]
+): string[] => {
   const paths = new Set<string>()
 
   for (const bundle of Object.values(INTEGRATION_BUNDLES)) {
@@ -836,8 +844,10 @@ export const codeTransformTargetPaths = (): string[] => {
     }
   }
 
-  paths.add(CACHE_COMPONENTS_DISABLE_TRANSFORM.file)
-  paths.add(CACHE_COMPONENTS_LLMS_TXT_TRANSFORM.file)
+  if (shouldDisableCacheComponents(keepIntegrations)) {
+    paths.add(CACHE_COMPONENTS_DISABLE_TRANSFORM.file)
+    paths.add(CACHE_COMPONENTS_LLMS_TXT_TRANSFORM.file)
+  }
 
   return [...paths]
 }
@@ -1180,7 +1190,7 @@ const setup = async (
   const missingPaths = await findMissingPaths([
     ...new Set([
       ...declaredBundlePaths(keepIntegrations),
-      ...codeTransformTargetPaths(),
+      ...codeTransformTargetPaths(keepIntegrations),
     ]),
   ])
   if (missingPaths.length > 0) {
@@ -1281,7 +1291,15 @@ const setup = async (
   //     just made (P-C3: `--keep sanity` reported "N dependencies pinned"
   //     while package.json on disk ended up with none of them, and the
   //     resulting build failed on module-not-found).
-  const collectedFailureCount = addFailures.length + cacheResult.failures.length
+  // Every collected-failure source that feeds the returned
+  // `transformFailures` must be counted here, or the gate leaks: step 6's
+  // strip pass collects per-file failures the same way steps 8 and 10 do,
+  // and missing it meant a failed strip still deleted this script while
+  // main() reported the failure and exited non-zero.
+  const collectedFailureCount =
+    leanResult.failures.length +
+    addFailures.length +
+    cacheResult.failures.length
   if (collectedFailureCount === 0) {
     const prunePkg = (await Bun.file(pkgPath).json()) as PackageJson
     await selfPrune(prunePkg, dryRun)


### PR DESCRIPTION
Scaffold-pipeline batch of the 2026-08-05 audit remediation. Closes #381, closes #382, closes #389, closes #390.

## What this does

If `setup:project` hits trouble partway through, the run is now recoverable. Two problems made it not so.

A transform marked as required could be skipped in complete silence when the file it targeted had been renamed or moved. Nothing threw, nothing was logged, and the run reported success having quietly not made the edits it was told it must make. That is the exact drift the required flag exists to catch.

Separately, the script deleted itself even when transforms had failed. The user saw a loud error and a non-zero exit, but `setup:project` and `test:setup` were already gone by then, so the documented advice to fix the cause and re-run had nothing left to run.

## Summary

Review order: `ast-transforms/index.ts` first, then `setup-project.ts`; the other two are cleanup.

1. `ast-transforms/index.ts` — a missing target file with any required op now throws `RequiredOpMatchError`, the same class and propagation path as a required op that matches nothing in a file that does exist. Transforms with no required ops keep the old silent skip.
2. `setup-project.ts` — self-prune is gated on zero collected failures, and the orchestration docstring now describes what the code actually guarantees rather than what it aspired to.
3. `setup-project.ts` — the preflight also validates every codeTransform target across all bundles, not just the kept ones. Those transforms run regardless of what is kept, so this is the guard that makes the first fix unreachable in practice.
4. `bundle-installer.ts` — dropped an unreachable safety branch. It compared each file against an expected-lean state to avoid clobbering local edits, but the only caller has passed `force: true` since `satus add` was removed in #277, so the branch could never run. Its JSDoc described the protection as live.

## Test Plan

- [ ] `bun run check` → exit 0 (478 pass, up from 473; 7 new tests)
- [ ] The self-prune gate test forces a real filesystem failure rather than mocking one, and asserts exit code 3 with `lib/scripts/setup-project.ts` still on disk
- [ ] Preflight test injects a missing transform target and asserts the run aborts before any mutation