### PR TITLE
fix(seo): stop child routes inheriting the site-wide canonical

### DIFF
--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -109,8 +109,9 @@ Quick-reference for every component, hook, and utility in the Satus starter kit.
 
 | Export | Signature |
 |--------|-----------|
+| truncateDescription | `(text: string | null | undefined, maxLength: number = DESCRIPTION_MAX_LENGTH) => string` |
 | generatePageMetadata | `(options: GenerateMetadataOptions) => Metadata` |
-| generateSanityMetadata | `(options: { // Fields are nullable to accept TypeGen query-result types directly // (projections type optional fields as `T | null`). document: { title?: string | null metadata?: { title?: string | null description?: string | null keywords?: string[] | null noIndex?: boolean | null } | null _updatedAt?: string | null publishedAt?: string | null } url?: string type?: 'website' | 'article' }) => Metadata` |
+| generateSanityMetadata | `(options: { // Fields are nullable to accept TypeGen query-result types directly // (projections type optional fields as `T | null`). document: { title?: string | null metadata?: { title?: string | null description?: string | null keywords?: string[] | null noIndex?: boolean | null } | null _updatedAt?: string | null publishedAt?: string | null /** Body prose used to derive a description when the editor left one blank. */ excerpt?: string | null } url?: string type?: 'website' | 'article' }) => Metadata` |
 
 ### Raf (`@/utils/raf`)
 

--- a/app/(site)/ai/page.tsx
+++ b/app/(site)/ai/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 
+import { routeAlternates } from '@/lib/seo/alternates'
 import { formatList, SITE } from '@/lib/seo/site'
 
 /**
@@ -30,9 +31,7 @@ import { formatList, SITE } from '@/lib/seo/site'
 export const metadata: Metadata = {
   title: 'Machine view',
   description: `Plain-text index of ${SITE.name} for AI agents and crawlers.`,
-  alternates: {
-    canonical: '/ai',
-  },
+  alternates: routeAlternates('/ai'),
 }
 
 /**

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -14,6 +14,7 @@ import { APP_BASE_URL, env } from '@/lib/env'
 import { OptionalFeatures } from '@/lib/features'
 import { isConfigured } from '@/lib/integrations/registry'
 import { SanityLive } from '@/lib/integrations/sanity/live'
+import { routeAlternates } from '@/lib/seo/alternates'
 import { JsonLd } from '@/lib/seo/json-ld'
 import { organizationSchema, websiteSchema } from '@/lib/seo/schemas'
 import { themes } from '@/lib/styles/colors'
@@ -33,13 +34,12 @@ export const metadata: Metadata = {
   },
   description: APP_DESCRIPTION,
   alternates: {
-    canonical: '/',
+    // Only the home route's canonical. Child routes build their own through
+    // `routeAlternates` — inheriting this one would canonicalize the whole
+    // site to `/`.
+    ...routeAlternates('/'),
     languages: {
       'en-US': '/en-US',
-    },
-    // Advertises the plain-text mirror via <link rel="alternate" type="text/plain">.
-    types: {
-      'text/plain': [{ url: '/llms.txt', title: 'llms.txt' }],
     },
   },
   appleWebApp: {

--- a/lib/seo/alternates.ts
+++ b/lib/seo/alternates.ts
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next'
+
+/**
+ * Builds the `alternates` block for one route.
+ *
+ * Next.js merges metadata shallowly: a child segment that declares its own
+ * `alternates` replaces the parent's entire object instead of merging into
+ * it. So a page that set `alternates: { canonical: '/ai' }` also dropped the
+ * `text/plain` link advertising `/llms.txt` — and `/ai` is the machine view,
+ * the one route that most needs to point crawlers at the plain-text mirror.
+ * Routing every page through this helper keeps the shared entries attached.
+ *
+ * `path` must be the same URL `app/sitemap.ts` submits for the route. A
+ * canonical that disagrees with the sitemap asks a search engine to crawl
+ * one URL and index another, and the engine picks — usually not the one you
+ * wanted. Pass a root-relative path (`/articles/foo`); Next resolves it
+ * against `metadataBase`.
+ */
+export function routeAlternates(path: string): Metadata['alternates'] {
+  return {
+    // Self-referential on every route. A single hardcoded canonical in a
+    // layout is inherited by every child that doesn't override it, which
+    // tells search engines the whole site is one duplicated page.
+    canonical: path,
+    // Advertises the plain-text mirror via <link rel="alternate" type="text/plain">.
+    types: {
+      'text/plain': [{ url: '/llms.txt', title: 'llms.txt' }],
+    },
+  }
+}

--- a/lib/seo/schemas.ts
+++ b/lib/seo/schemas.ts
@@ -67,6 +67,51 @@ export function breadcrumbSchema(
   }
 }
 
+/**
+ * A listing page — index, archive, category — as `CollectionPage` wrapping an
+ * `ItemList` of what it links to.
+ *
+ * Without this a listing is just a page of links: a crawler has to follow
+ * every one to learn what the collection contains, and an answer engine
+ * asking "what has this studio worked on?" has nothing to read in one fetch.
+ * The `ItemList` states the membership and the order directly.
+ *
+ * `url` and every item `url` must be absolute — relative paths are dropped by
+ * most consumers, and a half-relative `ItemList` validates clean while
+ * pointing nowhere.
+ */
+export function collectionPageSchema(input: {
+  name: string
+  url: string
+  description?: string
+  items: { name: string; url: string }[]
+}): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: input.name,
+    url: input.url,
+    isPartOf: { '@id': WEBSITE_ID },
+    ...(input.description ? { description: input.description } : {}),
+    // An empty list is worse than no list: it asserts the collection is
+    // empty rather than leaving the question open.
+    ...(input.items.length
+      ? {
+          mainEntity: {
+            '@type': 'ItemList',
+            numberOfItems: input.items.length,
+            itemListElement: input.items.map((item, index) => ({
+              '@type': 'ListItem',
+              position: index + 1,
+              name: item.name,
+              url: item.url,
+            })),
+          },
+        }
+      : {}),
+  }
+}
+
 export function articleSchema(input: {
   headline: string
   description?: string

--- a/lib/utils/metadata.ts
+++ b/lib/utils/metadata.ts
@@ -1,6 +1,37 @@
 import type { Metadata } from 'next'
 
 import { APP_BASE_URL, env } from '@/lib/env'
+import { routeAlternates } from '@/lib/seo/alternates'
+
+/** Roughly where Google truncates a description in a result snippet. */
+const DESCRIPTION_MAX_LENGTH = 155
+
+/**
+ * Trims prose to snippet length on a word boundary.
+ *
+ * For deriving a description from body copy when a page has no hand-written
+ * one. A page that inherits the site-wide description is, to an answer
+ * engine, indistinguishable from every other page — a real sentence from the
+ * page's own content is worth more than a polished generic one.
+ *
+ * Returns `''` for empty input so callers can use `||` to fall through to
+ * their own fallback rather than emitting an empty `description` tag.
+ */
+export function truncateDescription(
+  text: string | null | undefined,
+  maxLength: number = DESCRIPTION_MAX_LENGTH
+): string {
+  const collapsed = text?.replace(/\s+/g, ' ').trim()
+  if (!collapsed) return ''
+  if (collapsed.length <= maxLength) return collapsed
+
+  const clipped = collapsed.slice(0, maxLength)
+  const lastSpace = clipped.lastIndexOf(' ')
+
+  // A single word longer than the limit has no space to cut at; hard-clip it
+  // rather than returning the whole untruncated string.
+  return `${(lastSpace > 0 ? clipped.slice(0, lastSpace) : clipped).trimEnd()}…`
+}
 
 /**
  * Metadata Generation Utilities
@@ -74,9 +105,7 @@ export function generatePageMetadata(
     title,
     description,
     keywords,
-    alternates: {
-      canonical: url ?? '/',
-    },
+    alternates: routeAlternates(url ?? '/'),
     openGraph: {
       title,
       description,
@@ -154,6 +183,8 @@ export function generateSanityMetadata(options: {
     } | null
     _updatedAt?: string | null
     publishedAt?: string | null
+    /** Body prose used to derive a description when the editor left one blank. */
+    excerpt?: string | null
   }
   url?: string
   type?: 'website' | 'article'
@@ -161,10 +192,16 @@ export function generateSanityMetadata(options: {
   const { document, url, type = 'website' } = options
   const metadata = document.metadata
 
+  // Editors leave the SEO description empty far more often than they leave the
+  // body empty, and a page with no description of its own inherits the
+  // site-wide one — which makes every such page look identical to a crawler.
+  const derivedDescription = truncateDescription(document.excerpt)
+
   if (!metadata) {
     // Fallback to basic metadata if none provided
     return generatePageMetadata({
       ...(document.title ? { title: document.title } : {}),
+      ...(derivedDescription ? { description: derivedDescription } : {}),
       ...(url && { url }),
       type,
     })
@@ -179,9 +216,11 @@ export function generateSanityMetadata(options: {
   const { description, keywords, noIndex } = metadata
   const { publishedAt, _updatedAt } = document
 
+  const resolvedDescription = description || derivedDescription
+
   return generatePageMetadata({
     ...(title ? { title } : {}),
-    ...(description ? { description } : {}),
+    ...(resolvedDescription ? { description: resolvedDescription } : {}),
     ...(keywords ? { keywords } : {}),
     ...(url && { url }),
     ...(noIndex != null && { noIndex }),


### PR DESCRIPTION
## Summary

Every route that did not declare its own canonical was inheriting `canonical: '/'` from the site layout, which tells search engines the whole site is one duplicated page. Next hands a layout's canonical down to any child that does not override it.

`/ai` did declare its own, and that turned out to be the sharper bug: Next replaces a parent's `alternates` object rather than merging into it, so setting a canonical there silently dropped the `text/plain` link advertising `/llms.txt`. The one page whose whole job is being machine-readable had lost the link pointing crawlers at the plain-text mirror.

Both now go through a single `routeAlternates(path)` helper, so a route cannot get a canonical without the shared links riding along.

Also adds two reusable builders while in here: `collectionPageSchema` for listing pages, and `truncateDescription` so a page whose CMS description is empty falls back to its own body copy instead of inheriting the site-wide one. A page with no description of its own is indistinguishable from every other page to an answer engine.

## Changes

- `lib/seo/alternates.ts`: new `routeAlternates(path)`, canonical plus the shared llms.txt link
- `app/(site)/layout.tsx`, `app/(site)/ai/page.tsx`, `lib/utils/metadata.ts`: build alternates through it
- `lib/seo/schemas.ts`: `collectionPageSchema`, a CollectionPage wrapping an ItemList
- `lib/utils/metadata.ts`: `truncateDescription`, wired as the description fallback in `generateSanityMetadata`
- `COMPONENTS.md` regenerated

## Checklist

- [x] `bun run check` passes (oxlint + oxfmt + typecheck + 537 tests)
- [x] Verified against `next build` output rather than dev mode: `/ai` now emits both its own canonical and the llms.txt alternate, `/` is unchanged
- [x] No breaking changes
- [x] If this changes documented behaviour, the docs that state it changed in the same diff (COMPONENTS.md regenerated)

Known and deliberately left alone: the `hrefLang` alternate points at `/en-US`, a route that does not exist in the starter. Pre-existing placeholder, unrelated to this change.