### PR TITLE
fix(sanity): resolve home-slug pages to /home, keep / developer-owned

### DIFF
--- a/lib/integrations/sanity/sanity.config.ts
+++ b/lib/integrations/sanity/sanity.config.ts
@@ -21,9 +21,10 @@ import { schema } from './schemas'
 // module: it's dual-compiled into the client bundle for the Studio route).
 function resolveHref(documentType?: string, slug?: string): string | undefined {
   switch (documentType) {
+    // `home` is not special-cased: `/` is the developer-owned starter page,
+    // so a `home` document previews at `/home` like any other slug.
     case 'page':
-      if (!slug) return undefined
-      return slug === 'home' ? '/' : `/${slug}`
+      return slug ? `/${slug}` : undefined
     case 'article':
       return slug ? `/articles/${slug}` : undefined
     default:
@@ -68,14 +69,6 @@ export default projectId && dataset
               {
                 route: '/articles/:slug',
                 filter: `_type == "article" && slug.current == $slug`,
-              },
-              // `resolveHref('page', 'home')` returns '/', so the homepage
-              // document needs its own mapping — '/:slug' cannot match an
-              // empty segment, and without this Presentation can't associate
-              // the previewed homepage back to its document.
-              {
-                route: '/',
-                filter: `_type == "page" && slug.current == "home"`,
               },
               {
                 route: '/:slug',

--- a/lib/integrations/sanity/utils/link.test.ts
+++ b/lib/integrations/sanity/utils/link.test.ts
@@ -39,6 +39,33 @@ describe('urlForReference — external scheme allowlist', () => {
   })
 })
 
+describe('urlForReference — internal document resolution', () => {
+  test('a page slug maps to its own path, including `home` → /home', () => {
+    for (const [slug, expected] of [
+      ['about', '/about'],
+      // `/` is the developer-owned starter page; the catch-all can't match
+      // an empty segment, so `home` must not claim the root.
+      ['home', '/home'],
+    ] as const) {
+      expect(
+        urlForReference({
+          linkType: 'internal',
+          internalLink: { _type: 'page', slug: { current: slug } },
+        })
+      ).toBe(expected)
+    }
+  })
+
+  test('articles resolve under /articles', () => {
+    expect(
+      urlForReference({
+        linkType: 'internal',
+        internalLink: { _type: 'article', slug: { current: 'hello' } },
+      })
+    ).toBe('/articles/hello')
+  })
+})
+
 describe('getLinkAttributes', () => {
   test('a rejected scheme yields href="#" and no new-tab attrs', () => {
     expect(

--- a/lib/integrations/sanity/utils/link.ts
+++ b/lib/integrations/sanity/utils/link.ts
@@ -72,8 +72,12 @@ function resolveDocumentUrl(documentType?: string, slug?: string): string {
   if (!slug) return '#'
 
   switch (documentType) {
+    // Every page slug maps to its own path — including `home` → `/home`.
+    // `/` is the developer-owned starter page (`app/(site)/page.tsx`) and the
+    // catch-all can't match an empty segment, so claiming `/` for a `home`
+    // document would link to a route that never serves it.
     case 'page':
-      return slug === 'home' ? '/' : `/${slug}`
+      return `/${slug}`
     case 'article':
       return `/articles/${slug}`
     default:

--- a/lib/seo/routes.test.ts
+++ b/lib/seo/routes.test.ts
@@ -81,7 +81,22 @@ describe('buildRoutesFromDocuments', () => {
   })
 
   it('drops a document whose slug resolves to an already-listed static route', () => {
-    const homePath = STATIC_ROUTES[0]?.path
+    // `/ai` is a static route, so a page named `ai` collides with it.
+    const docs = [
+      {
+        _type: 'page',
+        title: 'AI',
+        slug: { current: 'ai' },
+        _updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]
+
+    const routes = buildRoutesFromDocuments(docs)
+    expect(STATIC_ROUTES.some((route) => route.path === '/ai')).toBe(true)
+    expect(routes.some((route) => route.path === '/ai')).toBe(false)
+  })
+
+  it('lists a `home` page at /home — `/` stays developer-owned', () => {
     const docs = [
       {
         _type: 'page',
@@ -92,6 +107,6 @@ describe('buildRoutesFromDocuments', () => {
     ]
 
     const routes = buildRoutesFromDocuments(docs)
-    expect(routes.some((route) => route.path === homePath)).toBe(false)
+    expect(routes.map((route) => route.path)).toEqual(['/home'])
   })
 })

--- a/lib/seo/routes.ts
+++ b/lib/seo/routes.ts
@@ -94,9 +94,9 @@ export function buildRoutesFromDocuments(data: unknown): ContentRoute[] {
       internalLink: { _type: doc._type, slug: doc.slug },
     })
 
-    // `path === '#'` is unresolvable; a `staticPaths` hit means the document
-    // stands in for an already-listed static route (e.g. a `page` with slug
-    // `home`, which `urlForReference` resolves to `/`).
+    // `path === '#'` is unresolvable; a `staticPaths` hit means the document's
+    // slug collides with an already-listed static route (e.g. a `page` with
+    // slug `ai` resolves to `/ai`, which the static route already serves).
     if (path === '#' || staticPaths.has(path)) continue
 
     routes.set(path, {


### PR DESCRIPTION
## What this does
A CMS page named `home` used to generate links to `/`, but `/` is the hardcoded starter page and the catch-all route can't match an empty segment — so those links pointed at a page that never renders the document. The document actually serves at `/home`, and now every link, Studio preview, and sitemap entry agrees on that. `/` stays developer-owned.

## Summary
- `resolveDocumentUrl` (`lib/integrations/sanity/utils/link.ts`) drops the `home` → `/` special case; every page slug maps to `/${slug}`
- `resolveHref` in `sanity.config.ts` mirrors the change, and the Presentation `mainDocuments` mapping that associated `/` with the `home` document is removed — `/:slug` now covers it
- Stale comment in `lib/seo/routes.ts` (described the old substitution) reworded around the real remaining case: slug collisions with static routes like `/ai`
- Tests: new resolver cases for `home` → `/home` and `/articles/*`; routes test now asserts a `home` page IS listed at `/home` and uses `ai` for the static-collision dedup case

Audit finding H3 (codebase correctness audit, 2026-08-12).

## Test Plan
- [x] `bun test lib/seo/routes.test.ts lib/integrations/sanity/utils/link.test.ts` — 13 pass
- [x] `bun run lint`, `bun run lint:types`, `bun run typecheck` — exit 0
- [x] full `bun run check` — 545 tests pass, manifest and assets clean