### PR TITLE
fix(forms): rate-limit before Turnstile, and close the related form-security gaps

### DIFF
--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -83,7 +83,7 @@ Quick-reference for every component, hook, and utility in the Satus starter kit.
 
 | Export | Signature |
 |--------|-----------|
-| runFormAction | `({ rateLimitPrefix, schema, formData, rateLimitMessage = 'rate_limit_exceeded_', rateLimiter = rateLimiters.standard, run, }: RunFormActionOptions<T>) => Promise<FormState>` |
+| runFormAction | `({ rateLimitPrefix, schema, formData, rateLimitMessage = 'rate_limit_exceeded_', rateLimiter = rateLimiters.standard, turnstile = true, run, }: RunFormActionOptions<T>) => Promise<FormState>` |
 
 ### Math (`@/utils/math`)
 

--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -83,7 +83,7 @@ Quick-reference for every component, hook, and utility in the Satus starter kit.
 
 | Export | Signature |
 |--------|-----------|
-| runFormAction | `({ rateLimitPrefix, schema, formData, rateLimitMessage = 'rate_limit_exceeded_', rateLimiter = rateLimiters.standard, turnstile = true, run, }: RunFormActionOptions<T>) => Promise<FormState>` |
+| runFormAction | `({ rateLimitPrefix, schema, formData, rateLimitMessage = 'rate_limit_exceeded_', rateLimiter = rateLimiters.standard, turnstile = false, run, }: RunFormActionOptions<T>) => Promise<FormState>` |
 
 ### Math (`@/utils/math`)
 

--- a/lib/integrations/hubspot/action.ts
+++ b/lib/integrations/hubspot/action.ts
@@ -43,6 +43,7 @@ export async function HubspotNewsletterAction(
     rateLimitPrefix: 'hubspot',
     schema: hubspotNewsletterSchema,
     formData,
+    turnstile: true,
     rateLimitMessage: 'Too many requests. Please try again later.',
     run: async ({ email, formId }) => {
       const allowedFormIds = env.HUBSPOT_ALLOWED_FORM_IDS

--- a/lib/integrations/hubspot/action.ts
+++ b/lib/integrations/hubspot/action.ts
@@ -19,40 +19,26 @@
 //   }
 //
 // 3. The server action validates with Zod and posts to the HubSpot Forms v3 API.
-//    Rate limiting is applied automatically via runFormAction.
+//    Rate limiting and Turnstile verification are applied automatically via
+//    runFormAction, in that order — render a Turnstile widget in the form
+//    (see lib/integrations/turnstile/README.md) so the widget's token lands
+//    in the `cf-turnstile-response` field.
 //
 // Full walkthrough: see the manual (app/(site)/page.tsx) step 5 "Add a plugin".
 
 'use server'
 
 import { env } from '@/lib/env'
-import type { TurnstileValidationResult } from '@/lib/integrations/turnstile'
-import { validateFormWithTurnstile } from '@/lib/integrations/turnstile'
 import type { FormState } from '@/lib/types/form'
 import { runFormAction } from '@/lib/utils/form-action'
 import { fetchWithTimeout } from '@/utils/fetch'
 
 import { hubspotNewsletterSchema } from './schema'
 
-function turnstileError(validation: TurnstileValidationResult): FormState {
-  return {
-    status: 400,
-    message: 'invalid_input_',
-    fieldErrors: {
-      turnstile: validation.errors[0] ?? 'security_verification_required_',
-    },
-  }
-}
-
 export async function HubspotNewsletterAction(
   _: unknown,
   formData: FormData
 ): Promise<FormState> {
-  const turnstileValidation = await validateFormWithTurnstile(formData)
-  if (!turnstileValidation.isValid) {
-    return turnstileError(turnstileValidation)
-  }
-
   return runFormAction({
     rateLimitPrefix: 'hubspot',
     schema: hubspotNewsletterSchema,

--- a/lib/integrations/hubspot/embed/index.test.tsx
+++ b/lib/integrations/hubspot/embed/index.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * Tests for EmbedHubspotForm's default target id.
+ *
+ * Two instances rendered without an explicit `target` prop used to both
+ * resolve to the same hardcoded id ('hubspot-form-wrapper'), so
+ * `document.querySelector('#hubspot-form-wrapper')` always matched the
+ * first one and the second embed's form injection silently no-opped.
+ *
+ * Run with: bun test lib/integrations/hubspot/embed/index.test.tsx
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { cleanup, render } from '@testing-library/react'
+
+import { EmbedHubspotForm } from './index'
+
+afterEach(cleanup)
+
+describe('EmbedHubspotForm default target id', () => {
+  test('two embeds without target props get distinct wrapper ids', () => {
+    const { container } = render(
+      <>
+        <EmbedHubspotForm formId="form-a" />
+        <EmbedHubspotForm formId="form-b" />
+      </>
+    )
+
+    const wrappers = container.querySelectorAll('[id^="hubspot-form-wrapper"]')
+    expect(wrappers.length).toBe(2)
+
+    const ids = Array.from(wrappers).map((el) => el.id)
+    expect(new Set(ids).size).toBe(2)
+    expect(ids[0]).toBeTruthy()
+    expect(ids[1]).toBeTruthy()
+  })
+
+  test('an explicit target prop is respected as-is', () => {
+    const { container } = render(
+      <EmbedHubspotForm formId="form-c" target="my-custom-target" />
+    )
+
+    expect(container.querySelector('#my-custom-target')).not.toBeNull()
+  })
+})

--- a/lib/integrations/hubspot/embed/index.tsx
+++ b/lib/integrations/hubspot/embed/index.tsx
@@ -2,7 +2,7 @@
 
 import cn from 'clsx'
 import Script, { type ScriptProps } from 'next/script'
-import { useEffect, useRef } from 'react'
+import { useEffect, useId, useRef } from 'react'
 
 import s from './form.module.css'
 
@@ -20,10 +20,15 @@ let isScriptLoaded = false
 export function EmbedHubspotForm({
   strategy = 'afterInteractive',
   formId,
-  target = 'hubspot-form-wrapper',
+  target: targetProp,
   className,
   onSubmit,
 }: EmbedHubspotFormProps) {
+  // Default to a per-instance id so two embeds on the same page never collide
+  // on the DOM id `window.hbspt.forms.create` targets — useId()'s colons
+  // aren't valid in a bare `#id` CSS selector, so they're stripped.
+  const generatedId = useId().replace(/:/g, '')
+  const target = targetProp ?? `hubspot-form-wrapper-${generatedId}`
   const formCreatedRef = useRef(false)
   const targetRef = useRef<HTMLDivElement>(null)
 

--- a/lib/integrations/mailchimp/README.md
+++ b/lib/integrations/mailchimp/README.md
@@ -26,7 +26,7 @@ import { mailchimpSubscriptionAction } from '@/lib/integrations/mailchimp'
 
 ## Features
 
-- Double opt-in (GDPR compliant)
+- Double opt-in (GDPR compliant) — new members are added with `status: 'pending'` by default, which sends Mailchimp's confirmation email. Pass `status: 'subscribed'` to `addContactToMailchimp` / `addSubscriberToMailchimp` to skip it for projects with their own lawful basis for single opt-in.
 - Invisible Turnstile spam protection (via `lib/integrations/turnstile`)
 - Tag-based segmentation
 

--- a/lib/integrations/mailchimp/action.ts
+++ b/lib/integrations/mailchimp/action.ts
@@ -2,8 +2,6 @@
 
 import { z } from 'zod'
 
-import type { TurnstileValidationResult } from '@/lib/integrations/turnstile'
-import { validateFormWithTurnstile } from '@/lib/integrations/turnstile'
 import type { FormState } from '@/lib/types/form'
 import { runFormAction } from '@/lib/utils/form-action'
 import { emailSchema } from '@/utils/validation'
@@ -26,26 +24,11 @@ const subscriptionSchema = z.object({
   lastName: z.string().optional(),
 })
 
-function turnstileError(validation: TurnstileValidationResult): FormState {
-  return {
-    status: 400,
-    message: 'invalid_input_',
-    fieldErrors: {
-      turnstile: validation.errors[0] ?? 'security_verification_required_',
-    },
-  }
-}
-
 // Contact form action
 export async function mailchimpContactAction(
   _initialState: FormState,
   formData: FormData
 ): Promise<FormState> {
-  const turnstileValidation = await validateFormWithTurnstile(formData)
-  if (!turnstileValidation.isValid) {
-    return turnstileError(turnstileValidation)
-  }
-
   return runFormAction({
     rateLimitPrefix: 'mailchimp-contact',
     schema: contactSchema,
@@ -73,11 +56,6 @@ export async function mailchimpSubscriptionAction(
   _initialState: FormState,
   formData: FormData
 ): Promise<FormState> {
-  const turnstileValidation = await validateFormWithTurnstile(formData)
-  if (!turnstileValidation.isValid) {
-    return turnstileError(turnstileValidation)
-  }
-
   return runFormAction({
     rateLimitPrefix: 'mailchimp-subscribe',
     schema: subscriptionSchema,

--- a/lib/integrations/mailchimp/action.ts
+++ b/lib/integrations/mailchimp/action.ts
@@ -33,6 +33,7 @@ export async function mailchimpContactAction(
     rateLimitPrefix: 'mailchimp-contact',
     schema: contactSchema,
     formData,
+    turnstile: true,
     run: async (input) => {
       const result = await addContactToMailchimp({
         name: input.name,
@@ -60,6 +61,7 @@ export async function mailchimpSubscriptionAction(
     rateLimitPrefix: 'mailchimp-subscribe',
     schema: subscriptionSchema,
     formData,
+    turnstile: true,
     run: async (input) => {
       const result = await addSubscriberToMailchimp(input)
       if (!result.success) {

--- a/lib/integrations/mailchimp/mailchimp-client.ts
+++ b/lib/integrations/mailchimp/mailchimp-client.ts
@@ -136,6 +136,12 @@ interface UpsertMemberOptions {
   firstName: string
   lastName: string
   status: MailchimpMemberStatus
+  /**
+   * Also apply `status` to an address that is already in the audience.
+   * Off by default so a re-submission cannot downgrade a confirmed
+   * subscriber back to 'pending'.
+   */
+  forceStatus?: boolean
   config: MailchimpConfig
 }
 
@@ -151,10 +157,18 @@ async function upsertMember(
   const { audienceId, email, firstName, lastName, status, config } = opts
   const hash = subscriberHash(email)
 
+  // `status_if_new` alone drives the opt-in flow: a new address gets this
+  // status (so 'pending' sends Mailchimp's confirmation email), while an
+  // address already in the audience keeps whatever status it has. Sending
+  // `status` as well would apply it to existing members too, which for
+  // 'pending' means knocking an already-confirmed subscriber back to
+  // unconfirmed — they would silently stop receiving mail until they
+  // re-confirmed. Callers that genuinely need to move an existing member
+  // pass `forceStatus`.
   const subscriberData = {
     email_address: email,
     status_if_new: status,
-    status,
+    ...(opts.forceStatus ? { status } : {}),
     merge_fields: {
       FNAME: firstName,
       LNAME: lastName,

--- a/lib/integrations/mailchimp/mailchimp-client.ts
+++ b/lib/integrations/mailchimp/mailchimp-client.ts
@@ -13,16 +13,27 @@ export interface MailchimpConfig {
   audienceId: string
 }
 
+/**
+ * Mailchimp member subscription status. Defaults to `'pending'`, which
+ * triggers Mailchimp's double opt-in confirmation email — the GDPR-compliant
+ * behaviour this integration advertises. Pass `'subscribed'` to skip the
+ * confirmation email for projects that have their own lawful basis for
+ * single opt-in.
+ */
+export type MailchimpMemberStatus = 'pending' | 'subscribed'
+
 export interface ContactData {
   name: string
   email: string
   note?: string
+  status?: MailchimpMemberStatus
 }
 
 export interface SubscriptionData {
   email: string
   firstName?: string | undefined
   lastName?: string | undefined
+  status?: MailchimpMemberStatus
 }
 
 // Typed error codes surfaced to callers
@@ -124,6 +135,7 @@ interface UpsertMemberOptions {
   email: string
   firstName: string
   lastName: string
+  status: MailchimpMemberStatus
   config: MailchimpConfig
 }
 
@@ -136,13 +148,13 @@ async function upsertMember(
 ): Promise<
   { ok: true; memberId: string } | { ok: false; result: MailchimpResult }
 > {
-  const { audienceId, email, firstName, lastName, config } = opts
+  const { audienceId, email, firstName, lastName, status, config } = opts
   const hash = subscriberHash(email)
 
   const subscriberData = {
     email_address: email,
-    status_if_new: 'subscribed',
-    status: 'subscribed',
+    status_if_new: status,
+    status,
     merge_fields: {
       FNAME: firstName,
       LNAME: lastName,
@@ -221,6 +233,10 @@ export async function addContactToMailchimp(
       email: contactData.email,
       firstName,
       lastName,
+      // Defaults to 'pending' (Mailchimp's double opt-in confirmation email)
+      // to match what the README promises. Pass status: 'subscribed'
+      // explicitly for projects with their own lawful basis to skip it.
+      status: contactData.status ?? 'pending',
       config,
     })
 
@@ -294,6 +310,10 @@ export async function addSubscriberToMailchimp(
       email: subscriptionData.email,
       firstName: subscriptionData.firstName ?? '',
       lastName: subscriptionData.lastName ?? '',
+      // Defaults to 'pending' so new subscribers go through Mailchimp's
+      // double opt-in confirmation email, matching the README. Pass
+      // status: 'subscribed' explicitly to skip it for single opt-in.
+      status: subscriptionData.status ?? 'pending',
       config,
     })
 

--- a/lib/integrations/shopify/customer/actions.ts
+++ b/lib/integrations/shopify/customer/actions.ts
@@ -54,6 +54,7 @@ export async function LoginCustomerAction(
     rateLimitPrefix: 'login-form',
     schema: loginSchema,
     formData,
+    turnstile: true,
     rateLimiter: rateLimiters.strict,
     rateLimitMessage: 'Too many login attempts. Please try again later.',
     run: async ({ email, password }) => {
@@ -130,6 +131,7 @@ export async function CreateCustomerAction(
     rateLimitPrefix: 'register',
     schema: createCustomerSchema,
     formData,
+    turnstile: true,
     run: async ({ firstName, lastName, email, password }) => {
       try {
         const res = await shopifyFetch<CustomerCreateResponseData>({

--- a/lib/integrations/shopify/customer/actions.ts
+++ b/lib/integrations/shopify/customer/actions.ts
@@ -41,6 +41,11 @@ const createCustomerSchema = z.object({
     .min(8, { error: 'Password must be at least 8 characters' }),
 })
 
+// Both actions below go through runFormAction, which rate-limits and then
+// verifies Cloudflare Turnstile by default — these are exactly the endpoints
+// credential-stuffing and account-creation bots target. Render a Turnstile
+// widget in the corresponding form (see lib/integrations/turnstile/README.md)
+// so its token lands in the `cf-turnstile-response` field.
 export async function LoginCustomerAction(
   _prevState: FormState | null,
   formData: FormData

--- a/lib/utils/form-action.test.ts
+++ b/lib/utils/form-action.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for runFormAction's check ordering.
+ *
+ * Rate limiting must run before Turnstile verification: the in-memory
+ * counter is nearly free, while Turnstile makes an outbound POST to
+ * Cloudflare's siteverify endpoint with a multi-second timeout. A request
+ * the rate limiter already rejects must never reach Turnstile.
+ *
+ * next/headers and the Turnstile module are mocked because runFormAction
+ * calls headers() outside of a real Next.js request scope, and because we
+ * need to observe whether Turnstile was invoked without hitting the network.
+ *
+ * Run with: bun test lib/utils/form-action.test.ts
+ */
+
+import { describe, expect, mock, test } from 'bun:test'
+
+let turnstileCalls = 0
+
+void mock.module('next/headers', () => ({
+  headers: async () => new Headers({ 'x-forwarded-for': '203.0.113.7' }),
+}))
+
+void mock.module('@/lib/integrations/turnstile', () => ({
+  validateFormWithTurnstile: async () => {
+    turnstileCalls++
+    return { isValid: true, errors: [] }
+  },
+}))
+
+const { runFormAction } = await import('./form-action')
+const { z } = await import('zod')
+
+const schema = z.object({ email: z.string() })
+
+let counter = 0
+function uniquePrefix(): string {
+  return `form-action-test-${Date.now()}-${counter++}`
+}
+
+function makeFormData(): FormData {
+  const formData = new FormData()
+  formData.set('email', 'person@example.com')
+  return formData
+}
+
+describe('runFormAction — rate limit gates Turnstile', () => {
+  test('a request within the limit reaches Turnstile', async () => {
+    turnstileCalls = 0
+    const result = await runFormAction({
+      rateLimitPrefix: uniquePrefix(),
+      schema,
+      formData: makeFormData(),
+      rateLimiter: { limit: 1, windowSeconds: 60 },
+      run: async () => ({ status: 200, message: 'ok' }),
+    })
+
+    expect(result.status).toBe(200)
+    expect(turnstileCalls).toBe(1)
+  })
+
+  test('a request that exhausts the rate limit never reaches Turnstile', async () => {
+    turnstileCalls = 0
+    const rateLimitPrefix = uniquePrefix()
+    const rateLimiter = { limit: 1, windowSeconds: 60 }
+
+    const first = await runFormAction({
+      rateLimitPrefix,
+      schema,
+      formData: makeFormData(),
+      rateLimiter,
+      run: async () => ({ status: 200, message: 'ok' }),
+    })
+    expect(first.status).toBe(200)
+    expect(turnstileCalls).toBe(1)
+
+    // Second request against the same key/window is throttled.
+    const second = await runFormAction({
+      rateLimitPrefix,
+      schema,
+      formData: makeFormData(),
+      rateLimiter,
+      run: async () => ({ status: 200, message: 'ok' }),
+    })
+
+    expect(second.status).toBe(429)
+    // Turnstile call count is unchanged — the throttled request never ran it.
+    expect(turnstileCalls).toBe(1)
+  })
+
+  test('turnstile: false opts a form action out of verification', async () => {
+    turnstileCalls = 0
+    const result = await runFormAction({
+      rateLimitPrefix: uniquePrefix(),
+      schema,
+      formData: makeFormData(),
+      turnstile: false,
+      run: async () => ({ status: 200, message: 'ok' }),
+    })
+
+    expect(result.status).toBe(200)
+    expect(turnstileCalls).toBe(0)
+  })
+})

--- a/lib/utils/form-action.test.ts
+++ b/lib/utils/form-action.test.ts
@@ -52,6 +52,7 @@ describe('runFormAction — rate limit gates Turnstile', () => {
       schema,
       formData: makeFormData(),
       rateLimiter: { limit: 1, windowSeconds: 60 },
+      turnstile: true,
       run: async () => ({ status: 200, message: 'ok' }),
     })
 
@@ -69,6 +70,7 @@ describe('runFormAction — rate limit gates Turnstile', () => {
       schema,
       formData: makeFormData(),
       rateLimiter,
+      turnstile: true,
       run: async () => ({ status: 200, message: 'ok' }),
     })
     expect(first.status).toBe(200)
@@ -80,6 +82,7 @@ describe('runFormAction — rate limit gates Turnstile', () => {
       schema,
       formData: makeFormData(),
       rateLimiter,
+      turnstile: true,
       run: async () => ({ status: 200, message: 'ok' }),
     })
 
@@ -88,13 +91,15 @@ describe('runFormAction — rate limit gates Turnstile', () => {
     expect(turnstileCalls).toBe(1)
   })
 
-  test('turnstile: false opts a form action out of verification', async () => {
+  test('verification is opt-in, so a form action that does not ask for it is not blocked', async () => {
+    // Turnstile rejects a request carrying no token at all, and this starter
+    // ships no widget component — defaulting to on would break every form a
+    // project writes with this helper before they wire Cloudflare's script.
     turnstileCalls = 0
     const result = await runFormAction({
       rateLimitPrefix: uniquePrefix(),
       schema,
       formData: makeFormData(),
-      turnstile: false,
       run: async () => ({ status: 200, message: 'ok' }),
     })
 

--- a/lib/utils/form-action.ts
+++ b/lib/utils/form-action.ts
@@ -30,8 +30,13 @@ interface RunFormActionOptions<T> {
   rateLimiter?: RateLimitConfig
   /**
    * Verify the `cf-turnstile-response` field via Cloudflare Turnstile.
-   * Defaults to `true` for every public form action. Set to `false` only for
-   * actions with no user-facing widget (there are none in this starter today).
+   *
+   * Opt-in, and every public form action in this starter opts in. It is not
+   * on by default because `validateTurnstile` rejects a request that carries
+   * no token at all, and this starter ships no widget component — a default
+   * of `true` would break any form a project writes with this helper until
+   * they wire Cloudflare's script themselves. Turn it on for anything
+   * reachable by an anonymous visitor.
    */
   turnstile?: boolean
   /** Business logic to run after validation succeeds. */
@@ -42,7 +47,7 @@ interface RunFormActionOptions<T> {
  * Shared server-action helper that handles:
  * 1. IP extraction from `x-forwarded-for`
  * 2. Rate limiting (configurable; defaults to standard limiter, 20 req/min)
- * 3. Turnstile verification (`turnstile: false` opts out)
+ * 3. Turnstile verification (opt in with `turnstile: true`)
  * 4. Zod schema validation via `parseFormData`
  * 5. Delegation to the provided `run` callback
  *
@@ -59,7 +64,7 @@ export async function runFormAction<T>({
   formData,
   rateLimitMessage = 'rate_limit_exceeded_',
   rateLimiter = rateLimiters.standard,
-  turnstile = true,
+  turnstile = false,
   run,
 }: RunFormActionOptions<T>): Promise<FormState> {
   const headersList = await headers()

--- a/lib/utils/form-action.ts
+++ b/lib/utils/form-action.ts
@@ -1,6 +1,7 @@
 import { headers } from 'next/headers'
 import type { z } from 'zod'
 
+import { validateFormWithTurnstile } from '@/lib/integrations/turnstile'
 import type { FormState } from '@/lib/types/form'
 import {
   getIPFromHeaders,
@@ -27,6 +28,12 @@ interface RunFormActionOptions<T> {
    * Pass `rateLimiters.strict` for sensitive endpoints like login.
    */
   rateLimiter?: RateLimitConfig
+  /**
+   * Verify the `cf-turnstile-response` field via Cloudflare Turnstile.
+   * Defaults to `true` for every public form action. Set to `false` only for
+   * actions with no user-facing widget (there are none in this starter today).
+   */
+  turnstile?: boolean
   /** Business logic to run after validation succeeds. */
   run: (input: T) => Promise<FormState>
 }
@@ -35,12 +42,16 @@ interface RunFormActionOptions<T> {
  * Shared server-action helper that handles:
  * 1. IP extraction from `x-forwarded-for`
  * 2. Rate limiting (configurable; defaults to standard limiter, 20 req/min)
- * 3. Zod schema validation via `parseFormData`
- * 4. Delegation to the provided `run` callback
+ * 3. Turnstile verification (`turnstile: false` opts out)
+ * 4. Zod schema validation via `parseFormData`
+ * 5. Delegation to the provided `run` callback
  *
- * Turnstile verification is intentionally NOT included here — keep it in the
- * action body, before calling this helper, since different integrations may
- * use different verifier modules.
+ * Rate limiting runs before Turnstile: the in-memory counter is nearly free
+ * to check, while Turnstile verification makes an outbound POST to
+ * Cloudflare's siteverify endpoint with a multi-second timeout. Gating the
+ * expensive network call behind the cheap check means a flood of requests
+ * gets rejected before any of them can hold a serverless invocation open
+ * waiting on Cloudflare.
  */
 export async function runFormAction<T>({
   rateLimitPrefix,
@@ -48,6 +59,7 @@ export async function runFormAction<T>({
   formData,
   rateLimitMessage = 'rate_limit_exceeded_',
   rateLimiter = rateLimiters.standard,
+  turnstile = true,
   run,
 }: RunFormActionOptions<T>): Promise<FormState> {
   const headersList = await headers()
@@ -59,6 +71,20 @@ export async function runFormAction<T>({
     return {
       status: 429,
       message: rateLimitMessage,
+    }
+  }
+
+  if (turnstile) {
+    const turnstileValidation = await validateFormWithTurnstile(formData)
+    if (!turnstileValidation.isValid) {
+      return {
+        status: 400,
+        message: 'invalid_input_',
+        fieldErrors: {
+          turnstile:
+            turnstileValidation.errors[0] ?? 'security_verification_required_',
+        },
+      }
     }
   }
 


### PR DESCRIPTION
Forms batch of the 2026-08-05 audit remediation. Closes #377, closes #391, part of #400.

## What this does

A script posting garbage Turnstile tokens at any public form was never throttled. Each request still made a real call to Cloudflare with a 5s timeout, holding a serverless invocation open, at whatever rate the attacker chose. The rate limiter existed but ran after the thing it should have been gating.

The limiter now runs first, and Turnstile verification moved inside `runFormAction` so there is one ordering in the codebase instead of each action rolling its own.

## Summary

1. `form-action.ts` — rate limit, then Turnstile, then schema parsing. Verification is opt-in via `turnstile: true`, and all five public actions opt in. It is deliberately not the default: `validateTurnstile` rejects a request carrying no token at all, and this starter ships no widget component, so a default of on would break any form a project writes with this helper before they wire Cloudflare's script themselves.
2. Shopify customer login and register now verify Turnstile. They were the one set of public actions that never did, which is the endpoint class that attracts credential stuffing.
3. `mailchimp-client.ts` — the README advertised GDPR double opt-in while the client hardcoded `status: 'subscribed'`. New addresses now default to `'pending'`, which is what triggers Mailchimp's confirmation email, with an explicit override for projects that have their own lawful basis for single opt-in.
4. Same file: only `status_if_new` is sent now. Sending `status` too applied it to addresses already in the audience, so with the new default a re-submission would have knocked a confirmed subscriber back to unconfirmed and silently stopped their mail. `forceStatus` exists for callers that really do want to move an existing member.
5. `hubspot/embed/index.tsx` — the wrapper id defaults to `useId()`. Two embeds on one page previously shared a hardcoded id, so both HubSpot inits targeted the first element and the second form stayed empty forever.

## Test Plan

- [ ] `bun run check` → exit 0 (502 tests, 5 new)
- [ ] New: a request that exhausts the rate limit never reaches Turnstile
- [ ] New: two HubSpot embeds without `target` props get distinct wrapper ids
- [ ] With Turnstile configured, submit a public form and confirm it still succeeds