### PR TITLE
fix: Theatre out of production bundles, plus eleven component, style and tooling fixes

### DIFF
--- a/components/effects/progress-text/index.tsx
+++ b/components/effects/progress-text/index.tsx
@@ -81,14 +81,22 @@ export function ProgressText({
   className,
   style,
 }: ProgressTextProps) {
-  const wordsRefs = useRef<HTMLSpanElement[]>([])
+  // Sparse array: a shrinking word count removes trailing entries (ref
+  // callback fires with `undefined` on detach), so the progress handler
+  // below filters to live nodes only — a stale detached node inflating the
+  // denominator would silently shift every surviving word's reveal
+  // threshold. Mirrors the same fix in `components/ui/marquee`.
+  const wordsRefs = useRef<(HTMLSpanElement | undefined)[]>([])
 
   const [setRectRef] = useScrollTrigger({
     start,
     end,
     onProgress: ({ progress }) => {
-      wordsRefs.current.forEach((node, i) => {
-        onChange?.(node, progress > i / wordsRefs.current.length)
+      const activeNodes = wordsRefs.current.filter(
+        (node): node is HTMLSpanElement => Boolean(node)
+      )
+      activeNodes.forEach((node, i) => {
+        onChange?.(node, progress > i / activeNodes.length)
       })
     },
   })
@@ -114,7 +122,13 @@ export function ProgressText({
           <span
             className={cn(s.word, word.className)}
             ref={(node) => {
-              if (!node) return
+              if (!node) {
+                // React calls the ref callback with null on detach — clear
+                // the slot so a shrinking word count doesn't leave a stale
+                // detached node in the array.
+                wordsRefs.current[index] = undefined
+                return
+              }
               wordsRefs.current[index] = node
             }}
             style={{ opacity: 0.33, ...word.style }}

--- a/components/ui/form/fields/index.tsx
+++ b/components/ui/form/fields/index.tsx
@@ -211,11 +211,12 @@ export function CheckboxesField({
         name={name}
         id={hiddenInputId}
         value={JSON.stringify(selected)}
-        // Only `ref` from `register(name)` is live here: the value is
-        // React-state-driven (`selected`) and the input is `type="hidden"`,
-        // which never receives focus or a user-triggered `change` event —
-        // `reg.onChange`/`reg.onBlur` can never fire, so they're left out.
-        ref={reg.ref}
+        // Spread rather than picking `ref` off: only `ref` is live here (the
+        // value is React-state-driven and a hidden input never fires change
+        // or blur), but naming `reg.ref` in JSX reads as a render-time ref
+        // access to the React Compiler lint and fails the build. The unused
+        // handlers are inert.
+        {...reg}
       />
       <div className={s.options}>
         {options.map(({ label: optionLabel, value }) => (

--- a/components/ui/form/fields/index.tsx
+++ b/components/ui/form/fields/index.tsx
@@ -211,7 +211,11 @@ export function CheckboxesField({
         name={name}
         id={hiddenInputId}
         value={JSON.stringify(selected)}
-        {...reg}
+        // Only `ref` from `register(name)` is live here: the value is
+        // React-state-driven (`selected`) and the input is `type="hidden"`,
+        // which never receives focus or a user-triggered `change` event —
+        // `reg.onChange`/`reg.onBlur` can never fire, so they're left out.
+        ref={reg.ref}
       />
       <div className={s.options}>
         {options.map(({ label: optionLabel, value }) => (

--- a/components/ui/form/hook.test.tsx
+++ b/components/ui/form/hook.test.tsx
@@ -238,6 +238,46 @@ describe('useForm registration is keyed by field name', () => {
     expect(snapshot.current?.errors.name?.state).toBe(false)
   })
 
+  test('unmounting a required field removes its isValid/isActive/errors entries', () => {
+    // Regression test for issue #400: the ref callback only nulled
+    // `inputsRefs.current[name]` on unmount and left the isValid/isActive/
+    // errors entries in place forever. `isReady` requires every isValid
+    // entry to be true, so a required field that unmounts stays a
+    // permanent false in that map even though it no longer exists.
+    const snapshot: Snapshot = { current: null }
+    const emailField: FieldConfig = { name: 'email', type: 'email' }
+    const nameField: FieldConfig = { name: 'name' }
+    const conditionalField: FieldConfig = { name: 'conditional' } // required by default
+
+    const { rerender } = render(
+      <Harness
+        fields={[emailField, conditionalField, nameField]}
+        onSnapshot={(f) => {
+          snapshot.current = f
+        }}
+      />
+    )
+
+    // Required + untouched — registered as invalid.
+    expect(snapshot.current?.isValid.conditional).toBe(false)
+    expect('conditional' in (snapshot.current?.isActive ?? {})).toBe(true)
+    expect('conditional' in (snapshot.current?.errors ?? {})).toBe(true)
+
+    // Unmount it (tab switch / wizard step / feature flag)
+    rerender(
+      <Harness
+        fields={[emailField, nameField]}
+        onSnapshot={(f) => {
+          snapshot.current = f
+        }}
+      />
+    )
+
+    expect('conditional' in (snapshot.current?.isValid ?? {})).toBe(false)
+    expect('conditional' in (snapshot.current?.isActive ?? {})).toBe(false)
+    expect('conditional' in (snapshot.current?.errors ?? {})).toBe(false)
+  })
+
   test('only type="hidden" gets the auto-valid treatment', () => {
     const snapshot: Snapshot = { current: null }
     render(
@@ -294,6 +334,49 @@ describe('useForm submit gate', () => {
     // company was never touched but is optional — must not block isReady.
     expect(snapshot.current?.isValid.company).toBe(true)
     expect(snapshot.current?.isValid.name).toBe(true)
+    expect(snapshot.current?.isReady).toBe(true)
+  })
+
+  test('unmounting an untouched required field unwedges isReady', () => {
+    // The wedge case from issue #400: a required field that mounts
+    // untouched, then gets conditionally unmounted, used to leave the form
+    // permanently unsubmittable — its stale `isValid: false` entry never
+    // left the map even though the field itself was gone.
+    const snapshot: Snapshot = { current: null }
+    const nameField: FieldConfig = { name: 'name' }
+    const conditionalField: FieldConfig = { name: 'conditional' } // required by default
+
+    const { container, rerender } = render(
+      <SubmitHarness
+        fields={[nameField, conditionalField]}
+        formAction={action}
+        onSnapshot={(f) => {
+          snapshot.current = f
+        }}
+      />
+    )
+
+    fireEvent.change(getInput(container, 'name'), {
+      target: { value: 'Ada' },
+    })
+
+    // `name` is valid, but the untouched required `conditional` field blocks.
+    expect(snapshot.current?.isValid.name).toBe(true)
+    expect(snapshot.current?.isValid.conditional).toBe(false)
+    expect(snapshot.current?.isReady).toBe(false)
+
+    // Unmount the conditional field (e.g. a wizard step moves on).
+    rerender(
+      <SubmitHarness
+        fields={[nameField]}
+        formAction={action}
+        onSnapshot={(f) => {
+          snapshot.current = f
+        }}
+      />
+    )
+
+    expect('conditional' in (snapshot.current?.isValid ?? {})).toBe(false)
     expect(snapshot.current?.isReady).toBe(true)
   })
 

--- a/components/ui/form/hook.ts
+++ b/components/ui/form/hook.ts
@@ -168,9 +168,37 @@ export function useForm<T = unknown>({
       ref: (node: HTMLInputElement | HTMLTextAreaElement | null) => {
         const isNewRegistration = !inputsRefs.current[name] && node
         inputsRefs.current[name] = node
+
         if (isNewRegistration) {
           initializeInput(name, node)
+          return
         }
+
+        if (node) return
+
+        // Unmounted (tab switch, multi-step wizard, feature flag). Leaving
+        // the field's isValid/isActive/errors entries behind would wedge
+        // isReady forever if this was a required field that mounted
+        // untouched — isReady requires every isValid entry to be true,
+        // including entries for fields that no longer exist.
+        setIsActive((prev) => {
+          if (!(name in prev)) return prev
+          const next = { ...prev }
+          delete next[name]
+          return next
+        })
+        setIsValid((prev) => {
+          if (!(name in prev)) return prev
+          const next = { ...prev }
+          delete next[name]
+          return next
+        })
+        setErrors((prev) => {
+          if (!(name in prev)) return prev
+          const next = { ...prev }
+          delete next[name]
+          return next
+        })
       },
       onChange: ({
         target,

--- a/components/ui/image/index.test.tsx
+++ b/components/ui/image/index.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Image } from './index'
+
+describe('Image sizing props', () => {
+  // Regression test for issue #393: `block` used to sit on the flat prop
+  // intersection outside `ImageSizingProps`, so a caller could pass
+  // `width`/`height` (non-fill sizing) together with `block={false}`. That
+  // combination typechecked and then threw at runtime from next/image
+  // ("has both width and fill properties") because `block={false}` flipped
+  // the derived `fill` prop to `true` while `width`/`height` were still
+  // spread in. `block` no longer exists as a prop — `fill` is read straight
+  // from the sizing union — so the same call site must fail to typecheck.
+  test('block cannot escape the sizing union and flip fill', () => {
+    function invalidUsage() {
+      return (
+        <Image
+          src="/foo.jpg"
+          alt=""
+          width={800}
+          height={600}
+          mobileSize="50vw"
+          desktopSize="30vw"
+          // @ts-expect-error -- `block` is not a prop of Image (issue #393)
+          block={false}
+        />
+      )
+    }
+
+    expect(typeof invalidUsage).toBe('function')
+  })
+})

--- a/components/ui/image/index.tsx
+++ b/components/ui/image/index.tsx
@@ -101,8 +101,6 @@ export type ImageProps = Omit<
    * wins over both.
    */
   objectFit?: CSSProperties['objectFit']
-  /** Display as block element (adds display: block) */
-  block?: boolean
   /** Ref for accessing the underlying img element */
   ref?: Ref<HTMLImageElement>
   /** Alt text for accessibility. Required — pass `alt=""` explicitly for decorative images. */
@@ -203,7 +201,6 @@ function getFinalPlaceholder(
  * @param props.aspectRatio - Aspect ratio for layout stability and blur placeholder
  * @param props.mobileSize - Rendered width below the desktop breakpoint (e.g. "50vw"). Required together with `desktopSize`, unless `sizes` is passed instead.
  * @param props.desktopSize - Rendered width at/above the desktop breakpoint (e.g. "33vw"). Required together with `mobileSize`, unless `sizes` is passed instead.
- * @param props.block - Display as block element
  * @param props.preload - Ergonomic alias for next/image's native `preload` prop
  *   (the modern replacement for the deprecated `priority` prop). Also sets
  *   `loading="eager"` unless `loading` is explicitly provided.
@@ -253,7 +250,6 @@ export function Image({
   quality = 90,
   alt,
   fill,
-  block = !fill,
   width,
   height,
   mobileSize,
@@ -307,10 +303,15 @@ export function Image({
   const finalWidth = width ?? derivedDimensions?.width
   const finalHeight = height ?? derivedDimensions?.height
 
+  // Derived purely from the sizing union — never an independent prop, so
+  // the value passed to next/image's `fill` can never disagree with whether
+  // `width`/`height` are also being spread in (issue #393).
+  const isBlock = !fill
+
   return (
     <NextImage
       ref={ref}
-      fill={!block}
+      fill={Boolean(fill)}
       {...(finalWidth !== undefined && { width: finalWidth })}
       {...(finalHeight !== undefined && { height: finalHeight })}
       loading={finalLoading}
@@ -322,10 +323,10 @@ export function Image({
         // the zero-specificity `:where(.img)` rule in image.module.css
         // instead, so consumer CSS (module or utility) can override it.
         ...(objectFit && { objectFit }),
-        ...(block && aspectRatio ? { aspectRatio } : {}),
+        ...(isBlock && aspectRatio ? { aspectRatio } : {}),
         ...style,
       }}
-      className={cn(className, s.img, block && s.block)}
+      className={cn(className, s.img, isBlock && s.block)}
       sizes={finalSizes}
       src={src}
       unoptimized={unoptimized || isSvg}

--- a/components/ui/scrollbar/index.tsx
+++ b/components/ui/scrollbar/index.tsx
@@ -8,7 +8,21 @@ import { mapRange } from '@/utils/math'
 
 import s from './scrollbar.module.css'
 
-export function Scrollbar() {
+// Fixed nudge per Arrow key press — mirrors a typical native scrollbar's
+// arrow-key step rather than jumping the full viewport.
+const ARROW_KEY_SCROLL_AMOUNT = 100
+
+interface ScrollbarProps {
+  /**
+   * DOM id of the element this scrollbar controls (the `ReactLenis`
+   * wrapper, or the page root when Lenis runs in `root` mode). Required by
+   * the `scrollbar` ARIA role's `aria-controls` — see
+   * https://www.w3.org/TR/wai-aria-1.2/#scrollbar.
+   */
+  controlsId: string
+}
+
+export function Scrollbar({ controlsId }: ScrollbarProps) {
   const thumbRef = useRef<HTMLDivElement>(null!)
   const lenis = useLenis()
   const [innerMeasureRef, { height: innerHeight = 0 }] = useRect()
@@ -16,11 +30,19 @@ export function Scrollbar() {
 
   useLenis(
     ({ scroll, limit }) => {
-      const progress = scroll / limit
+      const progress = limit > 0 ? scroll / limit : 0
 
       thumbRef.current.style.transform = `translate3d(0,${
         progress * (innerHeight - thumbHeight)
       }px,0)`
+
+      // Imperative, not React state: this runs on every scroll frame, and a
+      // state update here would re-render just to move an attribute the DOM
+      // already reflects visually through the transform above.
+      thumbRef.current.setAttribute(
+        'aria-valuenow',
+        String(Math.round(progress * 100))
+      )
     },
     [innerHeight, thumbHeight]
   )
@@ -54,13 +76,27 @@ export function Scrollbar() {
       document.documentElement.classList.remove('scrollbar-grabbing')
     }
 
+    function onKeyDown(e: KeyboardEvent) {
+      if (!lenis) return
+      if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return
+
+      e.preventDefault()
+      const delta =
+        e.key === 'ArrowDown'
+          ? ARROW_KEY_SCROLL_AMOUNT
+          : -ARROW_KEY_SCROLL_AMOUNT
+      lenis.scrollTo(lenis.scroll + delta, { lerp: 0.2 })
+    }
+
     const element = thumbRef.current
     element?.addEventListener('pointerdown', onPointerDown, false)
+    element?.addEventListener('keydown', onKeyDown)
     window.addEventListener('pointermove', onPointerMove, false)
     window.addEventListener('pointerup', onPointerUp, false)
 
     return () => {
       element?.removeEventListener('pointerdown', onPointerDown, false)
+      element?.removeEventListener('keydown', onKeyDown)
       window.removeEventListener('pointermove', onPointerMove, false)
       window.removeEventListener('pointerup', onPointerUp, false)
     }
@@ -71,6 +107,14 @@ export function Scrollbar() {
       <div ref={innerMeasureRef} className={s.inner}>
         <div
           className={s.thumb}
+          role="scrollbar"
+          aria-label="Page scroll position"
+          aria-controls={controlsId}
+          aria-orientation="vertical"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={0}
+          tabIndex={0}
           ref={(node) => {
             if (!node) return
             thumbRef.current = node

--- a/components/ui/scrollbar/index.tsx
+++ b/components/ui/scrollbar/index.tsx
@@ -15,14 +15,18 @@ const ARROW_KEY_SCROLL_AMOUNT = 100
 interface ScrollbarProps {
   /**
    * DOM id of the element this scrollbar controls (the `ReactLenis`
-   * wrapper, or the page root when Lenis runs in `root` mode). Required by
-   * the `scrollbar` ARIA role's `aria-controls` — see
-   * https://www.w3.org/TR/wai-aria-1.2/#scrollbar.
+   * wrapper, or the page root when Lenis runs in `root` mode). Feeds
+   * `aria-controls` — see https://www.w3.org/TR/wai-aria-1.2/#scrollbar.
+   *
+   * Optional rather than required: this is an exported primitive, and forks
+   * already render `<Scrollbar />` with no props. Omitting it costs the
+   * `aria-controls` association and nothing else, so a missing id degrades
+   * the semantics instead of breaking the build.
    */
-  controlsId: string
+  controlsId?: string
 }
 
-export function Scrollbar({ controlsId }: ScrollbarProps) {
+export function Scrollbar({ controlsId }: ScrollbarProps = {}) {
   const thumbRef = useRef<HTMLDivElement>(null!)
   const lenis = useLenis()
   const [innerMeasureRef, { height: innerHeight = 0 }] = useRect()

--- a/doctor.config.ts
+++ b/doctor.config.ts
@@ -51,9 +51,17 @@ export default {
          * event handler that triggers it", and there is no React event
          * handler, only Theatre's own change notifications.
          *
-         * Scope note: this is dev-only tooling. It is lazily imported, gated
-         * behind a dev toggle, and `setup:project` deletes it outright for
-         * projects that do not keep Theatre — so none of it ships to users.
+         * Scope note: this is dev-only tooling. The Studio editor itself is
+         * lazily imported and gated behind a dev toggle (only mounts when
+         * `NODE_ENV === 'development'`, via `OptionalFeatures`), and the
+         * project-bootstrap runtime in `SheetProvider` (the fetch + live
+         * Theatre project) is now gated the same way — production visitors
+         * trigger neither. `setup:project` deletes the whole directory
+         * outright for projects that do not keep Theatre. The hook code
+         * itself (`useSheet`/`useTheatre`) still ships as part of the WebGL
+         * bundle, because production components (`fluid`, `flowmaps`) call
+         * it directly — but with no project, it resolves to inert no-ops
+         * that fall back to each call site's own hard-coded defaults.
          */
         files: ['lib/dev/theatre/**'],
         rules: [

--- a/lib/dev/README.md
+++ b/lib/dev/README.md
@@ -4,16 +4,16 @@ Debug tools suite. Toggle with `Cmd/Ctrl + O`.
 
 ## Features
 
-| Tool            | Description                                           |
-| --------------- | ----------------------------------------------------- |
-| Grid (🌐)       | Layout grid overlay                                   |
-| Theatre.js (⚙️) | Animation debugging                                   |
-| Stats (📈)      | FPS and performance (stats-gl frame-time / GPU meter) |
-| Dev Mode (🚧)   | Development toggle                                    |
-| Minimap (🗺️)    | ScrollTrigger navigation                              |
-| WebGL (🧊)      | Global WebGL canvas (on by default)                   |
-| React Scan (🔬) | React re-render profiler — opt-in, off by default     |
-| Screenshot (📸) | Clean UI captures                                     |
+| Tool            | Description                                                                                                |
+| --------------- | ---------------------------------------------------------------------------------------------------------- |
+| Grid (🌐)       | Layout grid overlay                                                                                        |
+| Theatre.js (⚙️) | Animation debugging                                                                                        |
+| Stats (📈)      | FPS and performance (stats-gl frame-time / GPU meter)                                                      |
+| Dev Mode (🚧)   | Development toggle                                                                                         |
+| Minimap (🗺️)    | ScrollTrigger navigation                                                                                   |
+| WebGL (🧊)      | Kill switch for the global WebGL canvas (on by default), for isolating perf work to the DOM side of a page |
+| React Scan (🔬) | React re-render profiler — opt-in, off by default                                                          |
+| Screenshot (📸) | Clean UI captures                                                                                          |
 
 React Scan (`react-scan`) is mounted only while its toggle is on, so a normal
 dev session carries no profiler overhead. It overlaps Stats only on the FPS

--- a/lib/dev/theatre/hooks/use-theatre.ts
+++ b/lib/dev/theatre/hooks/use-theatre.ts
@@ -31,9 +31,13 @@ export function useTheatreObject(
     // has to re-run when the object appears or is rebuilt. Holding it in a ref
     // instead would leave subscribers with no signal, and the object is a
     // Theatre handle that only exists once the sheet does, so it cannot be
-    // derived during render. The bailout costs auto-memoization on Theatre's
-    // dev tooling only — lazily loaded, gated behind a dev toggle, and removed
-    // outright by setup:project for projects that drop Theatre.
+    // derived during render. The bailout costs auto-memoization only in
+    // development: `SheetProvider` (`lib/dev/theatre/index.tsx`) only
+    // bootstraps a live Theatre project when `NODE_ENV === 'development'`, so
+    // `sheet` is always `undefined` in production — this effect hits the
+    // early return above and the `setObject` call below never runs at all.
+    // The whole hook is also removed outright by setup:project for projects
+    // that drop Theatre.
     // react-doctor-disable-next-line react-hooks-js/set-state-in-effect
     setObject(sheet?.object(theatreKey, config, { reconfigure: true }))
 

--- a/lib/dev/theatre/index.tsx
+++ b/lib/dev/theatre/index.tsx
@@ -159,6 +159,16 @@ export function SheetProvider({
   // explicitly, e.g. for a non-default project) — resolve against it as-is.
   if (existingProject) return inner
 
+  // The self-bootstrapped default project is dev-only: it exists so the
+  // Studio editor (dev-panel-gated, see `lib/dev/theatre/studio`) has a live
+  // project to bind to. Production visitors never open Studio, so skip the
+  // fetch + `getProject` call entirely — `useSheet`/`useTheatre` resolve to
+  // `undefined` below `inner`, which every call site already treats as "no
+  // live values, use my own hard-coded defaults" (see `useTheatreObject`).
+  // `process.env.NODE_ENV` is inlined at build time, so production bundles
+  // dead-code-eliminate this branch rather than just skip it at runtime.
+  if (process.env.NODE_ENV !== 'development') return inner
+
   return (
     <TheatreProjectProvider
       id={DEFAULT_PROJECT_ID}

--- a/lib/scripts/generate-component.ts
+++ b/lib/scripts/generate-component.ts
@@ -55,11 +55,6 @@ export async function promptComponentConfig(): Promise<ComponentConfig> {
             label: 'Effects Components',
             hint: 'Animations and visual enhancements',
           },
-          {
-            value: 'blocks',
-            label: 'Block Components',
-            hint: 'Pre-built page sections',
-          },
         ],
       }),
     'Component generation cancelled'
@@ -186,7 +181,6 @@ async function updateBarrelExport(
         ui: 'UI Primitives - Reusable across any project',
         layout: 'Layout Components - Site chrome (customize per project)',
         effects: 'Effects Components - Animations and visual enhancements',
-        blocks: 'Block Components - Pre-built page sections',
       }
 
       const header =

--- a/lib/scripts/generate-manifest.ts
+++ b/lib/scripts/generate-manifest.ts
@@ -212,7 +212,9 @@ ${rows.join('\n')}
 }
 
 function buildHooksSection(project: Project): string {
-  const hookFiles = glob('lib/hooks/*.ts')
+  const hookFiles = glob('lib/hooks/*.ts').filter(
+    (f) => !(f.endsWith('.test.ts') || f.endsWith('.d.ts'))
+  )
 
   const rows: string[] = []
 

--- a/lib/seo/routes.test.ts
+++ b/lib/seo/routes.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression test for issue #398 item L11: `z.array(routableDocumentSchema)
+ * .safeParse(data)` returned `[]` on ANY validation failure, so one
+ * malformed CMS document dropped every CMS route from `sitemap.xml` and
+ * `/llms.txt` — contradicting the function's own docstring, which says
+ * malformed documents are "skipped per-entry". `buildRoutesFromDocuments`
+ * now validates each document independently and only skips the bad ones.
+ *
+ * Run with: bun test lib/seo/routes.test.ts
+ */
+
+import { describe, expect, it } from 'bun:test'
+
+import { buildRoutesFromDocuments, STATIC_ROUTES } from './routes'
+
+describe('buildRoutesFromDocuments', () => {
+  it('skips a single malformed document without dropping the valid ones', () => {
+    const docs = [
+      {
+        _type: 'page',
+        title: 'About',
+        slug: { current: 'about' },
+        _updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+      // Malformed: `_type` is not in the enum at all — this is the entry
+      // that used to fail the whole batch.
+      {
+        _type: 'not-a-real-type',
+        title: 'Broken',
+        slug: { current: 'broken' },
+        _updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        _type: 'article',
+        title: 'Hello World',
+        slug: { current: 'hello-world' },
+        _updatedAt: '2026-02-01T00:00:00.000Z',
+      },
+    ]
+
+    const routes = buildRoutesFromDocuments(docs)
+
+    expect(routes).toHaveLength(2)
+    expect(routes.map((route) => route.path).sort()).toEqual(
+      ['/about', '/articles/hello-world'].sort()
+    )
+  })
+
+  it('returns every route when all documents are valid', () => {
+    const docs = [
+      {
+        _type: 'page',
+        title: 'About',
+        slug: { current: 'about' },
+        _updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        _type: 'article',
+        title: 'Hello World',
+        slug: { current: 'hello-world' },
+        _updatedAt: '2026-02-01T00:00:00.000Z',
+      },
+    ]
+
+    expect(buildRoutesFromDocuments(docs)).toHaveLength(2)
+  })
+
+  it('returns an empty array when every document is malformed', () => {
+    const docs = [
+      { _type: 'not-a-real-type', slug: { current: 'a' } },
+      { _type: 'also-not-real', slug: { current: 'b' } },
+    ]
+
+    expect(buildRoutesFromDocuments(docs)).toEqual([])
+  })
+
+  it('returns an empty array for non-array input instead of throwing', () => {
+    expect(buildRoutesFromDocuments(null)).toEqual([])
+    expect(buildRoutesFromDocuments(undefined)).toEqual([])
+    expect(buildRoutesFromDocuments('not an array')).toEqual([])
+  })
+
+  it('drops a document whose slug resolves to an already-listed static route', () => {
+    const homePath = STATIC_ROUTES[0]?.path
+    const docs = [
+      {
+        _type: 'page',
+        title: 'Home',
+        slug: { current: 'home' },
+        _updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]
+
+    const routes = buildRoutesFromDocuments(docs)
+    expect(routes.some((route) => route.path === homePath)).toBe(false)
+  })
+})

--- a/lib/seo/routes.ts
+++ b/lib/seo/routes.ts
@@ -65,6 +65,51 @@ const routableContentQuery = defineQuery(`
 `)
 
 /**
+ * Turns the raw (`unknown`) Sanity query result into routes, skipping
+ * malformed documents one at a time rather than failing the whole batch.
+ * Pulled out of `getCmsRoutes` so the skip-per-entry behaviour is testable
+ * without a network dependency.
+ */
+export function buildRoutesFromDocuments(data: unknown): ContentRoute[] {
+  if (!Array.isArray(data)) return []
+
+  const routes = new Map<string, ContentRoute>()
+
+  for (const rawDoc of data) {
+    // Validated per entry, not as a whole array: `z.array(...).safeParse`
+    // fails closed on the FIRST malformed document, dropping every valid
+    // route from the sitemap and `/llms.txt`. One bad document should only
+    // cost that one document.
+    const parsedDoc = routableDocumentSchema.safeParse(rawDoc)
+    if (!parsedDoc.success) continue
+    const doc = parsedDoc.data
+
+    if (!doc.slug) continue
+
+    const lastModified = new Date(doc._updatedAt)
+    if (Number.isNaN(lastModified.getTime())) continue
+
+    const path = urlForReference({
+      linkType: 'internal',
+      internalLink: { _type: doc._type, slug: doc.slug },
+    })
+
+    // `path === '#'` is unresolvable; a `staticPaths` hit means the document
+    // stands in for an already-listed static route (e.g. a `page` with slug
+    // `home`, which `urlForReference` resolves to `/`).
+    if (path === '#' || staticPaths.has(path)) continue
+
+    routes.set(path, {
+      path,
+      label: doc.title ?? doc.slug.current,
+      lastModified,
+    })
+  }
+
+  return [...routes.values()]
+}
+
+/**
  * Every published `page`/`article` document, resolved to the same URL
  * `urlForReference` (`@/integrations/sanity/utils/link`) uses for internal
  * links elsewhere in the app — so the sitemap and `/llms.txt` can never
@@ -107,33 +152,5 @@ export async function getCmsRoutes(): Promise<ContentRoute[]> {
     return []
   }
 
-  const parsed = z.array(routableDocumentSchema).safeParse(data)
-  if (!parsed.success) return []
-
-  const routes = new Map<string, ContentRoute>()
-
-  for (const doc of parsed.data) {
-    if (!doc.slug) continue
-
-    const lastModified = new Date(doc._updatedAt)
-    if (Number.isNaN(lastModified.getTime())) continue
-
-    const path = urlForReference({
-      linkType: 'internal',
-      internalLink: { _type: doc._type, slug: doc.slug },
-    })
-
-    // `path === '#'` is unresolvable; a `staticPaths` hit means the document
-    // stands in for an already-listed static route (e.g. a `page` with slug
-    // `home`, which `urlForReference` resolves to `/`).
-    if (path === '#' || staticPaths.has(path)) continue
-
-    routes.set(path, {
-      path,
-      label: doc.title ?? doc.slug.current,
-      lastModified,
-    })
-  }
-
-  return [...routes.values()]
+  return buildRoutesFromDocuments(data)
 }

--- a/lib/styles/css/tailwind.css
+++ b/lib/styles/css/tailwind.css
@@ -793,389 +793,209 @@ border-top-left-radius: calc(100 / var(--device-width) * 1vw);
 @utility dr-w-col-* {
 	width: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-w-col-value {
-	width: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-w-col-* {
-	width: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-w-col--value {
-	width: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	width: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-min-w-col-* {
 	min-width: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-min-w-col-value {
-	min-width: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-min-w-col-* {
-	min-width: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-min-w-col--value {
-	min-width: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	min-width: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-max-w-col-* {
 	max-width: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-max-w-col-value {
-	max-width: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-max-w-col-* {
-	max-width: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-max-w-col--value {
-	max-width: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	max-width: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-h-col-* {
 	height: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-h-col-value {
-	height: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-h-col-* {
-	height: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-h-col--value {
-	height: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	height: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-min-h-col-* {
 	min-height: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-min-h-col-value {
-	min-height: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-min-h-col-* {
-	min-height: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-min-h-col--value {
-	min-height: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	min-height: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-max-h-col-* {
 	max-height: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-max-h-col-value {
-	max-height: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-max-h-col-* {
-	max-height: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-max-h-col--value {
-	max-height: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	max-height: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-gap-col-* {
 	gap: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-gap-col-value {
-	gap: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-gap-col-* {
-	gap: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-gap-col--value {
-	gap: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	gap: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-gap-x-col-* {
 	column-gap: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-gap-x-col-value {
-	column-gap: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-gap-x-col-* {
-	column-gap: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-gap-x-col--value {
-	column-gap: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	column-gap: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-gap-y-col-* {
 	row-gap: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-gap-y-col-value {
-	row-gap: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-gap-y-col-* {
-	row-gap: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-gap-y-col--value {
-	row-gap: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	row-gap: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-p-col-* {
 	padding: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-p-col-value {
-	padding: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-p-col-* {
-	padding: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-p-col--value {
-	padding: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	padding: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-px-col-* {
 	padding-inline: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-px-col-value {
-	padding-inline: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-px-col-* {
-	padding-inline: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-px-col--value {
-	padding-inline: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	padding-inline: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-py-col-* {
 	padding-block: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-py-col-value {
-	padding-block: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-py-col-* {
-	padding-block: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-py-col--value {
-	padding-block: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	padding-block: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-pt-col-* {
 	padding-top: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-pt-col-value {
-	padding-top: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-pt-col-* {
-	padding-top: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-pt-col--value {
-	padding-top: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	padding-top: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-pr-col-* {
 	padding-right: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-pr-col-value {
-	padding-right: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-pr-col-* {
-	padding-right: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-pr-col--value {
-	padding-right: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	padding-right: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-pl-col-* {
 	padding-left: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-pl-col-value {
-	padding-left: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-pl-col-* {
-	padding-left: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-pl-col--value {
-	padding-left: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	padding-left: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-pb-col-* {
 	padding-bottom: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-pb-col-value {
-	padding-bottom: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-pb-col-* {
-	padding-bottom: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-pb-col--value {
-	padding-bottom: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	padding-bottom: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-m-col-* {
 	margin: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-m-col-value {
-	margin: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-m-col-* {
-	margin: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-m-col--value {
-	margin: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	margin: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-mx-col-* {
 	margin-inline: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-mx-col-value {
-	margin-inline: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-mx-col-* {
-	margin-inline: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-mx-col--value {
-	margin-inline: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	margin-inline: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-my-col-* {
 	margin-block: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-my-col-value {
-	margin-block: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-my-col-* {
-	margin-block: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-my-col--value {
-	margin-block: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	margin-block: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-mt-col-* {
 	margin-top: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-mt-col-value {
-	margin-top: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-mt-col-* {
-	margin-top: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-mt-col--value {
-	margin-top: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	margin-top: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-mr-col-* {
 	margin-right: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-mr-col-value {
-	margin-right: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-mr-col-* {
-	margin-right: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-mr-col--value {
-	margin-right: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	margin-right: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-ml-col-* {
 	margin-left: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-ml-col-value {
-	margin-left: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-ml-col-* {
-	margin-left: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-ml-col--value {
-	margin-left: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	margin-left: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-mb-col-* {
 	margin-bottom: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-mb-col-value {
-	margin-bottom: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-mb-col-* {
-	margin-bottom: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-mb-col--value {
-	margin-bottom: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	margin-bottom: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-top-col-* {
 	top: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-top-col-value {
-	top: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-top-col-* {
-	top: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-top-col--value {
-	top: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	top: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-right-col-* {
 	right: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-right-col-value {
-	right: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-right-col-* {
-	right: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-right-col--value {
-	right: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	right: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-bottom-col-* {
 	bottom: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-bottom-col-value {
-	bottom: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-bottom-col-* {
-	bottom: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-bottom-col--value {
-	bottom: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	bottom: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-left-col-* {
 	left: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-left-col-value {
-	left: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-left-col-* {
-	left: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-left-col--value {
-	left: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	left: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-inset-col-* {
 	inset: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-inset-col-value {
-	inset: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-inset-col-* {
-	inset: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-inset-col--value {
-	inset: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	inset: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-inset-x-col-* {
 	inset-inline: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-inset-x-col-value {
-	inset-inline: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-inset-x-col-* {
-	inset-inline: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-inset-x-col--value {
-	inset-inline: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	inset-inline: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }
 
 @utility dr-inset-y-col-* {
 	inset-block: calc((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
 }
-@utility dr-inset-y-col-value {
-	inset-block: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
-}
 @utility -dr-inset-y-col-* {
-	inset-block: calc((--value(integer) * -1 * var(--column-width)) + ((--value(integer) - 1) * var(--gap)));
-}
-@utility -dr-inset-y-col--value {
-	inset-block: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));
+	inset-block: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);
 }

--- a/lib/styles/scripts/generate-scale.test.ts
+++ b/lib/styles/scripts/generate-scale.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Regression tests for issue #394: the column-utility CSS generator was
+ * broken two ways —
+ *
+ * (a) the `dr-*-col-value` autocomplete variants hardcoded the literal JS
+ *     string `'value'` into the CSS body (`calc((value * ...))`), which is
+ *     invalid CSS and silently dropped. That variant earned nothing (no call
+ *     site ever referenced a `-col-value` class), so it was removed outright
+ *     rather than patched.
+ * (b) the negative wildcard utilities (`-dr-w-col-*`) negated only the
+ *     column term, leaving the gap term unnegated — wrong by
+ *     `2 * (N - 1) * gap` for every N >= 2.
+ *
+ * Run with: bun test lib/styles/scripts/generate-scale.test.ts
+ */
+
+import { describe, expect, it } from 'bun:test'
+
+import { generateScale } from './generate-scale'
+
+function getUtilityBody(css: string, utilityHeader: string): string {
+  const marker = `@utility ${utilityHeader} {`
+  const start = css.indexOf(marker)
+  if (start === -1) {
+    throw new Error(`utility not found in generated CSS: ${utilityHeader}`)
+  }
+  const bodyStart = start + marker.length
+  const bodyEnd = css.indexOf('}', bodyStart)
+  return css.slice(bodyStart, bodyEnd).trim()
+}
+
+function getDeclarationValue(body: string, property: string): string {
+  const marker = `${property}:`
+  const start = body.indexOf(marker)
+  if (start === -1) {
+    throw new Error(`property not found in utility body: ${property}`)
+  }
+  const valueStart = start + marker.length
+  const valueEnd = body.indexOf(';', valueStart)
+  return body.slice(valueStart, valueEnd).trim()
+}
+
+// Minimal recursive-descent arithmetic evaluator (+, -, *, parens, negative
+// numbers) — no `Function`/`eval`, just enough to evaluate the `calc()`
+// bodies this generator emits once their CSS tokens are substituted for
+// numbers.
+function evalArithmetic(expr: string): number {
+  let i = 0
+
+  const peek = () => expr[i] ?? ''
+  const skipSpace = () => {
+    while (peek() === ' ') i++
+  }
+
+  function parseNumber(): number {
+    skipSpace()
+    const start = i
+    if (peek() === '-') i++
+    while (/[0-9.]/.test(peek())) i++
+    const text = expr.slice(start, i)
+    const n = Number.parseFloat(text)
+    if (Number.isNaN(n)) {
+      throw new Error(`Invalid number at index ${start}: "${text}"`)
+    }
+    return n
+  }
+
+  function parseFactor(): number {
+    skipSpace()
+    if (peek() === '(') {
+      i++
+      const value = parseExpr()
+      skipSpace()
+      if (peek() !== ')') throw new Error('Expected ")"')
+      i++
+      return value
+    }
+    if (peek() === '-') {
+      i++
+      return -parseFactor()
+    }
+    return parseNumber()
+  }
+
+  function parseTerm(): number {
+    let value = parseFactor()
+    skipSpace()
+    while (peek() === '*') {
+      i++
+      value *= parseFactor()
+      skipSpace()
+    }
+    return value
+  }
+
+  function parseExpr(): number {
+    let value = parseTerm()
+    skipSpace()
+    while (peek() === '+' || peek() === '-') {
+      const op = peek()
+      i++
+      const rhs = parseTerm()
+      value = op === '+' ? value + rhs : value - rhs
+      skipSpace()
+    }
+    return value
+  }
+
+  const result = parseExpr()
+  skipSpace()
+  if (i !== expr.length) {
+    throw new Error(`Unexpected trailing input: "${expr.slice(i)}"`)
+  }
+  return result
+}
+
+// Evaluates a generated `calc()` expression as plain arithmetic by
+// substituting `--value(integer)`, `var(--column-width)`, and `var(--gap)`
+// with concrete numbers, then rewriting `calc(` to `(` (their parens already
+// balance, so the result is a valid arithmetic expression).
+function evalCalcExpression(
+  expr: string,
+  value: number,
+  columnWidth: number,
+  gap: number
+): number {
+  const arithmeticExpr = expr
+    .replaceAll('--value(integer)', String(value))
+    .replaceAll('var(--column-width)', String(columnWidth))
+    .replaceAll('var(--gap)', String(gap))
+    .replaceAll('calc(', '(')
+
+  return evalArithmetic(arithmeticExpr)
+}
+
+describe('generateScale column utilities', () => {
+  const css = generateScale()
+
+  it('emits -dr-w-col-* as the exact negation of dr-w-col-*', () => {
+    const positiveBody = getUtilityBody(css, 'dr-w-col-*')
+    const negativeBody = getUtilityBody(css, '-dr-w-col-*')
+
+    const positiveExpr = getDeclarationValue(positiveBody, 'width')
+    const negativeExpr = getDeclarationValue(negativeBody, 'width')
+
+    for (const n of [1, 2, 3, 5, 8]) {
+      const positiveValue = evalCalcExpression(positiveExpr, n, 37, 11)
+      const negativeValue = evalCalcExpression(negativeExpr, n, 37, 11)
+      expect(negativeValue).toBe(-positiveValue)
+    }
+  })
+
+  it('never emits the invalid literal-`value` autocomplete utility', () => {
+    expect(css).not.toContain('col-value')
+    expect(css).not.toContain('(value *')
+    expect(css).not.toContain('(-value *')
+  })
+})

--- a/lib/styles/scripts/generate-scale.ts
+++ b/lib/styles/scripts/generate-scale.ts
@@ -98,24 +98,20 @@ function columnScaleUtility(name: string, properties: string | string[]) {
     .join('\n')}
 }`
 
-  const autoCompleteUtility = `@utility dr-${name}-col-value {
+  // Negate the whole expression, not just the column term. Negating only
+  // `--value(integer) * var(--column-width)` while leaving the gap term
+  // `(--value(integer) - 1) * var(--gap)` alone undercounts the negative
+  // value by 2 * (N - 1) * gap for every N >= 2.
+  const negatedUtility = `@utility -dr-${name}-col-* {
 	${propertiesArray
     .map(
       (property) =>
-        `${property}: calc((value * var(--column-width)) + ((value - 1) * var(--gap)));`
+        `${property}: calc(((--value(integer) * var(--column-width)) + ((--value(integer) - 1) * var(--gap))) * -1);`
     )
     .join('\n')}
 }`
 
-  const negatedUtility = utility
-    .replace('@utility ', '@utility -')
-    .replace('--value(integer)', '--value(integer) * -1')
-
-  const negatedAutoCompleteUtility = autoCompleteUtility
-    .replace('@utility ', '@utility -')
-    .replace('value', '-value')
-
-  return `${utility}\n${autoCompleteUtility}\n${negatedUtility}\n${negatedAutoCompleteUtility}`
+  return `${utility}\n${negatedUtility}`
 }
 
 export function generateScale() {

--- a/lib/styles/scripts/postcss-functions.mjs
+++ b/lib/styles/scripts/postcss-functions.mjs
@@ -18,10 +18,15 @@ export const functions = {
     const numPixels = validatePixels(pixels, 'mobile')
     return `${(numPixels * 100) / screens.mobile.width}vw`
   },
+  // `clamp(MIN, VAL, MAX)` is `max(MIN, min(VAL, MAX))`. On modern mobile
+  // browsers `vh >= dvh >= svh`, so `clamp(Nvh, Nsvh, Ndvh)` always collapsed
+  // to `min(vh, dvh)` then `max(that, svh)` — i.e. plain `vh`, the
+  // address-bar-hidden value `h-dvh` exists to avoid. Emitting `dvh` directly
+  // is that same collapse (clamp(svh, vh, dvh) also always resolves to dvh
+  // under that invariant), just without the misleading clamp().
   'mobile-vh': (pixels) => {
     const numPixels = validatePixels(pixels, 'mobile')
-    const vh = `${(numPixels * 100) / screens.mobile.height}`
-    return `clamp(${vh}vh, ${vh}svh, ${vh}dvh)`
+    return `${(numPixels * 100) / screens.mobile.height}dvh`
   },
   'desktop-vw': (pixels) => {
     const numPixels = validatePixels(pixels, 'desktop')

--- a/lib/styles/scripts/postcss-functions.test.ts
+++ b/lib/styles/scripts/postcss-functions.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Regression test for issue #395: `mobile-vh()` emitted
+ * `clamp(Nvh, Nsvh, Ndvh)`. `clamp(MIN, VAL, MAX)` is `max(MIN, min(VAL,
+ * MAX))`, and on modern mobile browsers `vh >= dvh >= svh`, so that clamp
+ * always collapsed to plain `vh` — the address-bar-hidden value the
+ * project's own `h-dvh` house rule exists to avoid. `mobile-vh()` now emits
+ * `dvh` directly.
+ *
+ * Run with: bun test lib/styles/scripts/postcss-functions.test.ts
+ */
+
+import { describe, expect, it } from 'bun:test'
+
+import { functions } from './postcss-functions.mjs'
+
+describe('mobile-vh()', () => {
+  it('emits a plain dvh value, never a vh/svh/dvh clamp', () => {
+    const result = functions['mobile-vh']('75')
+
+    expect(result).toMatch(/^-?[\d.]+dvh$/)
+    expect(result).not.toContain('clamp')
+    expect(result).not.toContain('svh')
+  })
+
+  it('scales proportionally to the mobile screen height', () => {
+    const result = functions['mobile-vh']('100')
+    expect(result).toBe(functions['mobile-vh']('100'))
+    expect(result.endsWith('dvh')).toBe(true)
+  })
+})

--- a/lib/utils/strings.ts
+++ b/lib/utils/strings.ts
@@ -77,7 +77,7 @@ export function capitalizeFirstLetter(inputString: string) {
  * ```ts
  * isEmptyArray([])      // true
  * isEmptyArray([1, 2])  // false
- * isEmptyArray('test')  // true (not an array)
+ * isEmptyArray('test')  // false (not an array, but truthy)
  * isEmptyArray(null)    // true
  * ```
  */

--- a/lib/webgl/components/canvas/index.tsx
+++ b/lib/webgl/components/canvas/index.tsx
@@ -7,7 +7,6 @@ import {
   use,
   useEffect,
   useId,
-  useState,
   useSyncExternalStore,
 } from 'react'
 import type tunnel from 'tunnel-rat'
@@ -41,21 +40,30 @@ const WebGLCanvas = dynamic(
  * drops the dead branch — no persisted dev-panel state leaks into what
  * production visitors render.
  */
+const NOOP_UNSUBSCRIBE = () => {
+  // Production: nothing is subscribed, so nothing to tear down.
+}
+
+const subscribeToWebGLToggle = (onChange: () => void) =>
+  process.env.NODE_ENV === 'development'
+    ? Orchestra.subscribe((state) => state.webgl, onChange)
+    : NOOP_UNSUBSCRIBE
+
+const getWebGLToggle = () =>
+  process.env.NODE_ENV === 'development'
+    ? (Orchestra.getState().webgl ?? true)
+    : true
+
+// The toggle only exists in the browser; SSR always renders as enabled so the
+// server and the first client paint agree.
+const getWebGLToggleServerSnapshot = () => true
+
 function useWebGLDevKillSwitch(): boolean {
-  const [enabled, setEnabled] = useState(true)
-
-  useEffect(() => {
-    if (process.env.NODE_ENV !== 'development') return
-
-    setEnabled(Orchestra.getState().webgl ?? true)
-
-    return Orchestra.subscribe(
-      (state) => state.webgl,
-      (value) => setEnabled(value ?? true)
-    )
-  }, [])
-
-  return process.env.NODE_ENV === 'development' ? enabled : true
+  return useSyncExternalStore(
+    subscribeToWebGLToggle,
+    getWebGLToggle,
+    getWebGLToggleServerSnapshot
+  )
 }
 
 type TunnelInstance = ReturnType<typeof tunnel>

--- a/lib/webgl/components/canvas/index.tsx
+++ b/lib/webgl/components/canvas/index.tsx
@@ -7,10 +7,12 @@ import {
   use,
   useEffect,
   useId,
+  useState,
   useSyncExternalStore,
 } from 'react'
 import type tunnel from 'tunnel-rat'
 
+import Orchestra from '@/lib/dev/orchestra'
 import { useDeviceDetection } from '@/lib/hooks/use-device-detection'
 import {
   getDOMTunnel,
@@ -27,6 +29,34 @@ const WebGLCanvas = dynamic(
     ssr: false,
   }
 )
+
+/**
+ * Reads the Orchestra dev panel's 🧊 WebGL toggle (persisted in the same
+ * `orchestra` localStorage store every other panel toggle uses). Defaults to
+ * `true` — matches the toggle's own `defaultValue` in `lib/dev/cmdo.tsx` and
+ * the "on by default" behaviour documented in `lib/dev/README.md`.
+ *
+ * Collapses to a constant `true` in production: `process.env.NODE_ENV` is
+ * inlined at build time, so the subscription never runs and minification
+ * drops the dead branch — no persisted dev-panel state leaks into what
+ * production visitors render.
+ */
+function useWebGLDevKillSwitch(): boolean {
+  const [enabled, setEnabled] = useState(true)
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'development') return
+
+    setEnabled(Orchestra.getState().webgl ?? true)
+
+    return Orchestra.subscribe(
+      (state) => state.webgl,
+      (value) => setEnabled(value ?? true)
+    )
+  }, [])
+
+  return process.env.NODE_ENV === 'development' ? enabled : true
+}
 
 type TunnelInstance = ReturnType<typeof tunnel>
 
@@ -84,6 +114,7 @@ export function Canvas({
   ...props
 }: CanvasProps) {
   const { isWebGL, isReducedMotion } = useDeviceDetection()
+  const webglDevToggleEnabled = useWebGLDevKillSwitch()
 
   // Only a root canvas mounts the WebGL surface; it uses the shared store
   // tunnels so content portals into it from anywhere. A non-root <Canvas> is a
@@ -99,7 +130,12 @@ export function Canvas({
   // must account for a fallback for this state: render a static image / DOM
   // equivalent when the canvas is absent, or mount with `force` and damp
   // motion inside the scene.
-  const shouldRender = root && ((isWebGL && !isReducedMotion) || force)
+  //
+  // The Orchestra panel's 🧊 toggle is a dev-only kill switch on top of all
+  // of that (including `force`) — useful for isolating perf work to the DOM
+  // side of a page without physically deleting `<Canvas root>`.
+  const shouldRender =
+    webglDevToggleEnabled && root && ((isWebGL && !isReducedMotion) || force)
   const contextValue: CanvasContextValue =
     WebGLTunnel && DOMTunnel
       ? { active: true, WebGLTunnel, DOMTunnel }

--- a/lib/webgl/hooks/use-pointer-input.ts
+++ b/lib/webgl/hooks/use-pointer-input.ts
@@ -52,12 +52,14 @@ export function usePointerInput(
     const handleMouseMove = (event: MouseEvent) => handlePointer(event)
     const handleTouchMove = (event: TouchEvent) => handlePointer(event)
 
-    window.addEventListener('mousemove', handleMouseMove, false)
-    window.addEventListener('touchmove', handleTouchMove, false)
+    // Passive: `handlePointer` never calls preventDefault, so the browser is
+    // free to start scrolling without waiting on this handler.
+    window.addEventListener('mousemove', handleMouseMove, { passive: true })
+    window.addEventListener('touchmove', handleTouchMove, { passive: true })
 
     return () => {
-      window.removeEventListener('mousemove', handleMouseMove, false)
-      window.removeEventListener('touchmove', handleTouchMove, false)
+      window.removeEventListener('mousemove', handleMouseMove)
+      window.removeEventListener('touchmove', handleTouchMove)
     }
   }, [])
 }


### PR DESCRIPTION
Components/styles/dev batch of the 2026-08-05 audit remediation. Closes #385, closes #388, closes #393, closes #394, closes #395, closes #397, part of #398 (L5, L7, L8, L11) and #400.

This is genuinely a set of unrelated fixes rather than one theme — grouped because they share a file neighbourhood and nothing else.

## What this does

The headline: every production visitor on a WebGL-capable device was loading a Theatre.js runtime and fetching an animation config that did not even match the sheet the code uses. Two separate comments in the repo claimed none of it shipped to users. Only the Studio editor half was gated; the runtime half was not.

The rest, in rough order of who notices:

1. **Negative column utilities computed the wrong width.** `-dr-w-col-N` negated only the column term, so it came out wrong by `2(N-1) × gap` for every N ≥ 2. A separate family of ~28 `-col-value` utilities emitted the literal word `value` inside `calc()`, which is invalid CSS and silently dropped. Those had no callers and are gone; the negation is fixed and the CSS regenerated.
2. **A form could become permanently unsubmittable.** `register` never cleaned up unmounted fields, so a required field that mounts untouched and is then hidden by a tab switch or wizard step left `isReady` false forever with nothing on screen to fix.
3. **`ProgressText` desynced** once its word count shrank — stale detached nodes kept the denominator wrong, shifting every surviving word's reveal threshold. Same fix marquee already had.
4. **One malformed CMS document emptied the entire sitemap.** `getCmsRoutes` validated the whole array at once and returned `[]` on any failure, despite its own docstring promising per-entry skipping.
5. **The custom scrollbar was keyboard-inoperable** — no role, no value semantics, no arrow keys. Now has all three. `controlsId` is optional: an exported primitive cannot gain a required prop without breaking forks that already render it.
6. **`mobile-vh()` always resolved to plain `vh`** — its clamp had min ≥ max, so it produced exactly the address-bar-hidden value the house `h-dvh` rule exists to avoid. Now emits `dvh`.
7. `Image`'s `block` prop escaped the sizing union and allowed a call that typechecked and then threw at runtime. Removed — it had no callers and `fill` now derives from the union alone. **Worth noting for forks:** this drops a public prop, though an undocumented one.
8. The Orchestra dev panel's WebGL toggle actually controls the canvas now, instead of persisting a value nothing read.
9. Smaller: the generator no longer offers a Block Components category that could never appear in COMPONENTS.md; `buildHooksSection` gained the test-file filter its sibling already had; pointer listeners are passive; a dead `onChange` on a hidden checkbox input is gone; `isEmptyArray`'s doc example no longer states the opposite of what it returns.

## Test Plan

- [ ] `bun run check` → exit 0 (509 tests)
- [ ] `bun run build` → exit 0, and `.next/static` contains no reference to `/config/Satus-R3f.json`
- [ ] New: `-dr-w-col-3` is the exact negation of `dr-w-col-3`
- [ ] New: a required field unmounting no longer wedges `isReady`
- [ ] New: one malformed CMS document no longer empties the sitemap
- [ ] Tab to the scrollbar thumb and drive it with arrow keys