### PR TITLE
docs: add the claims-updated checkbox to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,4 @@
 - [ ] `bun run check` passes (oxlint + oxfmt + typecheck + tests)
 - [ ] Tested locally in dev mode
 - [ ] No breaking changes (or documented in summary)
+- [ ] If this changes documented behaviour, the docs that state it changed in the same diff (CHANGELOG, README, JSDoc, audit reports)


### PR DESCRIPTION
Follow-up to #411, which landed the AGENTS.md conventions but silently dropped this one line.

macOS treats `pull_request_template.md` and `PULL_REQUEST_TEMPLATE.md` as the same file, but git tracks only the uppercase path. Editing the lowercase name changed the file on disk while staging that path added nothing, so the commit went through green with the change missing.

Fittingly, this is the convention it was implementing: ship the claim with the fix. The claim shipped, the fix did not.

## Test Plan

- [ ] `git show HEAD:.github/PULL_REQUEST_TEMPLATE.md` ends with the new checkbox