### PR TITLE
fix(scripts): make required AST ops idempotent so an aborted setup run can be repeated

### DIFF
--- a/lib/scripts/ast-operation-types.ts
+++ b/lib/scripts/ast-operation-types.ts
@@ -6,14 +6,22 @@
 
 /**
  * Shared by every op: a required-match contract (cross-model review
- * finding). When `required` is true and the op matches nothing on the file
- * it's applied to, the runner (`applyOpsToText` in `ast-transforms/index.ts`)
- * throws instead of silently leaving the file unchanged — a source shape
- * that drifted out from under a strip transform (a rename, a moved
- * function, a restructured try/catch) would otherwise strip an import while
- * leaving the code that used it, producing a tree that fails to build with
- * no signal until `bun run build` — by which point `setup:project` has
- * already self-pruned the machinery that could have caught it.
+ * finding). When `required` is true, the op matches nothing on the file
+ * it's applied to, AND a sibling op in the same transform DID change the
+ * file, the runner (`applyOpsToText` in `ast-transforms/index.ts`) throws
+ * instead of silently leaving a partial result — a source shape that
+ * drifted out from under a strip transform (a rename, a moved function, a
+ * restructured try/catch) would otherwise strip an import while leaving the
+ * code that used it, producing a tree that fails to build with no signal
+ * until `bun run build` — by which point `setup:project` has already
+ * self-pruned the machinery that could have caught it.
+ *
+ * When EVERY op in the transform misses (the file comes back
+ * byte-identical), the runner no-ops instead: file writes are per-transform
+ * atomic, so an all-miss file is one a previous run already transformed.
+ * That makes required ops idempotent — repeating a `setup:project` run that
+ * aborted mid-batch succeeds over the half-stripped tree instead of
+ * throwing on the files the first run finished.
  *
  * Defaults to false/undefined: most ops are intentionally best-effort or
  * idempotent by design (e.g. an additive op that's a legitimate no-op

--- a/lib/scripts/ast-operation-types.ts
+++ b/lib/scripts/ast-operation-types.ts
@@ -34,8 +34,12 @@
  */
 export interface RequiredMatchOp {
   /**
-   * When true, zero matches for this op on the file it's applied to is a
-   * hard failure, not a silent no-op.
+   * When true, zero matches for this op is a hard failure when it is
+   * evidence of drift: a sibling op changed the file (partial application),
+   * or the op's container construct is gone (`missedRequiredOpAnchorAbsent`
+   * in `ast-transforms/index.ts`). A miss on a byte-identical file whose
+   * container survives is tolerated as a previous run's completed work —
+   * the idempotent re-run contract described above.
    */
   required?: boolean
 }

--- a/lib/scripts/ast-transforms/index.ts
+++ b/lib/scripts/ast-transforms/index.ts
@@ -129,9 +129,25 @@ function describeOp(op: AstOperation): string {
  * between sequential ops.
  *
  * Required-match contract: an op with `required: true` that leaves `text`
- * byte-for-byte unchanged (no match found) throws `RequiredOpMatchError`
- * instead of silently continuing — see `RequiredMatchOp`'s docstring in
- * `ast-operation-types.ts`.
+ * byte-for-byte unchanged (no match found) is a drift signal — but only when
+ * some OTHER op in the same sequence DID change the file. Misses are
+ * collected across the whole sequence and judged at the end:
+ *
+ * - Misses + a changed file → `RequiredOpMatchError`. Partial application is
+ *   the hazard the contract exists for (an import stripped while the code
+ *   that used it survives), and it can only happen on drifted source.
+ * - Misses + a byte-identical file → no-op. Disk writes are per-file atomic
+ *   (`applyCodeTransforms` writes once per transform), so a file where EVERY
+ *   op misses is a file a previous run already fully transformed — the
+ *   re-run recovery path after a mid-batch abort. Throwing here made
+ *   "repeat the run" permanently fail with no way forward but a manual
+ *   `git checkout`.
+ *
+ * The tradeoff: a file so drifted that NO op matches is indistinguishable
+ * from an already-transformed file and passes silently. Every pinned drift
+ * scenario (a renamed function, a restructured try-block) leaves sibling
+ * ops matching, so partial application still catches them — see
+ * `RequiredMatchOp`'s docstring in `ast-operation-types.ts`.
  */
 export function applyOpsToText(
   sourceText: string,
@@ -148,6 +164,7 @@ export function applyOpsToText(
     },
   })
   let text = sourceText
+  const missedRequiredOps: AstOperation[] = []
 
   for (const op of ops) {
     const before = text
@@ -231,10 +248,16 @@ export function applyOpsToText(
     }
 
     if (op.required && text === before) {
-      throw new RequiredOpMatchError(
-        `Required op matched nothing (source shape may have drifted): ${describeOp(op)}`
-      )
+      missedRequiredOps.push(op)
     }
+  }
+
+  // Judged after the whole sequence, not at the first miss — see the
+  // required-match contract in this function's docstring.
+  if (missedRequiredOps.length > 0 && text !== sourceText) {
+    throw new RequiredOpMatchError(
+      `Required op(s) matched nothing while others applied (source shape may have drifted): ${missedRequiredOps.map(describeOp).join(', ')}`
+    )
   }
 
   return text
@@ -262,14 +285,18 @@ export interface TransformFailure {
  * the batch is done, rather than exiting 0 on a silently-incomplete run.
  *
  * Exception: a `RequiredOpMatchError` (a `required: true` op that matched
- * nothing) is deliberately NOT collected into `failures` — it's re-thrown
+ * nothing while sibling ops changed the same file — see `applyOpsToText`'s
+ * contract) is deliberately NOT collected into `failures` — it's re-thrown
  * immediately, aborting this whole batch. Regular per-file failures are
  * recoverable (the other files still get their intended changes; the run
- * finishes and reports non-zero); a required-match miss means the source
- * shape has drifted from what a strip transform expects, which risks
+ * finishes and reports non-zero); a partial required-match miss means the
+ * source shape has drifted from what a strip transform expects, which risks
  * leaving a broken tree (an import removed, the code that used it still
  * there) — that must stop the run before `setup()` reaches self-prune, not
- * just get reported alongside everything else at the end.
+ * just get reported alongside everything else at the end. A file where
+ * EVERY op misses is instead treated as already transformed (a previous
+ * run's write) and skipped, so repeating an aborted run recovers instead of
+ * failing on work the first run already finished.
  *
  * A missing target file is silently skipped (`continue`, no failure entry)
  * UNLESS the transform contains at least one `required: true` op — a missing

--- a/lib/scripts/ast-transforms/index.ts
+++ b/lib/scripts/ast-transforms/index.ts
@@ -8,7 +8,14 @@
  *   applyCodeTransforms — disk-writing orchestrator used by setup/satus
  */
 
-import { IndentationText, Project, QuoteKind, ts } from 'ts-morph'
+import {
+  IndentationText,
+  Project,
+  QuoteKind,
+  type SourceFile,
+  SyntaxKind,
+  ts,
+} from 'ts-morph'
 
 import type { AstOperation, CodeTransform } from '../ast-operation-types'
 import { resolvePath } from '../utils'
@@ -21,6 +28,7 @@ import {
   applyAddJsxChild,
   applyAddVariableStatement,
 } from './add-ops'
+import { resolvePropertyPath, withSourceFile } from './helpers'
 import {
   applyRemoveArrayObjectElement,
   applyRemoveArrayStringElement,
@@ -114,6 +122,102 @@ function describeOp(op: AstOperation): string {
   }
 }
 
+/**
+ * For a missed `required: true` op, decide whether the miss is provably
+ * drift rather than a previous run's completed work. Some op kinds target a
+ * construct INSIDE a container (a directive inside a named function, a
+ * property on a named interface) — for those, the two causes of a miss are
+ * distinguishable:
+ *
+ * - container present, construct gone → a previous run removed the
+ *   construct; the miss is the idempotent re-run case. Returns false.
+ * - container gone → the op's premise no longer exists in the source (a
+ *   renamed function, a restructured config object) — drift, even when the
+ *   file is otherwise byte-identical. Returns true.
+ *
+ * Kinds whose target IS the whole construct (an import, a variable
+ * statement, a JSX element) have no container to probe — absence is
+ * genuinely ambiguous there, and the function returns false (tolerated).
+ * Each probe mirrors the corresponding handler's lookup in remove-ops.ts /
+ * set-ops.ts, so "container present" means the handler would have found it.
+ *
+ * Caveat this encodes: a container-anchored required op assumes no sibling
+ * transform removes its container — if one did, the retry would read the
+ * missing container as drift and fail. No current bundle does this (there
+ * is no op kind that removes whole functions, interfaces, destructurings,
+ * or config variables).
+ */
+function missedRequiredOpAnchorAbsent(
+  project: Project,
+  sourceText: string,
+  op: AstOperation
+): boolean {
+  const probe = (check: (sf: SourceFile) => boolean) => {
+    let present = false
+    withSourceFile(project, sourceText, (sf) => {
+      present = check(sf)
+      return sourceText // never mutate — probe only
+    })
+    return !present
+  }
+
+  switch (op.kind) {
+    case 'removeUseCacheDirective':
+    case 'replaceFunctionBody':
+    case 'replaceJsDoc':
+    case 'removeFunctionParameter':
+      return probe((sf) => sf.getFunction(op.functionName) !== undefined)
+    case 'removeInterfaceProperty':
+      return probe((sf) => sf.getInterface(op.interfaceName) !== undefined)
+    case 'removeDestructuredBinding':
+      return probe((sf) =>
+        sf
+          .getDescendantsOfKind(SyntaxKind.VariableStatement)
+          .some((stmt) =>
+            stmt
+              .getDeclarations()
+              .some(
+                (decl) =>
+                  decl.getNameNode().getKind() ===
+                    SyntaxKind.ObjectBindingPattern &&
+                  (decl.getInitializer()?.getText() ?? '').includes(
+                    op.initializerContains
+                  )
+              )
+          )
+      )
+    case 'removeCallArgument':
+      return probe((sf) =>
+        sf
+          .getDescendantsOfKind(SyntaxKind.CallExpression)
+          .some((call) => call.getExpression().getText() === op.callee)
+      )
+    case 'removeJsxAttribute':
+      return probe(
+        (sf) =>
+          sf
+            .getDescendantsOfKind(SyntaxKind.JsxSelfClosingElement)
+            .some((el) => el.getTagNameNode().getText() === op.tagName) ||
+          sf
+            .getDescendantsOfKind(SyntaxKind.JsxElement)
+            .some(
+              (el) =>
+                el.getOpeningElement().getTagNameNode().getText() === op.tagName
+            )
+      )
+    case 'removeArrayObjectElement':
+    case 'removeArrayStringElement':
+    case 'setObjectProperty':
+      return probe(
+        (sf) =>
+          resolvePropertyPath(sf, op.variableName, op.propertyPath) !==
+          undefined
+      )
+    default:
+      return false
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Per-file transform runner
 // ---------------------------------------------------------------------------
@@ -143,11 +247,23 @@ function describeOp(op: AstOperation): string {
  *   "repeat the run" permanently fail with no way forward but a manual
  *   `git checkout`.
  *
- * The tradeoff: a file so drifted that NO op matches is indistinguishable
- * from an already-transformed file and passes silently. Every pinned drift
- * scenario (a renamed function, a restructured try-block) leaves sibling
- * ops matching, so partial application still catches them — see
- * `RequiredMatchOp`'s docstring in `ast-operation-types.ts`.
+ * A byte-identical file gets one more check before passing: a missed
+ * required op whose CONTAINER construct is gone (a `'use cache'` directive
+ * whose named function no longer exists, an interface property whose
+ * interface is missing) is provable drift — the already-applied case leaves
+ * the container standing — and throws even with no other change. See
+ * `missedRequiredOpAnchorAbsent`. This is what keeps a single-op required
+ * transform (e.g. `CACHE_COMPONENTS_LLMS_TXT_TRANSFORM`) protected: it can
+ * never trip the partial-application signal, so the anchor probe is its
+ * only drift detection.
+ *
+ * The remaining tradeoff: for container-less op kinds (an import, a
+ * variable statement, a JSX element), a file so drifted that NO op matches
+ * is indistinguishable from an already-transformed file and passes
+ * silently. Every pinned drift scenario (a renamed function, a
+ * restructured try-block) leaves sibling ops matching, so partial
+ * application still catches them — see `RequiredMatchOp`'s docstring in
+ * `ast-operation-types.ts`.
  */
 export function applyOpsToText(
   sourceText: string,
@@ -254,10 +370,24 @@ export function applyOpsToText(
 
   // Judged after the whole sequence, not at the first miss — see the
   // required-match contract in this function's docstring.
-  if (missedRequiredOps.length > 0 && text !== sourceText) {
-    throw new RequiredOpMatchError(
-      `Required op(s) matched nothing while others applied (source shape may have drifted): ${missedRequiredOps.map(describeOp).join(', ')}`
+  if (missedRequiredOps.length > 0) {
+    if (text !== sourceText) {
+      throw new RequiredOpMatchError(
+        `Required op(s) matched nothing while others applied (source shape may have drifted): ${missedRequiredOps.map(describeOp).join(', ')}`
+      )
+    }
+
+    // Byte-identical file: usually a previous run's completed work — but a
+    // container-anchored op whose container is GONE is provable drift even
+    // here (the already-applied case leaves the container standing).
+    const orphaned = missedRequiredOps.filter((op) =>
+      missedRequiredOpAnchorAbsent(project, text, op)
     )
+    if (orphaned.length > 0) {
+      throw new RequiredOpMatchError(
+        `Required op(s) matched nothing and their anchor construct is missing (source shape may have drifted): ${orphaned.map(describeOp).join(', ')}`
+      )
+    }
   }
 
   return text

--- a/lib/scripts/ast-transforms/index.ts
+++ b/lib/scripts/ast-transforms/index.ts
@@ -162,7 +162,26 @@ function missedRequiredOpAnchorAbsent(
   }
 
   switch (op.kind) {
+    // Stricter than function-exists: this op only runs when Cache Components
+    // is being disabled, which requires EVERY `'use cache'` boundary in the
+    // file to be gone (see the op's docstring). A directive that merely MOVED
+    // to another function leaves the named function standing directive-less —
+    // indistinguishable from already-applied by the container probe alone —
+    // so any surviving directive anywhere in the file is also drift.
     case 'removeUseCacheDirective':
+      return probe(
+        (sf) =>
+          sf.getFunction(op.functionName) !== undefined &&
+          !sf
+            .getDescendantsOfKind(SyntaxKind.ExpressionStatement)
+            .some(
+              (stmt) =>
+                stmt
+                  .getExpression()
+                  .asKind(SyntaxKind.StringLiteral)
+                  ?.getLiteralValue() === 'use cache'
+            )
+      )
     case 'replaceFunctionBody':
     case 'replaceJsDoc':
     case 'removeFunctionParameter':

--- a/lib/scripts/setup-project.test.ts
+++ b/lib/scripts/setup-project.test.ts
@@ -569,6 +569,38 @@ describe('RequiredOpMatchError (required-match contract)', () => {
     expect(result).toBe(src)
   })
 
+  // A single-op required transform can never trip the partial-application
+  // signal, so the anchor probe is its only drift detection: the miss is
+  // tolerated only while the op's container construct still exists.
+  it('single required op: container present without the construct no-ops (already applied)', async () => {
+    const content = await Bun.file(
+      CACHE_COMPONENTS_LLMS_TXT_TRANSFORM.file
+    ).text()
+    // First application strips the directive; buildBody itself survives.
+    const stripped = applyOpsToText(
+      content,
+      CACHE_COMPONENTS_LLMS_TXT_TRANSFORM.ops
+    )
+    expect(stripped).not.toBe(content)
+    expect(
+      applyOpsToText(stripped, CACHE_COMPONENTS_LLMS_TXT_TRANSFORM.ops)
+    ).toBe(stripped)
+  })
+
+  it('single required op: a missing container throws even on a byte-identical file', async () => {
+    const content = await Bun.file(
+      CACHE_COMPONENTS_LLMS_TXT_TRANSFORM.file
+    ).text()
+    // The drift Codex's cross-model review called out: buildBody renamed →
+    // the directive op misses AND nothing else changes the file, but the
+    // op's premise is gone — Cache Components would be disabled while a
+    // 'use cache' directive stays behind.
+    const drifted = content.replaceAll('buildBody', 'composeBody')
+    expect(() =>
+      applyOpsToText(drifted, CACHE_COMPONENTS_LLMS_TXT_TRANSFORM.ops)
+    ).toThrow(RequiredOpMatchError)
+  })
+
   it('re-applying a real bundle transform to an already-stripped file no-ops', () => {
     // The exact H5 scenario: a required op late in setupLean's union fails
     // after lib/seo/routes.ts was already stripped and written; the retry

--- a/lib/scripts/setup-project.test.ts
+++ b/lib/scripts/setup-project.test.ts
@@ -516,10 +516,14 @@ describe('Preset Configurations', () => {
 // ---------------------------------------------------------------------------
 
 describe('RequiredOpMatchError (required-match contract)', () => {
-  it('applyOpsToText throws when a required op matches nothing', () => {
-    const src = 'export function foo() {\n  return 1\n}\n'
+  it('applyOpsToText throws when a required op misses while a sibling op applies', () => {
+    // Partial application is the hazard the contract guards: the `bar`
+    // removal succeeds (file changed) while the required `doesNotExist`
+    // removal finds nothing — drifted source, not an already-stripped file.
+    const src = 'const bar = 1\nexport function foo() {\n  return bar\n}\n'
     expect(() =>
       applyOpsToText(src, [
+        { kind: 'removeVariableStatement', name: 'bar', required: true },
         {
           kind: 'removeVariableStatement',
           name: 'doesNotExist',
@@ -529,10 +533,12 @@ describe('RequiredOpMatchError (required-match contract)', () => {
     ).toThrow(RequiredOpMatchError)
   })
 
-  it('the thrown error names the op and hints at drift', () => {
-    const src = 'export function foo() {\n  return 1\n}\n'
+  it('the thrown error names the missed op and hints at drift', () => {
+    const src =
+      "import { x } from '@/exists'\nconst bar = 1\nexport function foo() {\n  return bar + x\n}\n"
     expect(() =>
       applyOpsToText(src, [
+        { kind: 'removeVariableStatement', name: 'bar', required: true },
         {
           kind: 'removeImport',
           specifier: '@/does/not/exist',
@@ -540,6 +546,42 @@ describe('RequiredOpMatchError (required-match contract)', () => {
         },
       ])
     ).toThrow(/drifted.*removeImport '@\/does\/not\/exist'/is)
+  })
+
+  it('a transform where EVERY required op misses no-ops (re-run recovery)', () => {
+    // The inverse of the partial case: a byte-identical result means a
+    // previous run already applied this transform (writes are per-file
+    // atomic), so repeating an aborted setup:project run must succeed here
+    // instead of throwing on work the first run finished.
+    const src = 'export function foo() {\n  return 1\n}\n'
+    const result = applyOpsToText(src, [
+      {
+        kind: 'removeVariableStatement',
+        name: 'doesNotExist',
+        required: true,
+      },
+      {
+        kind: 'removeImport',
+        specifier: '@/does/not/exist',
+        required: true,
+      },
+    ])
+    expect(result).toBe(src)
+  })
+
+  it('re-applying a real bundle transform to an already-stripped file no-ops', () => {
+    // The exact H5 scenario: a required op late in setupLean's union fails
+    // after lib/seo/routes.ts was already stripped and written; the retry
+    // reapplies the same ops to the stripped file and must not throw.
+    const content = sourceFiles['lib/seo/routes.ts']
+    const bundle = INTEGRATION_BUNDLES.sanity
+    const transform = bundle?.codeTransforms.find(
+      (t) => t.file === 'lib/seo/routes.ts'
+    )
+    if (!(content && transform)) return
+
+    const lean = applyOpsToText(content, transform.ops)
+    expect(applyOpsToText(lean, transform.ops)).toBe(lean)
   })
 
   it('a required op that DOES match does not throw', () => {

--- a/lib/scripts/setup-project.test.ts
+++ b/lib/scripts/setup-project.test.ts
@@ -601,6 +601,24 @@ describe('RequiredOpMatchError (required-match contract)', () => {
     ).toThrow(RequiredOpMatchError)
   })
 
+  it('single required op: a directive that MOVED to another function throws', async () => {
+    // Cross-model review round 2: the function-exists probe alone reads a
+    // relocated 'use cache' as already-applied — buildBody stands
+    // directive-less — but disabling Cache Components requires every
+    // directive gone, so a survivor anywhere in the file is drift.
+    const content = await Bun.file(
+      CACHE_COMPONENTS_LLMS_TXT_TRANSFORM.file
+    ).text()
+    const stripped = applyOpsToText(
+      content,
+      CACHE_COMPONENTS_LLMS_TXT_TRANSFORM.ops
+    )
+    const moved = `${stripped}\n\nasync function elsewhere() {\n  'use cache'\n  return null\n}\n`
+    expect(() =>
+      applyOpsToText(moved, CACHE_COMPONENTS_LLMS_TXT_TRANSFORM.ops)
+    ).toThrow(RequiredOpMatchError)
+  })
+
   it('re-applying a real bundle transform to an already-stripped file no-ops', () => {
     // The exact H5 scenario: a required op late in setupLean's union fails
     // after lib/seo/routes.ts was already stripped and written; the retry


### PR DESCRIPTION
## What this does
Repeating a `setup:project` run that aborted mid-batch used to fail permanently: the retry reapplied the same required ops to files the first run had already stripped, every op missed, and the run threw again — the only way out was a manual `git checkout` that nothing suggested. Retries now recognize already-transformed files and proceed, while genuine source drift still fails loudly before self-prune.

## Summary
Review order: `ast-transforms/index.ts` first, the rest is tests and doc alignment.

- `applyOpsToText` collects required-op misses across the whole transform instead of throwing at the first one. Misses plus a changed file still throw (partial application — an import stripped while its usage survives — only happens on drifted source). Misses on a byte-identical file are a previous run's completed work: writes are per-file atomic, so an all-miss file is a fully-transformed file.
- Container-anchored kinds (a directive in a named function, an interface property, a config path) get a drift probe even on byte-identical files: the already-applied case leaves the container standing, so a missing container throws. This keeps the single-op `CACHE_COMPONENTS_LLMS_TXT_TRANSFORM` protected — it can never trip the partial-application signal.
- `removeUseCacheDirective` probes stricter: any surviving `'use cache'` directive in the file is drift, since disabling Cache Components requires every boundary gone (catches a directive that merely moved to another function).
- Tests: reworked the two immediate-throw cases to partial-application, added re-run recovery against the real sanity bundle ops, plus single-op drift/already-applied/moved-directive cases. The pinned drift fixtures (renamed `getCmsRoutes`, restructured revalidate try-block) pass unchanged.

Audit finding H5 (codebase correctness audit, 2026-08-12). `setup:project` is a cross-repo contract with `create-darkroom`; no flag or output shape changes.

## Residual (known, accepted)
A file so drifted that NO op matches — and whose required ops are all containerless (imports, JSX elements, try-blocks) — is indistinguishable from an already-transformed file and passes silently. Codex's cross-model review flagged this in all three rounds and proposed a persisted completion journal or staged batch writes; that is the snapshot/restore direction the audit's DT4 weighed and the maintainer decided against in favor of idempotency, which also covers crash-between-writes cases staging cannot. Every realistic drift scenario (one renamed symbol, one restructured block) leaves sibling ops matching and still throws.

## Test Plan
- [x] `bun test lib/scripts/setup-project.test.ts lib/scripts/ast-transforms.test.ts` — 161 pass
- [x] full `bun run check` — 547 tests, exit 0
- [x] pinned drift fixtures unchanged and green