### PR TITLE
fix: three confirmed correctness-audit highs (cart + webgl)

### DIFF
--- a/lib/integrations/shopify/cart/actions.ts
+++ b/lib/integrations/shopify/cart/actions.ts
@@ -138,6 +138,20 @@ export async function addItem(
     const _cookies = await cookies()
     let cartId = _cookies.get('cartId')?.value
 
+    // A cart id in the cookie can be stale: Shopify nulls a cart once its
+    // checkout completes, but the 30-day cookie outlives it. Reusing a dead id
+    // makes every post-checkout add fail until the cookie expires. Verify the
+    // cart is still live and drop a dead id so the create-fresh branch runs.
+    // Guard the check: a transient getCart failure must not orphan a live cart,
+    // so on error keep the id and let addToCart surface any real problem.
+    if (cartId) {
+      try {
+        if (!(await getCart(cartId))) cartId = undefined
+      } catch {
+        // Liveness check failed transiently — keep the existing id.
+      }
+    }
+
     // This is here because cookie can only be set server side
     // and useFormState executes the addItem action in the server
     if (!cartId) {

--- a/lib/integrations/shopify/cart/modal/index.tsx
+++ b/lib/integrations/shopify/cart/modal/index.tsx
@@ -3,12 +3,12 @@
 import cn from 'clsx'
 import { useRouter } from 'next/navigation'
 import type { KeyboardEvent, ReactNode } from 'react'
-import { createContext, use, useState } from 'react'
-import { useFormStatus } from 'react-dom'
+import { createContext, use, useState, useTransition } from 'react'
 
 import { Image } from '@/components/ui/image'
 import { Link } from '@/components/ui/link'
 import { formatMoney } from '@/integrations/shopify/money'
+import type { CartLineItem } from '@/integrations/shopify/types'
 
 import { removeItem, updateItemQuantity } from '../actions'
 import { useCartContext } from '../cart-store-context'
@@ -20,35 +20,6 @@ interface ModalContextType {
   isOpen: boolean
   openCart: () => void
   closeCart: () => void
-}
-
-interface QuantityPayload {
-  merchandiseId: string
-  quantity: number
-  lineId?: string | undefined
-}
-
-interface QuantityProps {
-  className?: string
-  payload: QuantityPayload
-}
-
-interface QuantityButtonProps {
-  // Matches React's form action signature. It has to allow a promise: React
-  // keeps useFormStatus().pending true until the returned promise settles, and
-  // QuantitySubmitButton disables itself on that. Typing this `() => void`
-  // forces call sites to swallow the promise and the button stops staying
-  // disabled during the update.
-  formAction: () => void | Promise<void>
-  className?: string
-  children: ReactNode
-  'aria-label': string
-}
-
-interface RemoveButtonProps {
-  merchandiseId: string
-  lineId?: string | undefined
-  className?: string
 }
 
 const ModalContext = createContext<ModalContextType>({
@@ -119,60 +90,8 @@ function InnerCart() {
     <>
       <p className={s.heading}>your cart</p>
       <div className={s.lines} data-lenis-prevent>
-        {cart?.lines?.map(({ id, merchandise, cost, quantity }) => (
-          <div className={s.line} key={id}>
-            <div className={s.media}>
-              <Image
-                src={merchandise.product.featuredImage?.url ?? ''}
-                alt={merchandise.product.featuredImage?.altText ?? ''}
-                // The drawer is 75vw (mobile) / 50vw (desktop) and `.media`
-                // spans 2 of its 6 columns, so a third of each.
-                mobileSize="25vw"
-                desktopSize="17vw"
-                // Product shots vary in aspect and must not be cropped in the
-                // cart. This has to be the prop, not CSS: Image writes
-                // object-fit inline, which outranks any stylesheet rule.
-                objectFit="contain"
-                {...(merchandise.product.featuredImage?.width &&
-                merchandise.product.featuredImage?.height
-                  ? {
-                      width: merchandise.product.featuredImage.width,
-                      height: merchandise.product.featuredImage.height,
-                    }
-                  : // Shopify doesn't guarantee image dimensions — fall back
-                    // to a square box so the cart line keeps a stable layout.
-                    { aspectRatio: 1 })}
-              />
-            </div>
-
-            <div className={s.info}>
-              <div className={s.details}>
-                <p className={s.title}>{merchandise?.product?.title}</p>
-                <p className={s.size}>
-                  SIZE: {merchandise?.selectedOptions?.[0]?.value}
-                </p>
-              </div>
-            </div>
-
-            <RemoveButton
-              merchandiseId={merchandise.id}
-              lineId={id}
-              className={s.remove ?? ''}
-            />
-
-            <Quantity
-              className={s.quantity ?? ''}
-              payload={{
-                merchandiseId: merchandise.id,
-                quantity,
-                lineId: id,
-              }}
-            />
-
-            <p className={s.price}>
-              {cost?.totalAmount ? formatMoney(cost.totalAmount) : ''}
-            </p>
-          </div>
+        {cart?.lines?.map((line) => (
+          <CartLine key={line.id} line={line} />
         ))}
       </div>
       <div className={s.checkout}>
@@ -194,126 +113,131 @@ function InnerCart() {
   )
 }
 
-function Quantity({ className, payload }: QuantityProps) {
+/**
+ * One cart line, with quantity steppers and a remove control.
+ *
+ * All three controls share a single `isPending` transition, so only one
+ * mutation for this line can be in flight at a time. This is the fix for the
+ * concurrent-mutation race: each control computes an ABSOLUTE target quantity
+ * from `quantity` (the current render's value), so two overlapping clicks
+ * (a fast +/− before the first resolves) would otherwise send conflicting
+ * absolutes — e.g. 6 and 4 off a base of 5 — and whichever server response
+ * landed last would win, never the intended value. Serialising per line means
+ * the second click is disabled until the first settles and the displayed
+ * quantity has advanced, so each mutation builds on the previous one.
+ */
+function CartLine({ line }: { line: CartLineItem }) {
+  const { id, merchandise, cost, quantity } = line
   const { actions } = useCartContext()
   const { updateCartItem } = actions
   const router = useRouter()
   const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
 
-  async function formAction(type: 'minus' | 'plus') {
-    const updatePayload = {
-      ...payload,
-      quantity: Math.max(1, payload.quantity + quantityAction[type]),
-    }
+  function changeQuantity(type: 'minus' | 'plus') {
+    startTransition(async () => {
+      updateCartItem(merchandise.id, type)
+      const result = await updateItemQuantity(null, {
+        merchandiseId: merchandise.id,
+        quantity: Math.max(1, quantity + quantityAction[type]),
+        lineId: id,
+      })
+      setError(result.ok ? null : result.error)
+      // Sync server state with the optimistic update.
+      router.refresh()
+    })
+  }
 
-    updateCartItem(payload.merchandiseId, type)
-    const result = await updateItemQuantity(null, updatePayload)
-
-    setError(result.ok ? null : result.error)
-
-    // Refresh the router to sync server state with optimistic state
-    router.refresh()
+  function remove() {
+    startTransition(async () => {
+      updateCartItem(merchandise.id, 'delete')
+      const result = await removeItem(null, merchandise.id, id)
+      setError(result.ok ? null : result.error)
+      router.refresh()
+    })
   }
 
   return (
-    <div className={className}>
-      <QuantityButton
-        formAction={() => formAction('minus')}
-        aria-label="Decrease quantity"
-      >
-        -
-      </QuantityButton>
-      <span>{payload.quantity}</span>
-      <QuantityButton
-        formAction={() => formAction('plus')}
-        aria-label="Increase quantity"
-      >
-        +
-      </QuantityButton>
-      {error && (
-        <p role="status" aria-live="polite" className={cn('p1', s.actionError)}>
-          {error}
-        </p>
-      )}
-    </div>
-  )
-}
+    <div className={s.line}>
+      <div className={s.media}>
+        <Image
+          src={merchandise.product.featuredImage?.url ?? ''}
+          alt={merchandise.product.featuredImage?.altText ?? ''}
+          // The drawer is 75vw (mobile) / 50vw (desktop) and `.media`
+          // spans 2 of its 6 columns, so a third of each.
+          mobileSize="25vw"
+          desktopSize="17vw"
+          // Product shots vary in aspect and must not be cropped in the
+          // cart. This has to be the prop, not CSS: Image writes
+          // object-fit inline, which outranks any stylesheet rule.
+          objectFit="contain"
+          {...(merchandise.product.featuredImage?.width &&
+          merchandise.product.featuredImage?.height
+            ? {
+                width: merchandise.product.featuredImage.width,
+                height: merchandise.product.featuredImage.height,
+              }
+            : // Shopify doesn't guarantee image dimensions — fall back
+              // to a square box so the cart line keeps a stable layout.
+              { aspectRatio: 1 })}
+        />
+      </div>
 
-function QuantitySubmitButton({
-  children,
-  'aria-label': ariaLabel,
-}: {
-  children: ReactNode
-  'aria-label': string
-}) {
-  const { pending } = useFormStatus()
-  return (
-    <button
-      type="submit"
-      className="p1"
-      aria-label={ariaLabel}
-      disabled={pending}
-    >
-      {children}
-    </button>
-  )
-}
+      <div className={s.info}>
+        <div className={s.details}>
+          <p className={s.title}>{merchandise?.product?.title}</p>
+          <p className={s.size}>
+            SIZE: {merchandise?.selectedOptions?.[0]?.value}
+          </p>
+        </div>
+      </div>
 
-function QuantityButton({
-  formAction,
-  className,
-  children,
-  'aria-label': ariaLabel,
-}: QuantityButtonProps) {
-  return (
-    <form action={formAction} className={className}>
-      <QuantitySubmitButton aria-label={ariaLabel}>
-        {children}
-      </QuantitySubmitButton>
-    </form>
-  )
-}
+      <div className={s.remove ?? ''}>
+        <button
+          type="button"
+          className="p1"
+          aria-label="Remove cart item"
+          disabled={isPending}
+          onClick={remove}
+        >
+          remove
+        </button>
+      </div>
 
-function RemoveSubmitButton() {
-  const { pending } = useFormStatus()
-  return (
-    <button
-      type="submit"
-      className="p1"
-      aria-label="Remove cart item"
-      disabled={pending}
-    >
-      remove
-    </button>
-  )
-}
+      <div className={s.quantity ?? ''}>
+        <button
+          type="button"
+          className="p1"
+          aria-label="Decrease quantity"
+          disabled={isPending}
+          onClick={() => changeQuantity('minus')}
+        >
+          -
+        </button>
+        <span>{quantity}</span>
+        <button
+          type="button"
+          className="p1"
+          aria-label="Increase quantity"
+          disabled={isPending}
+          onClick={() => changeQuantity('plus')}
+        >
+          +
+        </button>
+        {error && (
+          <p
+            role="status"
+            aria-live="polite"
+            className={cn('p1', s.actionError)}
+          >
+            {error}
+          </p>
+        )}
+      </div>
 
-function RemoveButton({ merchandiseId, lineId, className }: RemoveButtonProps) {
-  const { actions } = useCartContext()
-  const { updateCartItem } = actions
-  const router = useRouter()
-  const [error, setError] = useState<string | null>(null)
-
-  async function formAction() {
-    updateCartItem(merchandiseId, 'delete')
-    const result = await removeItem(null, merchandiseId, lineId)
-
-    setError(result.ok ? null : result.error)
-
-    // Refresh the router to sync server state with optimistic state
-    router.refresh()
-  }
-
-  return (
-    <div className={className}>
-      <form action={formAction}>
-        <RemoveSubmitButton />
-      </form>
-      {error && (
-        <p role="status" aria-live="polite" className={cn('p1', s.actionError)}>
-          {error}
-        </p>
-      )}
+      <p className={s.price}>
+        {cost?.totalAmount ? formatMoney(cost.totalAmount) : ''}
+      </p>
     </div>
   )
 }

--- a/lib/webgl/components/image/index.tsx
+++ b/lib/webgl/components/image/index.tsx
@@ -38,13 +38,20 @@ export function Image({
 }: DRImageProps) {
   const [src, setSrc] = useState<string>()
   const { setRef, rect, isVisible } = useWebGLElement<HTMLDivElement>()
-  const { isWebGL } = useDeviceDetection()
+  const { isWebGL, isReducedMotion } = useDeviceDetection()
+
+  // Hide the DOM image only when the WebGL canvas will actually render its
+  // replacement. `Canvas` mounts on `isWebGL && !isReducedMotion` (see
+  // components/canvas), so gating on `isWebGL` alone would blank the image for
+  // a reduced-motion visitor whose canvas never mounts — the exact fallback
+  // the module contract promises. Match the canvas's default gate.
+  const webglActive = isWebGL && !isReducedMotion
 
   return (
     <div
       className={className}
       style={{
-        opacity: src && isWebGL ? 0 : 1,
+        opacity: src && webglActive ? 0 : 1,
         position: 'relative',
       }}
       ref={setRef}


### PR DESCRIPTION
## What this does

Fixes three real bugs the correctness audit confirmed, all user-facing:

1. **Cart images went blank for reduced-motion visitors.** A desktop user with WebGL support and OS "reduce motion" on saw empty space where product images should be — the DOM image was hidden but the WebGL replacement never mounted.
2. **Adding to cart broke for the rest of a session after checkout.** Once a buyer completed a purchase and came back, every "add to cart" failed for up to 30 days (until the cart cookie expired), because the code kept reusing the now-dead cart.
3. **Fast quantity clicks landed on the wrong number.** Clicking + then − quickly (or update + remove) on one cart line sent conflicting amounts and the cart settled on whichever reply came back last, not what the user intended.

## Summary

Review order: `image` (1 line) → `actions` (self-heal) → `modal` (the refactor).

- **H1 — `lib/webgl/components/image/index.tsx`.** The DOM `<img>` was hidden on `isWebGL`, but `Canvas` only mounts on `isWebGL && !isReducedMotion`. Gate the image on the same condition so reduced-motion visitors get the fallback. (Known residual, tracked separately: a `<Canvas force>` under reduced motion still shows the DOM image beneath the forced WebGL layer — the full fix is a shared mounted-state selector, out of scope here.)
- **H2 — `lib/integrations/shopify/cart/actions.ts`.** `addItem` now verifies the cart is live (`getCart`) before reusing the cookie's id, dropping a dead id so a fresh cart is created. Guarded: a transient `getCart` failure keeps the existing id rather than orphaning a live cart.
- **H6 — `lib/integrations/shopify/cart/modal/index.tsx`.** Replaced the per-button `<form>` + `useFormStatus` pattern (pending scoped per button) with a per-line `CartLine` owning one `useTransition`. All three controls disable together while a mutation is in flight, so overlapping clicks can't send conflicting absolute quantities. Net −55 lines.

The other audit Highs are intentionally **not** here: H3/H4/H7 each hinge on a design-intent decision (documented as open questions in the audit report), and H5 (scaffolder atomicity) needs its own dedicated change. Full report is local at `docs/audits/codebase-audit-2026-08-12.md`.

## Test Plan

- [x] `bun test` → 542 pass, 0 fail
- [x] `tsc --noEmit` → clean
- [x] `bun run lint` + `bun run lint:types` → clean (Codex flagged a type-import alias violation; fixed)
- [x] Cross-model Codex review → no High findings
- [ ] Manual: reduced-motion + WebGL page shows the image; post-checkout add works; rapid +/− settles on the right quantity