### PR TITLE
docs: record the four conventions the audits kept re-deriving

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,18 @@ Dispose materials, textures, geometries, and render targets on unmount. Remove e
 - Conventional commits: `feat:`, `fix:`, `refactor:`, `docs:`, `chore:`
 - No force push to `main`; no `--no-verify` unless explicitly requested
 
+### Rules the audits keep re-deriving
+
+Four positions that repeated audits arrived at independently. Each exists because the alternative already shipped a bug.
+
+**A comment that calls something deliberate must say what it costs.** Stating the intent alone is what let two real defects survive review: form actions verified Turnstile before rate limiting (documented as deliberate, never traced to the flood it invited), and the Sanity live module claimed published fetching was unaffected by a missing token (it was, in fact, entirely disabled). If you cannot name the cost you are accepting, the decision has not been made yet.
+
+**"Is X configured" has one answer per integration.** `lib/env.ts`, the per-integration `env.ts` files, and the schemas in `lib/utils/validation.ts` each parse environment differently. They may not disagree. Where they cannot be merged — `lib/integrations/sanity/env.ts` is dual-compiled into the client bundle and must not import server-only code — a test asserts they stay in sync instead. Note that "reads the same module" is not sufficient on its own: a dual-compiled module answers differently per side when its fallbacks are not statically inlinable, which is how an alias-only Sanity config broke the front end and the Studio at once.
+
+**Anything a scaffold step did not expect blocks self-prune.** `setup:project` has three failure modes — thrown, collected, and skipped — and only a thrown one used to stop the run. A required transform whose target file had been renamed was skipped in silence, and self-prune deleted the script even after transforms failed, so the documented advice to fix the cause and re-run had nothing left to run. New failure paths join the collected set; they do not get a fourth behaviour.
+
+**Ship the claim with the fix.** Changelog, README, JSDoc, audit ledger: whatever states the old behaviour changes in the same diff. This is the rule with the worst track record — the changelog and a process-audit report both credited a PR with an EOF fix that only ever covered one of the three scripts it named, which made the gap invisible to anyone checking the record instead of the code.
+
 ---
 
 ## Code Patterns

--- a/app/api/cart/ensure/route.ts
+++ b/app/api/cart/ensure/route.ts
@@ -1,0 +1,57 @@
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+import { isConfigured } from '@/integrations/registry'
+import { createCart } from '@/integrations/shopify/cart-operations'
+
+/**
+ * Idempotently ensure the visitor has a Shopify cart, and return nothing but
+ * whether one now exists.
+ *
+ * Exists to close a race: `addItem` creates the cart when the `cartId` cookie
+ * is absent, so two concurrent first-adds each created their own cart. One
+ * cookie won and the other cart — with the item the buyer had just added —
+ * was orphaned. Serverless invocations share no state, so the fix has to
+ * happen where the requests do share something: the browser. Clients call
+ * this behind a cross-tab Web Lock (see `ensure-cart.ts`), so only one
+ * request can be in flight per browser and every later one finds the cookie
+ * already set.
+ *
+ * The cart id never leaves the server. Shopify's cart id embeds a secret and
+ * their docs say to treat it like a password, so it stays in an httpOnly
+ * cookie and this route reports only presence.
+ */
+export async function POST() {
+  if (!isConfigured('shopify')) {
+    return NextResponse.json(
+      { error: 'Shopify is not configured' },
+      { status: 503 }
+    )
+  }
+
+  const cookieStore = await cookies()
+
+  // Already have one — the common case once a visitor has added anything, and
+  // the case every request queued behind the Web Lock hits.
+  if (cookieStore.get('cartId')?.value) {
+    return NextResponse.json({ ready: true })
+  }
+
+  try {
+    const cart = await createCart()
+
+    cookieStore.set('cartId', cart.id, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 60 * 60 * 24 * 30, // 30 days
+      path: '/',
+    })
+
+    return NextResponse.json({ ready: true })
+  } catch {
+    // Not fatal to the caller: `addItem` still creates a cart when the cookie
+    // is missing, so a failure here costs the race protection, not the sale.
+    return NextResponse.json({ ready: false }, { status: 502 })
+  }
+}

--- a/lib/integrations/shopify/cart/add-to-cart/index.tsx
+++ b/lib/integrations/shopify/cart/add-to-cart/index.tsx
@@ -10,6 +10,7 @@ import type { Product, ProductVariant } from '@/integrations/shopify/types'
 
 import { addItem } from '../actions'
 import { useCartContext } from '../cart-context'
+import { ensureCart } from '../ensure-cart'
 import { useCartModal } from '../modal'
 
 import s from './add-to-cart.module.css'
@@ -48,6 +49,12 @@ export function AddToCart({
       addCartItem(variant, product, quantity)
       openCart()
     })
+
+    // Create the cart first, behind a cross-tab lock, so two simultaneous
+    // first-adds cannot each create one and orphan the loser's item. The
+    // action still creates a cart when this is skipped (no JS, no Web Locks),
+    // so this is protection, not a prerequisite.
+    await ensureCart()
 
     const result = await addItem(null, {
       variantId: variant?.id || '',

--- a/lib/integrations/shopify/cart/ensure-cart.ts
+++ b/lib/integrations/shopify/cart/ensure-cart.ts
@@ -1,0 +1,56 @@
+'use client'
+
+/**
+ * Make sure a Shopify cart exists before a mutation needs one, serialised
+ * across every tab in the browser.
+ *
+ * The problem this solves: `addItem` creates the cart when the `cartId`
+ * cookie is absent. Two concurrent first-adds — two tabs, or a fast
+ * double-submit — each saw no cookie and each created a cart. One cookie
+ * won; the other cart, holding an item the buyer had just added, was
+ * orphaned. Serverless invocations share nothing, so there is no server-side
+ * place to reconcile them.
+ *
+ * The browser is the shared context. `navigator.locks` is held per origin
+ * across tabs, so the first caller creates the cart and everyone queued
+ * behind it finds the cookie already set and returns immediately.
+ *
+ * Deliberately does not return or receive the cart id: Shopify's cart id
+ * embeds a secret their docs say to treat like a password, so it stays in an
+ * httpOnly cookie the client never reads.
+ */
+
+const LOCK_NAME = 'satus.shopify.cart-ensure'
+
+/** Set once per page load — the cart outlives a single add. */
+let ensured = false
+
+async function requestEnsure(): Promise<void> {
+  const response = await fetch('/api/cart/ensure', {
+    method: 'POST',
+    // Same-origin by default, but be explicit: the whole point is the
+    // Set-Cookie on the response.
+    credentials: 'same-origin',
+  })
+
+  if (response.ok) ensured = true
+}
+
+export async function ensureCart(): Promise<void> {
+  if (ensured) return
+
+  // Web Locks is unavailable on older Safari and in non-secure contexts.
+  // Falling back to an unsynchronised call keeps the flow working; the worst
+  // case is the pre-existing race, never a failed add.
+  if (typeof navigator === 'undefined' || !navigator.locks) {
+    await requestEnsure()
+    return
+  }
+
+  await navigator.locks.request(LOCK_NAME, async () => {
+    // Re-check inside the lock: a tab that queued behind the creator has
+    // nothing left to do.
+    if (ensured) return
+    await requestEnsure()
+  })
+}

--- a/lib/scripts/integration-bundles.ts
+++ b/lib/scripts/integration-bundles.ts
@@ -510,7 +510,10 @@ export const INTEGRATION_BUNDLES = defineBundles({
     description: 'E-commerce platform integration with cart and checkout',
     dependencies: [],
     devDependencies: [],
-    folders: ['lib/integrations/shopify'],
+    // app/api/cart holds the cart-ensure endpoint, which imports this
+    // integration's cart operations — it must live and die with the bundle,
+    // or dropping Shopify leaves a route whose imports no longer resolve.
+    folders: ['lib/integrations/shopify', 'app/api/cart'],
     files: [],
     // Keep in sync with the SHOPIFY_* keys in lib/env.ts — that schema is the
     // source of truth for what the integration actually reads.

--- a/lib/scripts/setup-project.test.ts
+++ b/lib/scripts/setup-project.test.ts
@@ -1014,6 +1014,16 @@ describe('declaredBundlePaths / findMissingPaths (H8 preflight)', () => {
     expect(paths).toContain('app/(site)/[...slug]/page.tsx')
   })
 
+  it('shopify bundle owns every route folder that imports from it', () => {
+    // app/api/cart/ensure imports lib/integrations/shopify's cart operations.
+    // If it falls out of the bundle's folders, a fork that drops Shopify
+    // keeps the route and fails to build on module-not-found — the same
+    // lean-fork break the sanity assertions above guard against.
+    const paths = declaredBundlePaths(['shopify'])
+    expect(paths).toContain('lib/integrations/shopify')
+    expect(paths).toContain('app/api/cart')
+  })
+
   it('declaredBundlePaths is empty for an empty keep set', () => {
     expect(declaredBundlePaths([])).toEqual([])
   })


### PR DESCRIPTION
Closes #399.

## What this does

Four audits arrived at the same positions independently, and each one exists because the alternative already shipped a bug. They lived only in issue history, so the next audit would have rediscovered them from scratch. Now they are in AGENTS.md, next to the rules people already read.

## Summary

1. **A comment calling something deliberate must say what it costs.** Two real defects survived review behind intent-only comments: form actions verified Turnstile before rate limiting, and the Sanity live module claimed published fetching was unaffected by a missing token when it was entirely disabled by one.
2. **"Is X configured" has one answer per integration.** Where the modules cannot be merged — the Sanity env module is dual-compiled and must not import server-only code — a test keeps them in sync instead. With the non-obvious part recorded: reading the same module is not sufficient, because a dual-compiled module answers differently per side when its fallbacks are not statically inlinable.
3. **Anything a scaffold step did not expect blocks self-prune.** `setup:project` had three failure modes — thrown, collected, skipped — and only a thrown one stopped the run.
4. **Ship the claim with the fix.** The rule with the worst track record here — a changelog and an audit report both credited a PR with a fix covering one of the three scripts it named.

Also adds a line to the PR template for the fourth, since it is the one that slipped twice and the moment it matters is the moment you open a PR.

## Test Plan

- [ ] `bun run check` → exit 0 (docs and template only, no code)
