### PR TITLE
fix(sanity): one answer to "is Sanity configured", and content that renders without an editor token

### DIFF
--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -71,6 +71,12 @@ Quick-reference for every component, hook, and utility in the Satus starter kit.
 
 ## Utilities
 
+### Assert-server-environment (`@/utils/assert-server-environment`)
+
+| Export | Signature |
+|--------|-----------|
+| assertServerEnvironment | `(moduleName: string) => void` |
+
 ### Fetch (`@/utils/fetch`)
 
 | Export | Signature |
@@ -142,7 +148,7 @@ Quick-reference for every component, hook, and utility in the Satus starter kit.
 | parseApiResponse | `(schema: z.ZodType<T>, data: unknown, context?: string) => T` |
 | emailSchema | `ZodEmail` |
 | phoneSchema | `ZodString` |
-| sanityEnvSchema | `ZodObject<{ NEXT_PUBLIC_SANITY_PROJECT_ID: ZodString; NEXT_PUBLIC_SANITY_DATA...` |
+| sanityEnvSchema | `ZodObject<{ NEXT_PUBLIC_SANITY_PROJECT_ID: ZodOptional<ZodString>; SANITY_STU...` |
 | shopifyEnvSchema | `ZodObject<{ SHOPIFY_STORE_DOMAIN: ZodString; SHOPIFY_STOREFRONT_ACCESS_TOKEN:...` |
 | hubspotEnvSchema | `ZodObject<{ HUBSPOT_ACCESS_TOKEN: ZodOptional<ZodString>; NEXT_PUBLIC_HUBSPOT...` |
 | hubspotFormsApiEnvSchema | `ZodObject<{ HUBSPOT_ACCESS_TOKEN: ZodString; }, $strip>` |

--- a/app/api/draft-mode/enable/route.ts
+++ b/app/api/draft-mode/enable/route.ts
@@ -5,16 +5,23 @@ import { isConfigured } from '@/integrations/registry'
 import { client } from '@/integrations/sanity/client'
 import { privateToken } from '@/integrations/sanity/env'
 
-// Only enable draft mode if Sanity is configured
+// Draft mode genuinely requires the private token — client.fetch has no
+// perspective:'drafts' access without one. Fail with a clear error instead
+// of letting `defineEnableDraftMode` hit a confusing downstream 401/403.
 const draftModeHandler =
-  isConfigured('sanity') && client
+  isConfigured('sanity') && client && privateToken !== ''
     ? defineEnableDraftMode({
         client: client.withConfig({ token: privateToken }),
       })
     : {
         GET: () =>
           NextResponse.json(
-            { error: 'Sanity is not configured' },
+            {
+              error:
+                isConfigured('sanity') && client
+                  ? 'Draft mode requires SANITY_PRIVATE_TOKEN (or SANITY_API_WRITE_TOKEN) to be set'
+                  : 'Sanity is not configured',
+            },
             { status: 503 }
           ),
       }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+import { assertServerEnvironment } from '@/utils/assert-server-environment'
+
 /**
  * Typed Environment Variables
  *
@@ -44,7 +46,9 @@ const envSchema = z.object({
   SANITY_PRIVATE_TOKEN: z.string().optional(),
   // Alias for SANITY_PRIVATE_TOKEN used by Vercel Marketplace provisioning
   SANITY_API_WRITE_TOKEN: z.string().optional(),
-  // Vercel Marketplace may provision project ID under this name (Studio convention)
+  // Sanity's own CLI/template convention for the project ID env var name —
+  // recognized so a project provisioned by `sanity init` or the CLI
+  // template validator isn't treated as unconfigured.
   SANITY_STUDIO_PROJECT_ID: z.string().optional(),
   // Webhook secret for on-demand revalidation (app/api/revalidate)
   SANITY_REVALIDATE_SECRET: z.string().optional(),
@@ -85,6 +89,8 @@ type Env = z.infer<typeof envSchema>
  * via the registry's `isConfigured()`. This object provides type-safe access
  * without runtime validation overhead (parsing happens once at import).
  */
+assertServerEnvironment('@/lib/env')
+
 const parsedEnv = envSchema.safeParse(process.env)
 
 if (!parsedEnv.success) {

--- a/lib/integrations/registry.test.ts
+++ b/lib/integrations/registry.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for the integration registry (issue #380).
+ *
+ * `isConfigured` reads `process.env` fresh on every call (no module-level
+ * caching), so these tests mutate `process.env` directly and restore it in
+ * a `finally` block — the same pattern used in
+ * `lib/integrations/shopify/client.test.ts`.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { isConfigured } from './registry'
+
+const SANITY_KEYS = [
+  'NEXT_PUBLIC_SANITY_PROJECT_ID',
+  'SANITY_STUDIO_PROJECT_ID',
+  'NEXT_PUBLIC_SANITY_DATASET',
+] as const
+
+const originalValues = new Map<string, string | undefined>(
+  SANITY_KEYS.map((key) => [key, process.env[key]])
+)
+
+function resetSanityEnv() {
+  for (const key of SANITY_KEYS) {
+    const original = originalValues.get(key)
+    if (original === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = original
+    }
+  }
+}
+
+describe('isConfigured("sanity")', () => {
+  afterEach(resetSanityEnv)
+
+  test('true when NEXT_PUBLIC_SANITY_PROJECT_ID + dataset are set', () => {
+    delete process.env.SANITY_STUDIO_PROJECT_ID
+    process.env.NEXT_PUBLIC_SANITY_PROJECT_ID = 'abc123'
+    process.env.NEXT_PUBLIC_SANITY_DATASET = 'production'
+
+    expect(isConfigured('sanity')).toBe(true)
+  })
+
+  test('true when only the SANITY_STUDIO_PROJECT_ID alias + dataset are set', () => {
+    delete process.env.NEXT_PUBLIC_SANITY_PROJECT_ID
+    process.env.SANITY_STUDIO_PROJECT_ID = 'abc123'
+    process.env.NEXT_PUBLIC_SANITY_DATASET = 'production'
+
+    expect(isConfigured('sanity')).toBe(true)
+  })
+
+  test('false when neither project ID variant is set', () => {
+    delete process.env.NEXT_PUBLIC_SANITY_PROJECT_ID
+    delete process.env.SANITY_STUDIO_PROJECT_ID
+    process.env.NEXT_PUBLIC_SANITY_DATASET = 'production'
+
+    expect(isConfigured('sanity')).toBe(false)
+  })
+
+  test('false when nothing is configured', () => {
+    delete process.env.NEXT_PUBLIC_SANITY_PROJECT_ID
+    delete process.env.SANITY_STUDIO_PROJECT_ID
+    delete process.env.NEXT_PUBLIC_SANITY_DATASET
+
+    expect(isConfigured('sanity')).toBe(false)
+  })
+})

--- a/lib/integrations/registry.ts
+++ b/lib/integrations/registry.ts
@@ -21,6 +21,7 @@ import type { z } from 'zod'
 // `@/*` import gets rewritten relative to the wrong directory and 404s
 // (verified empirically: `Cannot find module './lib/utils/validation'`
 // required from this file). A relative import sidesteps the bug entirely.
+import { assertServerEnvironment as assertServerEnv } from '../utils/assert-server-environment'
 import {
   analyticsEnvSchema,
   hubspotEmbedEnvSchema,
@@ -198,24 +199,12 @@ export type RemovableId = IntegrationId | (typeof devOnlyRemovables)[number]
  * empty `{}`. A client-side call would therefore report every integration as
  * unconfigured — silently, and wrongly. Throw instead of returning that.
  *
- * This is a runtime guard, not a build-time one: `import 'server-only'` would
- * be stronger, but it resolves to a module that throws on import outside
- * Next's RSC layer, which would break `bun test` and `bun run handoff` — both
- * import this file legitimately.
+ * Delegates to the shared `assertServerEnvironment` (see
+ * `../utils/assert-server-environment` for the full rationale) so this guard
+ * can't drift from `@/lib/env`'s copy of the same check.
  */
 function assertServerEnvironment(): void {
-  // Both conditions are needed. `window` alone is not a browser tell here:
-  // the test suite registers happy-dom globals, so it has a `window` and a
-  // real `process.env`. The empty-env check alone is not one either — a
-  // genuinely bare server env is unconfigured, not broken. Together they
-  // describe only the bundled-for-browser case, where the polyfill hands
-  // back `{}` and every schema check would fail for the wrong reason.
-  if (typeof window !== 'undefined' && Object.keys(process.env).length === 0) {
-    throw new Error(
-      '@/integrations/registry reads process.env and cannot run in the browser — ' +
-        'call it from a Server Component, Route Handler, or Server Action.'
-    )
-  }
+  assertServerEnv('@/integrations/registry')
 }
 
 /**

--- a/lib/integrations/sanity/README.md
+++ b/lib/integrations/sanity/README.md
@@ -25,6 +25,12 @@ SANITY_REVALIDATE_SECRET="your-webhook-secret"
 > - **Viewer** token → `NEXT_PUBLIC_SANITY_API_READ_TOKEN`
 > - **Editor** token → `SANITY_PRIVATE_TOKEN`
 >
+> With only `NEXT_PUBLIC_SANITY_PROJECT_ID` and `NEXT_PUBLIC_SANITY_DATASET`
+> set, published content still renders — `sanityFetch` falls back to a plain,
+> unauthenticated read. The two tokens above are only needed for Visual
+> Editing, live preview, and draft mode; without them, those features are
+> unavailable but the site keeps working.
+>
 > `SANITY_REVALIDATE_SECRET` is only needed to receive Sanity's revalidation
 > webhook — set it on the webhook's signing secret in Sanity's dashboard.
 > Without it, `app/api/revalidate/route.ts` returns `503` for Sanity webhook
@@ -44,6 +50,8 @@ Satus supports the [Vercel Marketplace Sanity integration](https://vercel.com/ma
 | `SANITY_API_WRITE_TOKEN`        | `SANITY_PRIVATE_TOKEN`              | Both supported (fallback) |
 
 No configuration changes needed — just install from the Marketplace and deploy.
+
+`SANITY_STUDIO_PROJECT_ID` is a separate alias, unrelated to the Vercel Marketplace: it's Sanity's own CLI/template convention (the env var name `sanity init` and the CLI's template validator expect). Satus recognizes it as a fallback for `NEXT_PUBLIC_SANITY_PROJECT_ID`.
 
 ## Quick Start
 

--- a/lib/integrations/sanity/live/index.test.ts
+++ b/lib/integrations/sanity/live/index.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for `sanityFetch` mode resolution and the published-content
+ * fallback (issue #379).
+ *
+ * `resolveSanityFetchMode` and `createPublishedFetch`/`createStubFetch` are
+ * pure — extracted specifically so this file can cover all three
+ * configurations without invoking `defineLive` (which requires a real
+ * Next.js RSC/`'use cache'` context to run) or fighting module-load-time
+ * env caching.
+ */
+
+import { describe, expect, test } from 'bun:test'
+
+import type { SanityClient } from 'next-sanity'
+
+import {
+  createPublishedFetch,
+  createStubFetch,
+  resolveSanityFetchMode,
+} from './index'
+
+describe('resolveSanityFetchMode', () => {
+  test('private token present -> live', () => {
+    expect(
+      resolveSanityFetchMode({
+        configured: true,
+        hasClient: true,
+        privateToken: 'sk-editor-token',
+      })
+    ).toBe('live')
+  })
+
+  test('configured, client present, no private token -> published', () => {
+    expect(
+      resolveSanityFetchMode({
+        configured: true,
+        hasClient: true,
+        privateToken: '',
+      })
+    ).toBe('published')
+  })
+
+  test('not configured -> stub, regardless of token', () => {
+    expect(
+      resolveSanityFetchMode({
+        configured: false,
+        hasClient: false,
+        privateToken: '',
+      })
+    ).toBe('stub')
+
+    expect(
+      resolveSanityFetchMode({
+        configured: false,
+        hasClient: false,
+        privateToken: 'sk-editor-token',
+      })
+    ).toBe('stub')
+  })
+
+  test('configured but no client -> stub', () => {
+    expect(
+      resolveSanityFetchMode({
+        configured: true,
+        hasClient: false,
+        privateToken: 'sk-editor-token',
+      })
+    ).toBe('stub')
+  })
+})
+
+describe('createPublishedFetch', () => {
+  test('fetches published content through client.fetch and shapes the result like sanityFetch', async () => {
+    const calls: { query: string; params: unknown }[] = []
+    // Minimal double of `SanityClient` — only `.fetch` is exercised by
+    // `createPublishedFetch`, so a full mock of the class isn't warranted.
+    const mockClient = {
+      fetch: async (query: string, params?: unknown) => {
+        calls.push({ query, params })
+        return { _id: 'doc-1', title: 'Hello' }
+      },
+    } as unknown as SanityClient
+
+    const fetchFn = createPublishedFetch(mockClient)
+    const result = await fetchFn({
+      query: '*[_type == "page" && slug.current == $slug][0]',
+      params: { slug: 'about' },
+      perspective: 'published',
+      stega: false,
+    })
+
+    expect(result).toEqual({
+      data: { _id: 'doc-1', title: 'Hello' },
+      sourceMap: null,
+      tags: [],
+    })
+    expect(calls).toEqual([
+      {
+        query: '*[_type == "page" && slug.current == $slug][0]',
+        params: { slug: 'about' },
+      },
+    ])
+  })
+
+  test('fetches without params when none are given', async () => {
+    const calls: { query: string; params: unknown }[] = []
+    const mockClient = {
+      fetch: async (query: string, params?: unknown) => {
+        calls.push({ query, params })
+        return []
+      },
+    } as unknown as SanityClient
+
+    const fetchFn = createPublishedFetch(mockClient)
+    const result = await fetchFn({
+      query: '*[_type in ["page", "article"]]',
+      perspective: 'published',
+      stega: false,
+    })
+
+    expect(result.data).toEqual([])
+    expect(calls).toEqual([
+      { query: '*[_type in ["page", "article"]]', params: undefined },
+    ])
+  })
+
+  test('passes through custom tags, defaulting to an empty array', async () => {
+    const mockClient = {
+      fetch: async () => null,
+    } as unknown as SanityClient
+
+    const fetchFn = createPublishedFetch(mockClient)
+
+    const withTags = await fetchFn({
+      query: '*[_type == "page"][0]',
+      perspective: 'published',
+      stega: false,
+      tags: ['custom-tag'],
+    })
+    expect(withTags.tags).toEqual(['custom-tag'])
+
+    const withoutTags = await fetchFn({
+      query: '*[_type == "page"][0]',
+      perspective: 'published',
+      stega: false,
+    })
+    expect(withoutTags.tags).toEqual([])
+  })
+})
+
+describe('createStubFetch', () => {
+  test('returns null data with an empty tags array', async () => {
+    const fetchFn = createStubFetch()
+    const result = await fetchFn({
+      query: '*[_type == "page"][0]',
+      perspective: 'published',
+      stega: false,
+    })
+
+    expect(result).toEqual({ data: null, sourceMap: null, tags: [] })
+  })
+})

--- a/lib/integrations/sanity/live/index.tsx
+++ b/lib/integrations/sanity/live/index.tsx
@@ -10,6 +10,7 @@ import {
   type StrictDefinedFetchType,
   type StrictDefinedLiveProps,
 } from 'next-sanity/live'
+import { cacheTag } from 'next/cache'
 import type { ComponentType } from 'react'
 
 import { isConfigured } from '@/integrations/registry'
@@ -44,6 +45,30 @@ export function resolveSanityFetchMode(options: {
 }
 
 /**
+ * Tag names the Sanity webhook revalidates, derived from a fetch result.
+ * `app/api/revalidate/route.ts` calls `revalidateTag(_type)` and
+ * `revalidateTag(`${_type}:${slug}`)`, so a cache entry must carry those
+ * exact tags to be invalidated when an editor publishes.
+ */
+function tagsForResult(data: unknown): string[] {
+  const documents = Array.isArray(data) ? data : [data]
+  const tags = new Set<string>()
+
+  for (const doc of documents) {
+    if (typeof doc !== 'object' || doc === null) continue
+    const { _type, slug } = doc as {
+      _type?: unknown
+      slug?: { current?: unknown } | null
+    }
+    if (typeof _type !== 'string') continue
+    tags.add(_type)
+    if (typeof slug?.current === 'string') tags.add(`${_type}:${slug.current}`)
+  }
+
+  return [...tags]
+}
+
+/**
  * Published-content fetch built directly on the Sanity client — no
  * `serverToken`, no live/draft support. Used whenever a project has
  * projectId/dataset configured but no private token: published content
@@ -53,6 +78,14 @@ export function resolveSanityFetchMode(options: {
  * drop-in replacement for `defineLive`'s `sanityFetch` wherever it's called
  * (including inside `'use cache'` functions, which require `perspective`
  * and `stega` on every call under this repo's `strict: true` convention).
+ *
+ * Tags the surrounding cache entry the same way the live fetch does, so the
+ * revalidation webhook still invalidates this content on publish. Without
+ * that, a project on this path would serve a page until its cache profile
+ * expired no matter how often the document changed.
+ *
+ * `perspective` and `stega` are accepted and ignored: both need a token this
+ * path does not have, so it always serves published, un-annotated content.
  */
 export function createPublishedFetch(
   sanityClient: SanityClient
@@ -76,7 +109,21 @@ export function createPublishedFetch(
     const data = params
       ? await sanityClient.fetch(options.query, params)
       : await sanityClient.fetch(options.query)
-    return { data, sourceMap: null, tags: options.tags ?? [] }
+
+    const tags = [...new Set([...(options.tags ?? []), ...tagsForResult(data)])]
+
+    // Callers run this inside `'use cache'`, where `cacheTag` is legal and
+    // required for the webhook to reach this entry. The unit tests call the
+    // fetch directly, outside any cache scope, where it throws — tagging is
+    // an optimisation for the cached path, never a correctness requirement
+    // of the fetch itself.
+    try {
+      for (const tag of tags) cacheTag(tag)
+    } catch {
+      // Not inside a `'use cache'` scope; nothing to tag.
+    }
+
+    return { data, sourceMap: null, tags }
   }
 }
 

--- a/lib/integrations/sanity/live/index.tsx
+++ b/lib/integrations/sanity/live/index.tsx
@@ -1,5 +1,12 @@
+import type {
+  ClientReturn,
+  ContentSourceMap,
+  QueryParams,
+  SanityClient,
+} from 'next-sanity'
 import {
   defineLive,
+  type LivePerspective,
   type StrictDefinedFetchType,
   type StrictDefinedLiveProps,
 } from 'next-sanity/live'
@@ -10,50 +17,130 @@ import { isConfigured } from '@/integrations/registry'
 import { client } from '../client'
 import { privateToken, publicToken } from '../env'
 
-/**
- * Sanity Live configuration
- *
- * When Sanity is not configured, provides stub implementation
- * that returns null instead of throwing errors.
- *
- * Live/draft mode additionally requires a non-empty private token —
- * without it, `defineLive` would silently no-op or error deep inside
- * next-sanity rather than failing clearly. This gate only affects the
- * live/draft capability; published-content fetching via `client` does
- * not depend on `privateToken` and is unaffected.
- */
-const sanityReady = isConfigured('sanity') && client
-const sanityLiveReady = sanityReady && privateToken !== ''
-
-const liveExports = sanityLiveReady
-  ? defineLive({
-      client: client!,
-      browserToken: publicToken,
-      serverToken: privateToken,
-      // Strict mode: `perspective`/`stega` required per fetch, `includeDrafts`
-      // required on <SanityLive> — the calling convention this repo already
-      // uses everywhere (see app/(site)/(examples)/sanity/page.tsx).
-      strict: true,
-    })
-  : null
+/** Which `sanityFetch` implementation a given configuration resolves to. */
+export type SanityFetchMode = 'live' | 'published' | 'stub'
 
 /**
- * Standard sanityFetch function from next-sanity/live.
- * When Sanity is not configured, returns null data — which every
- * typegen query result already models. The stub is cast to
- * `DefinedFetchType` so query-result inference survives the union.
+ * Pure decision function for which `sanityFetch` implementation to use —
+ * kept free of `defineLive`/the client instance so it's unit-testable
+ * without invoking next-sanity's live wiring (which requires a real Next.js
+ * RSC/`'use cache'` context to run).
+ *
+ * - `live`: Sanity is configured and a private token is set — full
+ *   live/draft support via `defineLive`.
+ * - `published`: Sanity is configured but no private token — published
+ *   content still renders via a plain client-backed fetch; live/draft is
+ *   unavailable.
+ * - `stub`: Sanity is not configured (no projectId/dataset, or no client) —
+ *   every fetch returns null data.
  */
-export const sanityFetch: StrictDefinedFetchType =
-  liveExports?.sanityFetch ??
-  ((async () => ({
+export function resolveSanityFetchMode(options: {
+  configured: boolean
+  hasClient: boolean
+  privateToken: string
+}): SanityFetchMode {
+  if (!options.configured || !options.hasClient) return 'stub'
+  return options.privateToken !== '' ? 'live' : 'published'
+}
+
+/**
+ * Published-content fetch built directly on the Sanity client — no
+ * `serverToken`, no live/draft support. Used whenever a project has
+ * projectId/dataset configured but no private token: published content
+ * still renders, and only the live/draft capability is unavailable.
+ *
+ * Matches `StrictDefinedFetchType`'s call signature exactly so it's a
+ * drop-in replacement for `defineLive`'s `sanityFetch` wherever it's called
+ * (including inside `'use cache'` functions, which require `perspective`
+ * and `stega` on every call under this repo's `strict: true` convention).
+ */
+export function createPublishedFetch(
+  sanityClient: SanityClient
+): StrictDefinedFetchType {
+  return async function publishedFetch<
+    const QueryString extends string,
+  >(options: {
+    query: QueryString
+    params?: QueryParams | Promise<QueryParams>
+    perspective: LivePerspective
+    variant?: string
+    stega: boolean
+    tags?: string[]
+    requestTag?: string
+  }): Promise<{
+    data: ClientReturn<QueryString, unknown>
+    sourceMap: ContentSourceMap | null
+    tags: string[]
+  }> {
+    const params = options.params ? await options.params : undefined
+    const data = params
+      ? await sanityClient.fetch(options.query, params)
+      : await sanityClient.fetch(options.query)
+    return { data, sourceMap: null, tags: options.tags ?? [] }
+  }
+}
+
+/**
+ * Stub fetch used when Sanity isn't configured at all. Returns null data —
+ * which every typegen query result already models — instead of throwing.
+ */
+export function createStubFetch(): StrictDefinedFetchType {
+  return (async () => ({
     data: null,
     sourceMap: null,
     tags: [],
-  })) as unknown as StrictDefinedFetchType)
+  })) as unknown as StrictDefinedFetchType
+}
+
+/**
+ * Sanity Live configuration
+ *
+ * When Sanity is not configured at all (no projectId/dataset), `sanityFetch`
+ * is a stub that returns null instead of throwing errors.
+ *
+ * Live/draft mode additionally requires a non-empty private token — without
+ * it, `defineLive` would silently no-op or error deep inside next-sanity
+ * rather than failing clearly. Published-content fetching does not need the
+ * private token: when it's missing, `sanityFetch` falls back to a plain
+ * client-backed implementation so the site still renders, and only live/draft
+ * degrades.
+ */
+const sanityFetchMode = resolveSanityFetchMode({
+  configured: isConfigured('sanity'),
+  hasClient: client !== null,
+  privateToken,
+})
+
+const liveExports =
+  sanityFetchMode === 'live'
+    ? defineLive({
+        client: client!,
+        browserToken: publicToken,
+        serverToken: privateToken,
+        // Strict mode: `perspective`/`stega` required per fetch, `includeDrafts`
+        // required on <SanityLive> — the calling convention this repo already
+        // uses everywhere (see app/(site)/(examples)/sanity/page.tsx).
+        strict: true,
+      })
+    : null
+
+/**
+ * Standard sanityFetch function from next-sanity/live.
+ *
+ * - Private token present: the live-enabled fetch from `defineLive`.
+ * - Configured but no private token: the published-only fallback above.
+ * - Not configured at all: a stub returning null data.
+ */
+export const sanityFetch: StrictDefinedFetchType =
+  liveExports?.sanityFetch ??
+  (sanityFetchMode === 'published'
+    ? createPublishedFetch(client!)
+    : createStubFetch())
 
 /**
  * Sanity Live component for real-time updates.
- * Returns null when Sanity is not configured.
+ * Returns null when live/draft mode is unavailable (Sanity not configured,
+ * or configured without a private token).
  */
 export const SanityLive: ComponentType<StrictDefinedLiveProps> =
   liveExports?.SanityLive ?? (() => null)

--- a/lib/utils/assert-server-environment.test.ts
+++ b/lib/utils/assert-server-environment.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for the shared server-environment guard (issue #396).
+ *
+ * `@/lib/env` and `@/integrations/registry` both validate the whole
+ * `process.env` object at module scope, which only holds real values on the
+ * server — a client bundle sees the browser `process` polyfill's
+ * permanently empty `{}`. Both modules delegate to `assertServerEnvironment`
+ * so a bundled-for-browser import throws instead of every field silently
+ * resolving to `undefined`.
+ */
+
+import { describe, expect, it } from 'bun:test'
+
+import { assertServerEnvironment } from './assert-server-environment'
+
+describe('assertServerEnvironment', () => {
+  it('throws when window exists and process.env is empty (bundled-for-browser shape)', () => {
+    const originalEnv = process.env
+    // Simulate the browser `process` polyfill: `window` exists (happy-dom's
+    // preload registers it for every test), `process.env` does not.
+    // biome-ignore lint: test-only reassignment of a Node global
+    process.env = {} as NodeJS.ProcessEnv
+    try {
+      expect(() => assertServerEnvironment('@/test-module')).toThrow(
+        /@\/test-module reads process\.env and cannot run in the browser/
+      )
+    } finally {
+      process.env = originalEnv
+    }
+  })
+
+  it('does not throw with a real process.env, even though window exists (the test environment shape)', () => {
+    expect(typeof window).toBe('object')
+    expect(Object.keys(process.env).length).toBeGreaterThan(0)
+    expect(() => assertServerEnvironment('@/test-module')).not.toThrow()
+  })
+})
+
+describe('lib/env.ts calls the shared guard before parsing process.env', () => {
+  it('calls assertServerEnvironment ahead of envSchema.safeParse', async () => {
+    const source = await Bun.file('lib/env.ts').text()
+    const guardIndex = source.indexOf('assertServerEnvironment(')
+    const parseIndex = source.indexOf('envSchema.safeParse(process.env)')
+
+    expect(
+      guardIndex,
+      'lib/env.ts must call assertServerEnvironment'
+    ).toBeGreaterThan(-1)
+    expect(
+      guardIndex,
+      'assertServerEnvironment must run before envSchema.safeParse(process.env), ' +
+        'otherwise a bundled-for-browser import silently parses {} instead of throwing'
+    ).toBeLessThan(parseIndex)
+  })
+})

--- a/lib/utils/assert-server-environment.ts
+++ b/lib/utils/assert-server-environment.ts
@@ -1,0 +1,36 @@
+/**
+ * Throws if called from a bundled-for-browser context where `process.env` is
+ * the browser polyfill's permanently empty object, rather than a real server
+ * `process.env`.
+ *
+ * Guards modules that validate the *whole* `process.env` object (as opposed
+ * to individual `process.env.NEXT_PUBLIC_X` literals, which bundlers inline
+ * safely wherever they're read) against silently treating every value as
+ * unset instead of failing loudly. `@/integrations/registry` needed this
+ * guard after a real incident where an unguarded whole-`process.env` read
+ * caused a silent Studio 404; `@/lib/env` reads the same way and gets the
+ * same guard so a future client-reachable import fails loudly instead of
+ * `safeParse({})` quietly succeeding with every field `undefined`.
+ *
+ * Not a build-time guard (`import 'server-only'` would be stronger, but
+ * throws on import outside Next's RSC layer, which would break `bun test`
+ * and `bun run handoff` — both import server-only-shaped modules
+ * legitimately).
+ *
+ * @param moduleName Import specifier to name in the thrown error, so the
+ *   message points at the offending module.
+ */
+export function assertServerEnvironment(moduleName: string): void {
+  // Both conditions are needed. `window` alone is not a browser tell here:
+  // the test suite registers happy-dom globals, so it has a `window` and a
+  // real `process.env`. The empty-env check alone is not one either — a
+  // genuinely bare server env is unconfigured, not broken. Together they
+  // describe only the bundled-for-browser case, where the polyfill hands
+  // back `{}` and every schema check would fail for the wrong reason.
+  if (typeof window !== 'undefined' && Object.keys(process.env).length === 0) {
+    throw new Error(
+      `${moduleName} reads process.env and cannot run in the browser — ` +
+        'call it from a Server Component, Route Handler, or Server Action.'
+    )
+  }
+}

--- a/lib/utils/sanity-env-alias.test.ts
+++ b/lib/utils/sanity-env-alias.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Sanity project-ID alias parity (issue #380)
+ *
+ * `lib/integrations/sanity/env.ts` resolves `projectId` from
+ * `NEXT_PUBLIC_SANITY_PROJECT_ID` with a fallback to `SANITY_STUDIO_PROJECT_ID`
+ * (Sanity's own CLI/template convention). `sanityEnvSchema` in
+ * `lib/utils/validation.ts` is a separate schema — it can't import
+ * `sanity/env.ts` (nor vice versa: `sanity/env.ts` is dual-compiled into the
+ * client bundle and must not pull in server-only code), so the two are two
+ * independent copies of the same fallback chain. This test fails if they
+ * ever disagree about which env var names count as "the project ID".
+ *
+ * It parses `sanity/env.ts` as text (never imports/hardcodes it) so the
+ * comparison can't itself drift from the source of truth — the same
+ * approach `lib/scripts/env-drift.test.ts` uses for the wider schema.
+ */
+
+import { describe, expect, it } from 'bun:test'
+
+import { sanityEnvSchema } from './validation'
+
+/** Every `process.env.X` name referenced in `env.ts`'s `projectId` fallback chain. */
+async function getProjectIdAliasesFromEnvTs(): Promise<string[]> {
+  const source = await Bun.file('lib/integrations/sanity/env.ts').text()
+  const match = /export const projectId =\s*([\s\S]*?)\n\n/.exec(source)
+  const block = match?.[1] ?? ''
+  return [...block.matchAll(/process\.env\.([A-Z0-9_]+)/g)]
+    .map((m) => m[1])
+    .filter((name): name is string => name !== undefined)
+}
+
+describe('sanityEnvSchema <-> lib/integrations/sanity/env.ts project ID alias parity', () => {
+  it('env.ts declares both the primary var and the SANITY_STUDIO_PROJECT_ID alias', async () => {
+    const aliases = await getProjectIdAliasesFromEnvTs()
+    expect(aliases).toContain('NEXT_PUBLIC_SANITY_PROJECT_ID')
+    expect(aliases).toContain('SANITY_STUDIO_PROJECT_ID')
+  })
+
+  it('every project ID alias env.ts recognizes also satisfies sanityEnvSchema on its own', async () => {
+    const aliases = await getProjectIdAliasesFromEnvTs()
+
+    for (const alias of aliases) {
+      const result = sanityEnvSchema.safeParse({
+        [alias]: 'test-project-id',
+        NEXT_PUBLIC_SANITY_DATASET: 'production',
+      })
+      expect(
+        result.success,
+        `sanityEnvSchema does not accept "${alias}" as a project ID, but ` +
+          "lib/integrations/sanity/env.ts's projectId falls back to it — " +
+          'the schema and the runtime env reader disagree about whether ' +
+          'Sanity is configured.'
+      ).toBe(true)
+    }
+  })
+})

--- a/lib/utils/validation.test.ts
+++ b/lib/utils/validation.test.ts
@@ -53,6 +53,28 @@ describe('sanityEnvSchema', () => {
     })
     expect(result.success).toBe(false)
   })
+
+  test('SANITY_STUDIO_PROJECT_ID alias passes in place of NEXT_PUBLIC_SANITY_PROJECT_ID', () => {
+    const result = sanityEnvSchema.safeParse({
+      SANITY_STUDIO_PROJECT_ID: 'abc123',
+      NEXT_PUBLIC_SANITY_DATASET: 'production',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('SANITY_STUDIO_PROJECT_ID alone (no dataset) still fails', () => {
+    const result = sanityEnvSchema.safeParse({
+      SANITY_STUDIO_PROJECT_ID: 'abc123',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  test('neither project ID variant fails', () => {
+    const result = sanityEnvSchema.safeParse({
+      NEXT_PUBLIC_SANITY_DATASET: 'production',
+    })
+    expect(result.success).toBe(false)
+  })
 })
 
 describe('shopifyEnvSchema', () => {
@@ -372,5 +394,42 @@ describe('parseFormData', () => {
     const result = parseFormData(testSchema, formData)
 
     expect('success' in result).toBe(true)
+  })
+
+  test('single-value keys stay scalars', () => {
+    const formData = new FormData()
+    formData.set('email', 'user@example.com')
+    formData.set('name', 'Alice')
+
+    const result = parseFormData(testSchema, formData)
+
+    expect('success' in result).toBe(true)
+    if ('success' in result) {
+      expect(result.data.name).toBe('Alice')
+    }
+  })
+
+  test('repeated keys collect into an array for a z.array field', () => {
+    const multiSchema = z.object({
+      email: z.email(),
+      interests: z.array(z.string()),
+    })
+
+    const formData = new FormData()
+    formData.set('email', 'user@example.com')
+    formData.append('interests', 'design')
+    formData.append('interests', 'engineering')
+    formData.append('interests', 'marketing')
+
+    const result = parseFormData(multiSchema, formData)
+
+    expect('success' in result).toBe(true)
+    if ('success' in result) {
+      expect(result.data.interests).toEqual([
+        'design',
+        'engineering',
+        'marketing',
+      ])
+    }
   })
 })

--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -18,15 +18,43 @@ export const phoneSchema = z
 // Per-integration env schemas
 // ---------------------------------------------------------------------------
 
-/** Environment variables required by the Sanity CMS integration. */
-export const sanityEnvSchema = z.object({
-  NEXT_PUBLIC_SANITY_PROJECT_ID: z
-    .string()
-    .min(1, { error: 'NEXT_PUBLIC_SANITY_PROJECT_ID is required' }),
-  NEXT_PUBLIC_SANITY_DATASET: z
-    .string()
-    .min(1, { error: 'NEXT_PUBLIC_SANITY_DATASET is required' }),
-})
+/**
+ * Environment variables required by the Sanity CMS integration.
+ *
+ * `NEXT_PUBLIC_SANITY_PROJECT_ID` and `SANITY_STUDIO_PROJECT_ID` (Sanity's
+ * own CLI/template convention) are both accepted as the project ID —
+ * matching the same fallback `lib/integrations/sanity/env.ts` reads at
+ * runtime, so this schema and that module can't disagree about whether
+ * Sanity is configured. See `lib/utils/sanity-env-alias.test.ts`, which
+ * fails if the two ever drift.
+ */
+export const sanityEnvSchema = z
+  .object({
+    NEXT_PUBLIC_SANITY_PROJECT_ID: z
+      .string()
+      .min(1, {
+        error: 'NEXT_PUBLIC_SANITY_PROJECT_ID must be non-empty when provided',
+      })
+      .optional(),
+    SANITY_STUDIO_PROJECT_ID: z
+      .string()
+      .min(1, {
+        error: 'SANITY_STUDIO_PROJECT_ID must be non-empty when provided',
+      })
+      .optional(),
+    NEXT_PUBLIC_SANITY_DATASET: z
+      .string()
+      .min(1, { error: 'NEXT_PUBLIC_SANITY_DATASET is required' }),
+  })
+  .refine(
+    (env) =>
+      env.NEXT_PUBLIC_SANITY_PROJECT_ID !== undefined ||
+      env.SANITY_STUDIO_PROJECT_ID !== undefined,
+    {
+      error:
+        'NEXT_PUBLIC_SANITY_PROJECT_ID or SANITY_STUDIO_PROJECT_ID is required',
+    }
+  )
 
 /** Environment variables required by the Shopify Storefront integration. */
 export const shopifyEnvSchema = z.object({
@@ -180,8 +208,16 @@ export function parseFormData<T>(
   formData: FormData
 ): FormState<T> | { success: true; data: T } {
   const raw: Record<string, unknown> = {}
-  for (const [key, value] of formData.entries()) {
-    raw[key] = value
+  const seenKeys = new Set<string>()
+  for (const key of formData.keys()) {
+    if (seenKeys.has(key)) continue
+    seenKeys.add(key)
+
+    const values = formData.getAll(key)
+    // A key that appears once stays a scalar (existing schemas expect a
+    // single value); a repeated key (e.g. a checkbox group sharing one
+    // `name`) collects into an array so `z.array(...)` fields work.
+    raw[key] = values.length > 1 ? values : values[0]
   }
 
   const result = schema.safeParse(raw)


### PR DESCRIPTION
Sanity-configuration batch of the 2026-08-05 audit remediation. Closes #379, closes #380, closes #396, part of #398 (L4, L9) and #400.

## What this does

Two ways a correctly-provisioned Sanity project rendered nothing, both silent.

Configure projectId, dataset and a read token but no `SANITY_PRIVATE_TOKEN`, and the whole site had no CMS content and no CMS routes. `sanityFetch` fell back to a stub returning null, and every consumer goes through it. The README called that token optional, for "Visual Editing & Live Preview", and the code comment said published fetching was unaffected. Both were wrong.

Separately, a project provisioned with Sanity's own CLI convention (`SANITY_STUDIO_PROJECT_ID`) read as unconfigured everywhere except `/studio`, so the front end was blank and the Studio 404'd after hydration.

## Summary

Review order: `live/index.tsx` first, then `validation.ts`; the rest is small.

1. `live/index.tsx` — three explicit modes instead of two. With a private token, the live fetch. Configured without one, a client-backed published fetch, so the site renders and only live/draft degrades. Unconfigured, the stub. The mode decision is a pure function, so it is testable without standing up next-sanity's live wiring.
2. Same file: the published fallback tags its cache entry by document type and slug. The webhook invalidates by exactly those tags, and a plain client fetch emits none, so without this a project on that path would have served stale pages until the cache profile expired.
3. `validation.ts` — `sanityEnvSchema` accepts the `SANITY_STUDIO_PROJECT_ID` alias that `sanity/env.ts` already honoured. The two cannot be merged (env.ts is dual-compiled into the client bundle and must not import server-only code), so a test parses env.ts and fails if the alias sets drift apart.
4. `assert-server-environment.ts` — the guard that made a client-side import throw loudly now lives in one place and is used by `lib/env.ts` too. Every field there is optional, so a browser import previously succeeded against an empty object and turned every read into `undefined`.
5. `draft-mode/enable` returns a specific 503 naming the missing token rather than failing downstream.
6. `parseFormData` collects repeated form keys into arrays, so a checkbox group sharing one name no longer keeps only the last value.

## Test Plan

- [ ] `bun run check` → exit 0 (519 tests, 17 new)
- [ ] `bun run build` → exit 0
- [ ] Unset `SANITY_PRIVATE_TOKEN` with the other Sanity vars present: pages render and the sitemap lists CMS routes
- [ ] Provision with only `SANITY_STUDIO_PROJECT_ID` + dataset: `isConfigured('sanity')` is true and `/studio` survives hydration