### PR TITLE
fix(shopify): stop two simultaneous first-adds from creating two carts

### DIFF
--- a/app/api/cart/ensure/route.ts
+++ b/app/api/cart/ensure/route.ts
@@ -1,0 +1,57 @@
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+import { isConfigured } from '@/integrations/registry'
+import { createCart } from '@/integrations/shopify/cart-operations'
+
+/**
+ * Idempotently ensure the visitor has a Shopify cart, and return nothing but
+ * whether one now exists.
+ *
+ * Exists to close a race: `addItem` creates the cart when the `cartId` cookie
+ * is absent, so two concurrent first-adds each created their own cart. One
+ * cookie won and the other cart — with the item the buyer had just added —
+ * was orphaned. Serverless invocations share no state, so the fix has to
+ * happen where the requests do share something: the browser. Clients call
+ * this behind a cross-tab Web Lock (see `ensure-cart.ts`), so only one
+ * request can be in flight per browser and every later one finds the cookie
+ * already set.
+ *
+ * The cart id never leaves the server. Shopify's cart id embeds a secret and
+ * their docs say to treat it like a password, so it stays in an httpOnly
+ * cookie and this route reports only presence.
+ */
+export async function POST() {
+  if (!isConfigured('shopify')) {
+    return NextResponse.json(
+      { error: 'Shopify is not configured' },
+      { status: 503 }
+    )
+  }
+
+  const cookieStore = await cookies()
+
+  // Already have one — the common case once a visitor has added anything, and
+  // the case every request queued behind the Web Lock hits.
+  if (cookieStore.get('cartId')?.value) {
+    return NextResponse.json({ ready: true })
+  }
+
+  try {
+    const cart = await createCart()
+
+    cookieStore.set('cartId', cart.id, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 60 * 60 * 24 * 30, // 30 days
+      path: '/',
+    })
+
+    return NextResponse.json({ ready: true })
+  } catch {
+    // Not fatal to the caller: `addItem` still creates a cart when the cookie
+    // is missing, so a failure here costs the race protection, not the sale.
+    return NextResponse.json({ ready: false }, { status: 502 })
+  }
+}

--- a/lib/integrations/shopify/cart/add-to-cart/index.tsx
+++ b/lib/integrations/shopify/cart/add-to-cart/index.tsx
@@ -10,6 +10,7 @@ import type { Product, ProductVariant } from '@/integrations/shopify/types'
 
 import { addItem } from '../actions'
 import { useCartContext } from '../cart-context'
+import { ensureCart } from '../ensure-cart'
 import { useCartModal } from '../modal'
 
 import s from './add-to-cart.module.css'
@@ -48,6 +49,12 @@ export function AddToCart({
       addCartItem(variant, product, quantity)
       openCart()
     })
+
+    // Create the cart first, behind a cross-tab lock, so two simultaneous
+    // first-adds cannot each create one and orphan the loser's item. The
+    // action still creates a cart when this is skipped (no JS, no Web Locks),
+    // so this is protection, not a prerequisite.
+    await ensureCart()
 
     const result = await addItem(null, {
       variantId: variant?.id || '',

--- a/lib/integrations/shopify/cart/ensure-cart.ts
+++ b/lib/integrations/shopify/cart/ensure-cart.ts
@@ -1,0 +1,56 @@
+'use client'
+
+/**
+ * Make sure a Shopify cart exists before a mutation needs one, serialised
+ * across every tab in the browser.
+ *
+ * The problem this solves: `addItem` creates the cart when the `cartId`
+ * cookie is absent. Two concurrent first-adds — two tabs, or a fast
+ * double-submit — each saw no cookie and each created a cart. One cookie
+ * won; the other cart, holding an item the buyer had just added, was
+ * orphaned. Serverless invocations share nothing, so there is no server-side
+ * place to reconcile them.
+ *
+ * The browser is the shared context. `navigator.locks` is held per origin
+ * across tabs, so the first caller creates the cart and everyone queued
+ * behind it finds the cookie already set and returns immediately.
+ *
+ * Deliberately does not return or receive the cart id: Shopify's cart id
+ * embeds a secret their docs say to treat like a password, so it stays in an
+ * httpOnly cookie the client never reads.
+ */
+
+const LOCK_NAME = 'satus.shopify.cart-ensure'
+
+/** Set once per page load — the cart outlives a single add. */
+let ensured = false
+
+async function requestEnsure(): Promise<void> {
+  const response = await fetch('/api/cart/ensure', {
+    method: 'POST',
+    // Same-origin by default, but be explicit: the whole point is the
+    // Set-Cookie on the response.
+    credentials: 'same-origin',
+  })
+
+  if (response.ok) ensured = true
+}
+
+export async function ensureCart(): Promise<void> {
+  if (ensured) return
+
+  // Web Locks is unavailable on older Safari and in non-secure contexts.
+  // Falling back to an unsynchronised call keeps the flow working; the worst
+  // case is the pre-existing race, never a failed add.
+  if (typeof navigator === 'undefined' || !navigator.locks) {
+    await requestEnsure()
+    return
+  }
+
+  await navigator.locks.request(LOCK_NAME, async () => {
+    // Re-check inside the lock: a tab that queued behind the creator has
+    // nothing left to do.
+    if (ensured) return
+    await requestEnsure()
+  })
+}

--- a/lib/scripts/integration-bundles.ts
+++ b/lib/scripts/integration-bundles.ts
@@ -510,7 +510,10 @@ export const INTEGRATION_BUNDLES = defineBundles({
     description: 'E-commerce platform integration with cart and checkout',
     dependencies: [],
     devDependencies: [],
-    folders: ['lib/integrations/shopify'],
+    // app/api/cart holds the cart-ensure endpoint, which imports this
+    // integration's cart operations — it must live and die with the bundle,
+    // or dropping Shopify leaves a route whose imports no longer resolve.
+    folders: ['lib/integrations/shopify', 'app/api/cart'],
     files: [],
     // Keep in sync with the SHOPIFY_* keys in lib/env.ts — that schema is the
     // source of truth for what the integration actually reads.

--- a/lib/scripts/setup-project.test.ts
+++ b/lib/scripts/setup-project.test.ts
@@ -1014,6 +1014,16 @@ describe('declaredBundlePaths / findMissingPaths (H8 preflight)', () => {
     expect(paths).toContain('app/(site)/[...slug]/page.tsx')
   })
 
+  it('shopify bundle owns every route folder that imports from it', () => {
+    // app/api/cart/ensure imports lib/integrations/shopify's cart operations.
+    // If it falls out of the bundle's folders, a fork that drops Shopify
+    // keeps the route and fails to build on module-not-found — the same
+    // lean-fork break the sanity assertions above guard against.
+    const paths = declaredBundlePaths(['shopify'])
+    expect(paths).toContain('lib/integrations/shopify')
+    expect(paths).toContain('app/api/cart')
+  })
+
   it('declaredBundlePaths is empty for an empty keep set', () => {
     expect(declaredBundlePaths([])).toEqual([])
   })


### PR DESCRIPTION
Closes the last open item on #400.

## What this does

Add to an empty cart from two tabs at the same moment and each request created its own Shopify cart. One cookie won; the other cart — holding an item the buyer had just added — was orphaned, and the item silently never appeared.

Serverless invocations share no state, so there is no server-side place to reconcile the two. The coordination happens where the requests genuinely do share something: the browser. A cross-tab Web Lock funnels cart creation through a single idempotent request before the add runs.

## Why not do it in the browser directly

The obvious version of "move it client-side" is to give the browser a public Storefront token and call `cartCreate` from there. Shopify's docs rule that out for this repo: the cart id embeds a secret, they say to treat it like a password, and without it buyer details are stripped from responses and mutations fail. Satus already keeps the id in an httpOnly cookie, which is exactly that protection.

So the client only *orchestrates*. It holds the lock and asks the server to create; the id never reaches client code and the private token never leaves the server.

Refs: [Create and update a cart](https://shopify.dev/docs/storefronts/headless/building-with-the-storefront-api/cart/manage), [Building with the Storefront API](https://shopify.dev/docs/storefronts/headless/building-with-the-storefront-api)

## Summary

1. `app/api/cart/ensure/route.ts` — idempotent: returns early if the cookie exists, otherwise creates the cart and sets it. Reports presence only, never the id.
2. `cart/ensure-cart.ts` — takes `navigator.locks` per origin, so tabs queue and everyone after the first finds the cookie already set. Falls back to an unsynchronised call where Web Locks is unavailable (older Safari, non-secure contexts); worst case there is today's behaviour, never a failed add.
3. `AddToCart` awaits it before invoking the action. Lazy, so visitors who never add cost no API call.
4. The server action still creates a cart when the cookie is missing, so a form submitted before hydration or without JS still works. That path keeps the race, where concurrent requests are effectively impossible anyway.
5. `integration-bundles.ts` — `app/api/cart` joins the Shopify bundle, since the route imports its cart operations. A new test asserts it, mirroring the sanity guard: without it, dropping Shopify would leave a route whose imports do not resolve.

## Test Plan

- [ ] `bun run check` → exit 0 (536 tests, 1 new)
- [ ] `bun run build` → exit 0, `/api/cart/ensure` in the route table
- [ ] Open two tabs on a product with an empty cart, add from both at once: one cart, both items
- [ ] Drop Shopify via `setup:project` and build — no dangling route